### PR TITLE
Security: Spring Boot 3.4.13 + springdoc 2.8.16 (16 CVE fixes)

### DIFF
--- a/SECURITY-SCAN-REPORT-2026-03-22.md
+++ b/SECURITY-SCAN-REPORT-2026-03-22.md
@@ -1,0 +1,259 @@
+# Security Scan Report — Finding A Bed Tonight
+
+**Date:** 2026-03-22
+**Scanner:** OWASP Dependency-Check 12.2.0, SpotBugs, PMD, Semgrep, Gitleaks
+**Jenkins Build:** portfolio-security-scan #41
+**Spring Boot Version:** 3.4.4
+**Embedded Tomcat:** 10.1.39 (via Spring Boot BOM)
+
+---
+
+## Executive Summary
+
+The security scan identified **3 critical**, **10 high**, **8 medium**, and **1 low** vulnerability across the project's dependency tree. The vast majority trace to two root causes:
+
+1. **Embedded Tomcat 10.1.39** — 13 CVEs (3 critical, 8 high, 2 medium)
+2. **Swagger UI 5.20.1 (DOMPurify)** — 2 medium XSS vulnerabilities
+
+Both are resolved by upgrading Spring Boot and springdoc-openapi. No secrets were detected (Gitleaks clean). No custom code vulnerabilities were found (Semgrep clean for application code; 2 Terraform infrastructure findings are addressed separately below).
+
+---
+
+## Critical & High Vulnerabilities
+
+### Tomcat Embed Core 10.1.39 — 13 CVEs
+
+All vulnerabilities are inherited via `spring-boot-starter-web` → `tomcat-embed-core`. No direct Tomcat configuration exists in the project (embedded Tomcat via Spring Boot).
+
+| CVE | Severity | Description | Relevant? |
+|-----|----------|-------------|-----------|
+| **CVE-2025-31651** | CRITICAL (9.8) | Escape/meta sequence injection — subset of URL patterns bypass security constraints | **Yes** — affects request routing |
+| **CVE-2025-55754** | CRITICAL (9.6) | ANSI escape sequence injection in error pages | **Yes** — affects error handling |
+| **CVE-2025-66614** | CRITICAL (9.1) | Improper input validation | **Yes** — affects request processing |
+| CVE-2025-49124 | HIGH (8.4) | Untrusted search path in Windows installer | **No** — installer-only, not embedded Tomcat |
+| CVE-2025-31650 | HIGH (7.5) | Invalid HTTP priority header causes DoS | **Yes** — affects HTTP/2 handling |
+| CVE-2025-48988 | HIGH (7.5) | Resource allocation without limits | **Yes** — DoS vector |
+| CVE-2025-48989 | HIGH (7.5) | "Made you reset" attack via improper resource release | **Yes** — HTTP/2 RST_STREAM abuse |
+| CVE-2025-49125 | HIGH (7.5) | Auth bypass via PreResources/PostResources | **Unlikely** — requires specific Tomcat resource config not used by Spring Boot |
+| CVE-2025-52520 | HIGH (7.5) | Integer overflow in multipart upload | **Possible** — if multipart uploads are enabled |
+| CVE-2025-53506 | HIGH (7.5) | HTTP/2 SETTINGS frame resource consumption | **Yes** — affects HTTP/2 |
+| CVE-2025-55752 | HIGH (7.5) | Relative path traversal (regression from bug 60013 fix) | **Yes** — affects static resource serving |
+| CVE-2026-24734 | HIGH (7.5) | OCSP responder input validation (Tomcat Native) | **No** — requires Tomcat Native library, not used with embedded Tomcat |
+| CVE-2025-46701 | HIGH (7.3) | Case sensitivity bypass in CGI servlet | **No** — CGI servlet not used in Spring Boot |
+
+**Action Required:** Upgrade Spring Boot to latest 3.4.x (or 3.5.x if available). This is the single highest-impact fix — resolves 13 CVEs at once.
+
+---
+
+## Medium Vulnerabilities
+
+### 1. Swagger UI 5.20.1 — DOMPurify XSS (2 CVEs)
+
+| CVE | CVSS | Description |
+|-----|------|-------------|
+| **CVE-2025-15599** | MEDIUM | DOMPurify 3.1.3–3.2.6 XSS via crafted HTML |
+| **CVE-2026-0540** | MEDIUM | DOMPurify 3.1.3–3.3.1 XSS (separate vector) |
+
+**Risk Assessment: ELEVATED**
+
+Swagger UI is currently:
+- **Publicly accessible** — `SecurityConfig.java` permits all requests to `/swagger-ui/**`, `/api/v1/docs/**`, and `/api/v1/api-docs/**`
+- **Not restricted to any Spring profile** — available in all deployment tiers (lite, standard, full)
+- **Version:** springdoc-openapi `2.8.6` bundles swagger-ui `5.20.1` with vulnerable DOMPurify
+
+An attacker could craft a malicious API description or exploit the XSS to execute scripts in the context of anyone viewing the Swagger UI.
+
+**Actions Required (choose one or both):**
+
+1. **Upgrade springdoc-openapi** to a version bundling swagger-ui with DOMPurify >= 3.3.2:
+   ```xml
+   <!-- pom.xml -->
+   <springdoc.version>2.9.0</springdoc.version>  <!-- or latest stable -->
+   ```
+
+2. **Restrict Swagger UI to dev/local profiles only** (recommended for production regardless):
+   ```yaml
+   # application-prod.yml (or application-lite.yml etc.)
+   springdoc:
+     api-docs:
+       enabled: false
+     swagger-ui:
+       enabled: false
+   ```
+   And update `SecurityConfig.java` to conditionally permit Swagger paths only when springdoc is enabled.
+
+### 2. PostgreSQL JDBC Driver 42.7.5
+
+| CVE | CVSS | Description |
+|-----|------|-------------|
+| **CVE-2025-49146** | MEDIUM | Config-dependent vulnerability in pgjdbc 42.7.4–42.7.6 |
+
+**Risk Assessment: LOW-MEDIUM**
+
+This vulnerability requires non-default JDBC configuration (e.g., `preferQueryMode=simple`). The project uses standard Spring Boot DataSource configuration with no custom query mode settings.
+
+**Action:** Upgrade to `postgresql >= 42.7.7` by adding a property override in pom.xml:
+```xml
+<properties>
+    <postgresql.version>42.7.7</postgresql.version>
+</properties>
+```
+Or wait for the next Spring Boot BOM bump to include it.
+
+### 3. Log4j API 2.24.3 — Socket Appender TLS
+
+| CVE | CVSS | Description |
+|-----|------|-------------|
+| **CVE-2025-68161** | MEDIUM | Socket Appender doesn't verify TLS hostname |
+
+**Risk Assessment: NONE**
+
+This only affects the Log4j Socket Appender, which sends logs to a remote socket over TLS. FABT uses SLF4J/Logback (Spring Boot default) for logging to stdout/file. The `log4j-api` dependency is present only as a bridge artifact — the Socket Appender is never instantiated.
+
+**Action:** Suppress. No code change needed.
+
+### 4. Commons Lang3 3.17.0 — Uncontrolled Recursion
+
+| CVE | CVSS | Description |
+|-----|------|-------------|
+| **CVE-2025-48924** | MEDIUM | Recursive toString/equals on deeply nested structures |
+
+**Risk Assessment: LOW**
+
+Exploitation requires attacker-controlled, deeply nested objects passed to `ToStringBuilder` or `EqualsBuilder` reflective methods. FABT does not use reflective toString/equals on untrusted input.
+
+**Action:** Upgrade when Spring Boot bumps it. No immediate action needed.
+
+### 5. Kotlin Stdlib 1.9.25 — Temp File Creation
+
+| CVE | CVSS | Description |
+|-----|------|-------------|
+| **CVE-2020-29582** | MEDIUM (5.0) | Insecure temp file/folder creation in Kotlin < 1.4.21 |
+
+**Risk Assessment: NONE**
+
+FABT is a Java project. `kotlin-stdlib` is a transitive dependency from Spring Boot. The vulnerable `createTempDir`/`createTempFile` Kotlin APIs are not called by any Java code in this project. The vulnerability also requires local attacker access to the filesystem.
+
+**Action:** Suppress. This is a transitive dependency not used by application code.
+
+### 6. Tomcat Embed Core — Session Fixation & Resource Leak
+
+| CVE | CVSS | Description |
+|-----|------|-------------|
+| **CVE-2025-55668** | MEDIUM | Session fixation via rewrite valve |
+| **CVE-2025-61795** | MEDIUM | Improper resource release on error |
+
+**Risk Assessment:**
+- **CVE-2025-55668: NONE** — requires Tomcat's rewrite valve, which is not configured. FABT uses embedded Tomcat via Spring Boot with no custom valve configuration.
+- **CVE-2025-61795: LOW** — resource leak on error conditions. Resolved by the Tomcat upgrade.
+
+**Action:** Resolved by the Spring Boot upgrade (same as critical Tomcat CVEs above).
+
+---
+
+## Low Vulnerabilities
+
+| CVE | Dependency | Description | Action |
+|-----|-----------|-------------|--------|
+| CVE-2026-24733 | tomcat-embed-core 10.1.39 | HTTP/0.9 not restricted to GET | Resolved by Spring Boot upgrade |
+
+---
+
+## Infrastructure Findings (Semgrep — Terraform)
+
+These are outside the application code but were flagged during the scan:
+
+| Rule | File | Description | Action |
+|------|------|-------------|--------|
+| `aws-dynamodb-table-unencrypted` | `infra/terraform/bootstrap/main.tf:90` | DynamoDB state lock table uses AWS-managed encryption (default), not CMK. Semgrep wants an explicit `server_side_encryption` block. | **Low priority** — AWS encrypts DynamoDB at rest by default. Add explicit block for compliance documentation if required. |
+| `insecure-load-balancer-tls-version` | `infra/terraform/modules/app/main.tf:213` | ALB may use TLS < 1.2. | **Verify** `ssl_policy` is set to `ELBSecurityPolicy-TLS13-1-2-2021-06` or newer. If missing, add it. |
+
+---
+
+## Static Analysis (SpotBugs)
+
+SpotBugs reported ~70 instances of `EI_EXPOSE_REP` / `EI_EXPOSE_REP2` (exposing internal representation). **All are false positives** — the flagged classes are Java records, DTOs, and immutable value objects where returning the internal reference is intentional and safe:
+
+- Request/Response DTOs (`CreateUserRequest`, `ShelterDetailResponse`, etc.)
+- Domain value objects (`BedSearchResult`, `ShelterConstraints`, `DomainEvent`)
+- Service classes returning query results
+
+**Action:** No changes needed. Consider adding a SpotBugs exclusion filter for `EI_EXPOSE_REP` on record/DTO packages to clean up future reports.
+
+---
+
+## Other Scans — Clean
+
+| Tool | Result |
+|------|--------|
+| **Gitleaks** | No secrets detected |
+| **PMD** | No findings |
+| **Semgrep (application code)** | No findings (Java, Python, TypeScript rulesets) |
+
+---
+
+## Recommended Upgrade Plan
+
+### Priority 1 — Spring Boot Upgrade (resolves 16 of 23 CVEs)
+
+Upgrade Spring Boot from `3.4.4` to the latest `3.4.x` patch (or `3.5.x` if stable). This single change resolves:
+- All 13 Tomcat CVEs (critical + high + medium)
+- Likely bumps commons-lang3, postgresql, and kotlin-stdlib
+
+```xml
+<!-- pom.xml -->
+<parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>3.4.x</version>  <!-- latest stable -->
+</parent>
+```
+
+### Priority 2 — springdoc-openapi Upgrade (resolves 2 XSS CVEs)
+
+```xml
+<!-- pom.xml -->
+<springdoc.version>2.9.0</springdoc.version>  <!-- or latest with DOMPurify >= 3.3.2 -->
+```
+
+Additionally, restrict Swagger UI to non-production profiles:
+```yaml
+# application-prod.yml
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false
+```
+
+### Priority 3 — PostgreSQL Driver Override (if not resolved by Spring Boot bump)
+
+```xml
+<!-- pom.xml properties -->
+<postgresql.version>42.7.7</postgresql.version>
+```
+
+### Priority 4 — Terraform TLS Policy
+
+Verify ALB ssl_policy in `infra/terraform/modules/app/main.tf:213`:
+```hcl
+resource "aws_lb_listener" "https" {
+  ssl_policy = "ELBSecurityPolicy-TLS13-1-2-2021-06"
+  # ...
+}
+```
+
+### Suppressions (no action needed)
+
+| CVE | Reason |
+|-----|--------|
+| CVE-2025-68161 (log4j Socket Appender) | Socket Appender not used; SLF4J/Logback is the logging backend |
+| CVE-2020-29582 (kotlin-stdlib temp files) | Transitive dep; Kotlin temp file APIs not called from Java code |
+| CVE-2025-49124 (Tomcat Windows installer) | Installer-only; not applicable to embedded Tomcat |
+| CVE-2026-24734 (Tomcat Native OCSP) | Tomcat Native not used with embedded Tomcat |
+| CVE-2025-46701 (Tomcat CGI servlet) | CGI servlet not used in Spring Boot |
+| CVE-2025-55668 (Tomcat rewrite valve) | Rewrite valve not configured |
+
+---
+
+*Generated by portfolio-security-scan Jenkins pipeline. Full HTML report available at Jenkins build #41.*

--- a/backend/owasp-suppressions.xml
+++ b/backend/owasp-suppressions.xml
@@ -24,4 +24,55 @@
         <cvssBelow>7</cvssBelow>
     </suppress>
 
+    <!-- CVE-2025-68161: Log4j Socket Appender TLS hostname verification.
+         FABT uses SLF4J/Logback (Spring Boot default). Socket Appender is never instantiated.
+         log4j-api is present only as a bridge artifact.
+         Review date: 2026-06-22 -->
+    <suppress>
+        <notes>Socket Appender not used; SLF4J/Logback is the logging backend</notes>
+        <cve>CVE-2025-68161</cve>
+    </suppress>
+
+    <!-- CVE-2020-29582: Kotlin stdlib insecure temp file creation.
+         FABT is a Java project. kotlin-stdlib is a transitive dependency from Spring Boot.
+         The vulnerable createTempDir/createTempFile Kotlin APIs are not called from Java code.
+         Review date: 2026-06-22 -->
+    <suppress>
+        <notes>Transitive dependency; Kotlin temp file APIs not called from Java code</notes>
+        <cve>CVE-2020-29582</cve>
+    </suppress>
+
+    <!-- CVE-2025-49124: Tomcat Windows installer untrusted search path.
+         Not applicable to embedded Tomcat (Spring Boot). Installer-only vulnerability.
+         Review date: 2026-06-22 -->
+    <suppress>
+        <notes>Installer-only; not applicable to embedded Tomcat via Spring Boot</notes>
+        <cve>CVE-2025-49124</cve>
+    </suppress>
+
+    <!-- CVE-2026-24734: Tomcat Native OCSP responder input validation.
+         Tomcat Native library is not used with embedded Tomcat in Spring Boot.
+         Review date: 2026-06-22 -->
+    <suppress>
+        <notes>Tomcat Native not used with embedded Tomcat</notes>
+        <cve>CVE-2026-24734</cve>
+    </suppress>
+
+    <!-- CVE-2025-46701: Tomcat CGI servlet case sensitivity bypass.
+         CGI servlet is not used in Spring Boot applications.
+         Review date: 2026-06-22 -->
+    <suppress>
+        <notes>CGI servlet not used in Spring Boot</notes>
+        <cve>CVE-2025-46701</cve>
+    </suppress>
+
+    <!-- CVE-2025-55668: Tomcat session fixation via rewrite valve.
+         Rewrite valve is not configured. FABT uses embedded Tomcat via Spring Boot
+         with no custom valve configuration. Stateless JWT auth (no sessions).
+         Review date: 2026-06-22 -->
+    <suppress>
+        <notes>Rewrite valve not configured; stateless JWT auth (no sessions)</notes>
+        <cve>CVE-2025-55668</cve>
+    </suppress>
+
 </suppressions>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -7,7 +7,7 @@
     <parent>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-starter-parent</artifactId>
-        <version>3.4.4</version>
+        <version>3.4.13</version>
         <relativePath/>
     </parent>
 
@@ -19,7 +19,7 @@
 
     <properties>
         <java.version>21</java.version>
-        <springdoc.version>2.8.6</springdoc.version>
+        <springdoc.version>2.8.16</springdoc.version>
         <logstash-logback.version>8.0</logstash-logback.version>
         <testcontainers.version>1.20.4</testcontainers.version>
         <resilience4j.version>2.2.0</resilience4j.version>

--- a/backend/src/main/resources/application-prod.yml
+++ b/backend/src/main/resources/application-prod.yml
@@ -1,0 +1,9 @@
+# Production profile — disables Swagger UI and API docs.
+# Swagger UI in production is a security risk (DOMPurify XSS, information disclosure).
+# Activate with: --spring.profiles.active=prod
+
+springdoc:
+  api-docs:
+    enabled: false
+  swagger-ui:
+    enabled: false

--- a/docs/.$architecture.drawio.bkp
+++ b/docs/.$architecture.drawio.bkp
@@ -1,0 +1,216 @@
+<mxfile host="app.diagrams.net" modified="2026-03-20T00:00:00.000Z" agent="FABT Docs" version="24.0.0" type="device">
+  <diagram id="fabt-architecture" name="FABT Architecture">
+    <mxGraphModel dx="1422" dy="762" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1600" pageHeight="1000" math="0" shadow="0">
+      <root>
+        <mxCell id="0" />
+        <mxCell id="1" parent="0" />
+
+        <!-- ============================================================ -->
+        <!-- Title                                                        -->
+        <!-- ============================================================ -->
+        <mxCell id="title" value="Finding A Bed Tonight — System Architecture" style="text;html=1;align=center;verticalAlign=middle;resizable=0;points=[];autosize=1;strokeColor=none;fillColor=none;fontSize=20;fontStyle=1;fontColor=#1a1a1a;" vertex="1" parent="1">
+          <mxGeometry x="440" y="10" width="520" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Deployment Tier Labels (right side)                          -->
+        <!-- ============================================================ -->
+        <mxCell id="tier-label" value="Deployment Tiers" style="text;html=1;align=left;verticalAlign=top;fontSize=14;fontStyle=5;fontColor=#6c6c6c;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="60" width="200" height="30" as="geometry" />
+        </mxCell>
+        <mxCell id="tier-lite" value="&lt;b&gt;Lite&lt;/b&gt;&lt;br&gt;JAR + PostgreSQL&lt;br&gt;Spring Events / PG NOTIFY&lt;br&gt;Caffeine cache&lt;br&gt;~$15–30/mo" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#999999;fontColor=#333333;fontSize=11;align=left;verticalAlign=top;spacingLeft=8;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="100" width="200" height="90" as="geometry" />
+        </mxCell>
+        <mxCell id="tier-standard" value="&lt;b&gt;Standard&lt;/b&gt;&lt;br&gt;+ Redis&lt;br&gt;Distributed cache + reservation accel.&lt;br&gt;$30–75/mo" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#999999;fontColor=#333333;fontSize=11;align=left;verticalAlign=top;spacingLeft=8;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="200" width="200" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="tier-full" value="&lt;b&gt;Full&lt;/b&gt;&lt;br&gt;+ Kafka&lt;br&gt;Event-driven, multi-service ready&lt;br&gt;$100+/mo" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#f5f5f5;strokeColor=#999999;fontColor=#333333;fontSize=11;align=left;verticalAlign=top;spacingLeft=8;spacingTop=4;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="290" width="200" height="80" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Frontend Layer                                               -->
+        <!-- ============================================================ -->
+        <mxCell id="frontend-group" value="Frontend" style="swimlane;startSize=24;fillColor=#dae8fc;strokeColor=#6c8ebf;fontStyle=1;fontSize=13;rounded=1;arcSize=8;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="340" y="70" width="720" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="pwa" value="React PWA&lt;br&gt;&lt;font style=&quot;font-size:10px;color:#666;&quot;&gt;Vite + Workbox + react-intl&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#6c8ebf;fontSize=12;" vertex="1" parent="frontend-group">
+          <mxGeometry x="20" y="35" width="200" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="coordinator-ui" value="Coordinator View&lt;br&gt;&lt;font style=&quot;font-size:10px;color:#666;&quot;&gt;3-tap bed update&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="frontend-group">
+          <mxGeometry x="240" y="35" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="outreach-ui" value="Outreach Worker&lt;br&gt;&lt;font style=&quot;font-size:10px;color:#666;&quot;&gt;Query / Reserve&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="frontend-group">
+          <mxGeometry x="400" y="35" width="140" height="50" as="geometry" />
+        </mxCell>
+        <mxCell id="admin-ui" value="CoC Admin Dashboard&lt;br&gt;&lt;font style=&quot;font-size:10px;color:#666;&quot;&gt;Surge / Analytics&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#6c8ebf;fontSize=11;" vertex="1" parent="frontend-group">
+          <mxGeometry x="560" y="35" width="140" height="50" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Arrow: Frontend → Backend                                    -->
+        <!-- ============================================================ -->
+        <mxCell id="arrow-fe-be" value="REST API /api/v1/*" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=10;fontColor=#666666;strokeColor=#333333;strokeWidth=2;" edge="1" parent="1" source="frontend-group" target="backend-group">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Backend Layer                                                -->
+        <!-- ============================================================ -->
+        <mxCell id="backend-group" value="Backend — Spring Boot Modular Monolith (org.fabt)" style="swimlane;startSize=28;fillColor=#d5e8d4;strokeColor=#82b366;fontStyle=1;fontSize=13;rounded=1;arcSize=6;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="200" y="230" width="1000" height="320" as="geometry" />
+        </mxCell>
+
+        <!-- Row 1: Domain Modules -->
+        <mxCell id="mod-tenant" value="&lt;b&gt;tenant&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Tenant CRUD&lt;br&gt;Config&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="20" y="45" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-auth" value="&lt;b&gt;auth&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Users, API Keys&lt;br&gt;OAuth2, Roles&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="160" y="45" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-shelter" value="&lt;b&gt;shelter&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Profiles, Capacity&lt;br&gt;Constraints, Search&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="300" y="45" width="130" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-availability" value="&lt;b&gt;availability&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Bed counts&lt;br&gt;Real-time query&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="450" y="45" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-reservation" value="&lt;b&gt;reservation&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Soft-hold&lt;br&gt;Opaque tokens&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="590" y="45" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-surge" value="&lt;b&gt;surge&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;White Flag&lt;br&gt;Surge events&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="730" y="45" width="120" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-dataimport" value="&lt;b&gt;dataimport&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;HSDS / CSV / 211&lt;br&gt;Import log&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="870" y="45" width="110" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- Row 2: Cross-cutting modules -->
+        <mxCell id="mod-webhook" value="&lt;b&gt;webhook&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Subscriptions&lt;br&gt;Delivery&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="20" y="125" width="120" height="55" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-analytics" value="&lt;b&gt;analytics&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;CoC reporting&lt;br&gt;Dashboards&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="160" y="125" width="120" height="55" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-hmis" value="&lt;b&gt;hmis-bridge&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;HMIS integration&lt;br&gt;Future extraction&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="300" y="125" width="130" height="55" as="geometry" />
+        </mxCell>
+        <mxCell id="mod-observability" value="&lt;b&gt;observability&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Micrometer Metrics, OTel Tracing&lt;br&gt;@Scheduled Monitors, Resilience4J&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#82b366;fontSize=11;" vertex="1" parent="backend-group">
+          <mxGeometry x="450" y="125" width="160" height="55" as="geometry" />
+        </mxCell>
+
+        <!-- Shared Kernel bar -->
+        <mxCell id="shared-kernel" value="shared/ — Config, Cache, EventBus, Security, Web, i18n" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=12;fontStyle=1;" vertex="1" parent="backend-group">
+          <mxGeometry x="20" y="200" width="960" height="40" as="geometry" />
+        </mxCell>
+
+        <!-- EventBus callout -->
+        <mxCell id="eventbus-note" value="EventBus&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Spring Events → PG NOTIFY → Kafka&lt;br&gt;(tier-dependent transport)&lt;/font&gt;" style="shape=note;whiteSpace=wrap;html=1;backgroundOutline=1;size=14;fillColor=#fff2cc;strokeColor=#d6b656;fontSize=10;fontStyle=0;align=center;" vertex="1" parent="backend-group">
+          <mxGeometry x="630" y="120" width="200" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- ArchUnit label -->
+        <mxCell id="archunit-label" value="&lt;font style=&quot;font-size:10px;color:#999;&quot;&gt;Module boundaries enforced by ArchUnit tests&lt;/font&gt;" style="text;html=1;align=center;verticalAlign=middle;strokeColor=none;fillColor=none;" vertex="1" parent="backend-group">
+          <mxGeometry x="300" y="255" width="400" height="20" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Infrastructure Layer                                         -->
+        <!-- ============================================================ -->
+        <mxCell id="infra-group" value="Infrastructure" style="swimlane;startSize=24;fillColor=#f8cecc;strokeColor=#b85450;fontStyle=1;fontSize=13;rounded=1;arcSize=8;collapsible=0;" vertex="1" parent="1">
+          <mxGeometry x="340" y="620" width="720" height="120" as="geometry" />
+        </mxCell>
+        <mxCell id="postgres" value="&lt;b&gt;PostgreSQL&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;All tiers — source of truth&lt;br&gt;Flyway migrations&lt;br&gt;RLS for DV data&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#FFFFFF;strokeColor=#b85450;fontSize=11;" vertex="1" parent="infra-group">
+          <mxGeometry x="40" y="30" width="160" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="redis" value="&lt;b&gt;Redis&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Standard + Full tiers&lt;br&gt;Cache, reservation accel.&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#FFFFFF;strokeColor=#b85450;fontSize=11;strokeDasharray=3 3;" vertex="1" parent="infra-group">
+          <mxGeometry x="280" y="30" width="160" height="80" as="geometry" />
+        </mxCell>
+        <mxCell id="kafka" value="&lt;b&gt;Kafka&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Full tier only&lt;br&gt;Event streaming&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#FFFFFF;strokeColor=#b85450;fontSize=11;strokeDasharray=3 3;" vertex="1" parent="infra-group">
+          <mxGeometry x="520" y="30" width="160" height="80" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Observability Infrastructure (optional profile)              -->
+        <!-- ============================================================ -->
+        <mxCell id="obs-group" value="Observability (optional — docker compose --profile observability)" style="swimlane;startSize=24;fillColor=#e1d5e7;strokeColor=#9673a6;fontStyle=1;fontSize=12;rounded=1;arcSize=8;collapsible=0;strokeDasharray=3 3;" vertex="1" parent="1">
+          <mxGeometry x="340" y="770" width="720" height="100" as="geometry" />
+        </mxCell>
+        <mxCell id="prometheus" value="&lt;b&gt;Prometheus&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;:9090 scrapes :9091&lt;br&gt;Management port&lt;/font&gt;" style="shape=cylinder3;whiteSpace=wrap;html=1;boundedLbl=1;backgroundOutline=1;size=12;fillColor=#FFFFFF;strokeColor=#9673a6;fontSize=11;strokeDasharray=3 3;" vertex="1" parent="obs-group">
+          <mxGeometry x="20" y="30" width="150" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="grafana" value="&lt;b&gt;Grafana&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;:3000&lt;br&gt;FABT Operations dashboard&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#9673a6;fontSize=11;strokeDasharray=3 3;" vertex="1" parent="obs-group">
+          <mxGeometry x="190" y="30" width="160" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="jaeger" value="&lt;b&gt;Jaeger&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;:16686&lt;br&gt;Trace visualization&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#9673a6;fontSize=11;strokeDasharray=3 3;" vertex="1" parent="obs-group">
+          <mxGeometry x="370" y="30" width="150" height="60" as="geometry" />
+        </mxCell>
+        <mxCell id="otel-collector" value="&lt;b&gt;OTel Collector&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;OTLP → Jaeger&lt;/font&gt;" style="rounded=1;whiteSpace=wrap;html=1;fillColor=#FFFFFF;strokeColor=#9673a6;fontSize=11;strokeDasharray=3 3;" vertex="1" parent="obs-group">
+          <mxGeometry x="540" y="30" width="150" height="60" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- External: NOAA API                                           -->
+        <!-- ============================================================ -->
+        <mxCell id="noaa-api" value="&lt;b&gt;NOAA Weather API&lt;/b&gt;&lt;br&gt;&lt;font style=&quot;font-size:9px;&quot;&gt;Temperature monitoring&lt;br&gt;Resilience4J circuit breaker&lt;/font&gt;" style="shape=hexagon;perimeter=hexagonPerimeter2;whiteSpace=wrap;html=1;fixedSize=1;fillColor=#f5f5f5;strokeColor=#666666;fontSize=10;strokeDasharray=3 3;" vertex="1" parent="1">
+          <mxGeometry x="60" y="370" width="180" height="70" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow-be-noaa" value="HTTPS" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;fontSize=10;fontColor=#666666;strokeColor=#333333;strokeWidth=1;strokeDasharray=3 3;" edge="1" parent="1" source="backend-group" target="noaa-api">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- Arrow: Backend → Observability Infrastructure -->
+        <mxCell id="arrow-be-obs" value="OTLP / Prometheus scrape" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;fontSize=10;fontColor=#666666;strokeColor=#9673a6;strokeWidth=2;strokeDasharray=3 3;" edge="1" parent="1" source="backend-group" target="obs-group">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Arrows: Backend → Infrastructure                             -->
+        <!-- ============================================================ -->
+        <mxCell id="arrow-be-pg" value="JDBC" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0.3;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=10;fontColor=#666666;strokeColor=#333333;strokeWidth=2;" edge="1" parent="1" source="backend-group" target="postgres">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow-be-redis" value="Lettuce" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0.5;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=10;fontColor=#666666;strokeColor=#333333;strokeWidth=2;strokeDasharray=3 3;" edge="1" parent="1" source="backend-group" target="redis">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+        <mxCell id="arrow-be-kafka" value="Spring Kafka" style="edgeStyle=orthogonalEdgeStyle;rounded=1;orthogonalLoop=1;jettySize=auto;exitX=0.7;exitY=1;exitDx=0;exitDy=0;entryX=0.5;entryY=0;entryDx=0;entryDy=0;fontSize=10;fontColor=#666666;strokeColor=#333333;strokeWidth=2;strokeDasharray=3 3;" edge="1" parent="1" source="backend-group" target="kafka">
+          <mxGeometry relative="1" as="geometry" />
+        </mxCell>
+
+        <!-- ============================================================ -->
+        <!-- Legend (optional indicator)                                   -->
+        <!-- ============================================================ -->
+        <mxCell id="legend-title" value="Legend" style="text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=5;fontColor=#666;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1280" y="400" width="60" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="legend-solid" value="" style="endArrow=classic;html=1;strokeWidth=2;strokeColor=#333333;" edge="1" parent="1">
+          <mxGeometry width="80" relative="1" as="geometry">
+            <mxPoint x="1280" y="440" as="sourcePoint" />
+            <mxPoint x="1360" y="440" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="legend-solid-label" value="All tiers" style="text;html=1;align=left;verticalAlign=middle;fontSize=10;fontColor=#666;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1370" y="430" width="80" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="legend-dashed" value="" style="endArrow=classic;html=1;strokeWidth=2;strokeColor=#333333;strokeDasharray=3 3;" edge="1" parent="1">
+          <mxGeometry width="80" relative="1" as="geometry">
+            <mxPoint x="1280" y="465" as="sourcePoint" />
+            <mxPoint x="1360" y="465" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="legend-dashed-label" value="Optional (tier-dependent)" style="text;html=1;align=left;verticalAlign=middle;fontSize=10;fontColor=#666;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1370" y="455" width="160" height="20" as="geometry" />
+        </mxCell>
+        <mxCell id="legend-obs" value="" style="endArrow=classic;html=1;strokeWidth=2;strokeColor=#9673a6;strokeDasharray=3 3;" edge="1" parent="1">
+          <mxGeometry width="80" relative="1" as="geometry">
+            <mxPoint x="1280" y="490" as="sourcePoint" />
+            <mxPoint x="1360" y="490" as="targetPoint" />
+          </mxGeometry>
+        </mxCell>
+        <mxCell id="legend-obs-label" value="Observability profile (optional)" style="text;html=1;align=left;verticalAlign=middle;fontSize=10;fontColor=#666;strokeColor=none;fillColor=none;" vertex="1" parent="1">
+          <mxGeometry x="1370" y="480" width="180" height="20" as="geometry" />
+        </mxCell>
+
+      </root>
+    </mxGraphModel>
+  </diagram>
+</mxfile>


### PR DESCRIPTION
## Summary
- Upgrade Spring Boot 3.4.4 → 3.4.13 (Tomcat 10.1.39 → 10.1.50)
- Upgrade springdoc-openapi 2.8.6 → 2.8.16 (DOMPurify XSS fix)
- PostgreSQL driver auto-bumped to 42.7.8
- Swagger UI disabled in production profiles (application-prod.yml)
- 6 OWASP suppressions for non-applicable transitive CVEs

## CVEs Resolved
- **3 CRITICAL**: CVE-2025-31651 (CVSS 9.8 URL bypass), CVE-2025-55754, CVE-2025-66614
- **8 HIGH**: Tomcat HTTP/2 DoS, path traversal, multipart overflow
- **2 MEDIUM**: DOMPurify XSS in Swagger UI
- **1 MEDIUM**: PostgreSQL driver config-dependent vulnerability
- **1 LOW**: Tomcat HTTP/0.9
- **1 MEDIUM**: Tomcat resource leak (resolved by upgrade)

## Test plan
- [x] Backend: 152 tests, 0 failures
- [x] Playwright: 52 tests, 0 failures
- [x] Karate: 32 tests, 0 failures
- [x] Gatling: 3 simulations, 0 failures
- [x] Swagger UI accessible (dev profile)
- [x] OAuth2 SSO flow works
- [x] Terraform TLS policy verified (TLS 1.2+)

🤖 Generated with [Claude Code](https://claude.com/claude-code)