### PR TITLE
Add admin user management: edit, deactivate, audit trail

### DIFF
--- a/backend/src/main/java/org/fabt/auth/api/AuthController.java
+++ b/backend/src/main/java/org/fabt/auth/api/AuthController.java
@@ -67,6 +67,12 @@ public class AuthController {
                     .body(new ErrorBody("Invalid credentials"));
         }
 
+        // Reject deactivated users
+        if (!user.isActive()) {
+            return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                    .body(new ErrorBody("Account deactivated. Contact your administrator."));
+        }
+
         // Verify password
         if (!passwordService.matches(request.password(), user.getPasswordHash())) {
             return ResponseEntity.status(HttpStatus.UNAUTHORIZED)

--- a/backend/src/main/java/org/fabt/auth/api/UpdateUserRequest.java
+++ b/backend/src/main/java/org/fabt/auth/api/UpdateUserRequest.java
@@ -2,6 +2,7 @@ package org.fabt.auth.api;
 
 public record UpdateUserRequest(
         String displayName,
+        String email,
         String[] roles,
         Boolean dvAccess
 ) {

--- a/backend/src/main/java/org/fabt/auth/api/UserController.java
+++ b/backend/src/main/java/org/fabt/auth/api/UserController.java
@@ -1,27 +1,25 @@
 package org.fabt.auth.api;
 
-import java.time.Instant;
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import jakarta.servlet.http.HttpServletRequest;
 import jakarta.validation.Valid;
 import org.fabt.auth.domain.User;
-import org.fabt.auth.repository.UserRepository;
-import org.fabt.auth.service.PasswordService;
-import org.fabt.shared.web.TenantContext;
+import org.fabt.auth.service.UserService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -29,12 +27,10 @@ import org.springframework.web.bind.annotation.RestController;
 @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
 public class UserController {
 
-    private final UserRepository userRepository;
-    private final PasswordService passwordService;
+    private final UserService userService;
 
-    public UserController(UserRepository userRepository, PasswordService passwordService) {
-        this.userRepository = userRepository;
-        this.passwordService = passwordService;
+    public UserController(UserService userService) {
+        this.userService = userService;
     }
 
     @Operation(
@@ -50,38 +46,20 @@ public class UserController {
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PostMapping
-    @Transactional
     public ResponseEntity<UserResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
-        UUID tenantId = TenantContext.getTenantId();
-
-        User user = new User();
-        // ID left null — database generates via gen_random_uuid()
-        user.setTenantId(tenantId);
-        user.setEmail(request.email());
-        user.setDisplayName(request.displayName());
-        user.setPasswordHash(request.password() != null ? passwordService.hash(request.password()) : null);
-        user.setRoles(request.roles() != null ? request.roles() : new String[0]);
-        user.setDvAccess(request.dvAccess() != null && request.dvAccess());
-        user.setCreatedAt(Instant.now());
-        user.setUpdatedAt(Instant.now());
-
-        User saved = userRepository.save(user);
+        User saved = userService.createUser(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(UserResponse.from(saved));
     }
 
     @Operation(
             summary = "List all users in the authenticated tenant",
-            description = "Returns all users belonging to the caller's tenant. The list is unfiltered " +
-                    "and unpaginated. Each user record includes id, email, displayName, roles, " +
-                    "dvAccess flag, and timestamps. Users from other tenants are never returned — " +
-                    "tenant isolation is enforced server-side via the JWT's tenant claim. " +
+            description = "Returns all users belonging to the caller's tenant. Each user record " +
+                    "includes id, email, displayName, roles, dvAccess flag, status, and timestamps. " +
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @GetMapping
-    @Transactional(readOnly = true)
     public ResponseEntity<List<UserResponse>> listUsers() {
-        UUID tenantId = TenantContext.getTenantId();
-        List<UserResponse> users = userRepository.findByTenantId(tenantId).stream()
+        List<UserResponse> users = userService.listUsers().stream()
                 .map(UserResponse::from)
                 .toList();
         return ResponseEntity.ok(users);
@@ -90,65 +68,60 @@ public class UserController {
     @Operation(
             summary = "Get a single user by ID within the authenticated tenant",
             description = "Returns the user with the specified UUID, provided the user belongs to " +
-                    "the caller's tenant. Returns 404 (via NoSuchElementException) if the user does " +
-                    "not exist or belongs to a different tenant — the error is intentionally " +
-                    "indistinguishable to prevent cross-tenant enumeration. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "the caller's tenant. Returns 404 if the user does not exist or belongs to a " +
+                    "different tenant. Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @GetMapping("/{id}")
-    @Transactional(readOnly = true)
     public ResponseEntity<UserResponse> getUser(
             @Parameter(description = "UUID of the user to retrieve") @PathVariable UUID id) {
-        UUID tenantId = TenantContext.getTenantId();
-
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("User not found: " + id));
-
-        if (!user.getTenantId().equals(tenantId)) {
-            throw new NoSuchElementException("User not found: " + id);
-        }
-
-        return ResponseEntity.ok(UserResponse.from(user));
+        return ResponseEntity.ok(UserResponse.from(userService.getUser(id)));
     }
 
     @Operation(
             summary = "Update a user's profile, roles, or DV access",
             description = "Partially updates a user within the caller's tenant. Only non-null fields " +
-                    "in the request body are applied — omit a field to leave it unchanged. Updatable " +
-                    "fields: displayName (string), roles (string array — replaces the entire role " +
-                    "list, not a merge), and dvAccess (boolean). Email cannot be changed through this " +
-                    "endpoint. Use PUT /api/v1/auth/password for self-service password change or " +
-                    "POST /api/v1/users/{id}/reset-password for admin-initiated reset. " +
-                    "Returns the full updated user object. Returns 404 if the " +
-                    "user does not exist or belongs to a different tenant. " +
+                    "in the request body are applied. Updatable fields: displayName, email, roles " +
+                    "(replaces entire list), dvAccess. Role or dvAccess changes increment " +
+                    "tokenVersion, invalidating the user's existing JWTs. " +
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PutMapping("/{id}")
-    @Transactional
     public ResponseEntity<UserResponse> updateUser(
             @Parameter(description = "UUID of the user to update") @PathVariable UUID id,
-            @Valid @RequestBody UpdateUserRequest request) {
-        UUID tenantId = TenantContext.getTenantId();
-
-        User user = userRepository.findById(id)
-                .orElseThrow(() -> new NoSuchElementException("User not found: " + id));
-
-        if (!user.getTenantId().equals(tenantId)) {
-            throw new NoSuchElementException("User not found: " + id);
-        }
-
-        if (request.displayName() != null) {
-            user.setDisplayName(request.displayName());
-        }
-        if (request.roles() != null) {
-            user.setRoles(request.roles());
-        }
-        if (request.dvAccess() != null) {
-            user.setDvAccess(request.dvAccess());
-        }
-        user.setUpdatedAt(Instant.now());
-
-        User saved = userRepository.save(user);
+            @Valid @RequestBody UpdateUserRequest request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
+        UUID actorUserId = (UUID) authentication.getPrincipal();
+        String ipAddress = httpRequest.getRemoteAddr();
+        User saved = userService.updateUser(id, request, actorUserId, ipAddress);
         return ResponseEntity.ok(UserResponse.from(saved));
     }
+
+    @Operation(
+            summary = "Deactivate or reactivate a user account",
+            description = "Sets the user's status to DEACTIVATED or ACTIVE. Deactivated users " +
+                    "cannot log in and their existing JWTs are immediately invalidated via " +
+                    "tokenVersion increment. Deactivation also disconnects any active SSE " +
+                    "notification stream. Requires COC_ADMIN or PLATFORM_ADMIN role."
+    )
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<UserResponse> changeStatus(
+            @Parameter(description = "UUID of the user") @PathVariable UUID id,
+            @RequestBody StatusChangeRequest request,
+            Authentication authentication,
+            HttpServletRequest httpRequest) {
+        UUID actorUserId = (UUID) authentication.getPrincipal();
+        String ipAddress = httpRequest.getRemoteAddr();
+
+        User saved = switch (request.status()) {
+            case "DEACTIVATED" -> userService.deactivateUser(id, actorUserId, ipAddress);
+            case "ACTIVE" -> userService.reactivateUser(id, actorUserId, ipAddress);
+            default -> throw new IllegalArgumentException("Invalid status: " + request.status()
+                    + ". Valid values: ACTIVE, DEACTIVATED");
+        };
+
+        return ResponseEntity.ok(UserResponse.from(saved));
+    }
+
+    public record StatusChangeRequest(String status) {}
 }

--- a/backend/src/main/java/org/fabt/auth/api/UserResponse.java
+++ b/backend/src/main/java/org/fabt/auth/api/UserResponse.java
@@ -11,6 +11,7 @@ public record UserResponse(
         String displayName,
         String[] roles,
         boolean dvAccess,
+        String status,
         Instant createdAt
 ) {
     public static UserResponse from(User user) {
@@ -20,6 +21,7 @@ public record UserResponse(
                 user.getDisplayName(),
                 user.getRoles(),
                 user.isDvAccess(),
+                user.getStatus(),
                 user.getCreatedAt()
         );
     }

--- a/backend/src/main/java/org/fabt/auth/domain/User.java
+++ b/backend/src/main/java/org/fabt/auth/domain/User.java
@@ -17,6 +17,8 @@ public class User {
     private String displayName;
     private String[] roles;
     private boolean dvAccess;
+    private String status = "ACTIVE";
+    private int tokenVersion;
     private Instant passwordChangedAt;
     private Instant createdAt;
     private Instant updatedAt;
@@ -92,6 +94,26 @@ public class User {
 
     public void setDvAccess(boolean dvAccess) {
         this.dvAccess = dvAccess;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public int getTokenVersion() {
+        return tokenVersion;
+    }
+
+    public void setTokenVersion(int tokenVersion) {
+        this.tokenVersion = tokenVersion;
+    }
+
+    public boolean isActive() {
+        return "ACTIVE".equals(status);
     }
 
     public Instant getPasswordChangedAt() {

--- a/backend/src/main/java/org/fabt/auth/service/JwtService.java
+++ b/backend/src/main/java/org/fabt/auth/service/JwtService.java
@@ -109,6 +109,7 @@ public class JwtService {
         payload.put("displayName", user.getDisplayName());
         payload.put("roles", user.getRoles());
         payload.put("dvAccess", user.isDvAccess());
+        payload.put("ver", user.getTokenVersion());
         payload.put("type", "access");
         payload.put("iat", now.getEpochSecond());
         payload.put("exp", exp.getEpochSecond());
@@ -207,11 +208,15 @@ public class JwtService {
                 ? Instant.ofEpochSecond(((Number) payload.get("iat")).longValue())
                 : null;
 
+        int tokenVersion = payload.containsKey("ver")
+                ? ((Number) payload.get("ver")).intValue()
+                : 0;
+
         // Calculate TTL for cache: exp - now - 30s
         long ttlSeconds = Duration.between(Instant.now(), expInstant).getSeconds() - 30;
         long remainingNanos = ttlSeconds > 0 ? Duration.ofSeconds(ttlSeconds).toNanos() : 0;
 
-        JwtClaims claims = new JwtClaims(userId, tenantId, roles, dvAccess, type, issuedAt, remainingNanos);
+        JwtClaims claims = new JwtClaims(userId, tenantId, roles, dvAccess, type, issuedAt, tokenVersion, remainingNanos);
 
         if (ttlSeconds > 0) {
             claimsCache.put(cacheKey, claims);
@@ -273,6 +278,6 @@ public class JwtService {
     }
 
     public record JwtClaims(UUID userId, UUID tenantId, String[] roles, boolean dvAccess, String type,
-                            Instant issuedAt, long remainingNanos) {
+                            Instant issuedAt, int tokenVersion, long remainingNanos) {
     }
 }

--- a/backend/src/main/java/org/fabt/auth/service/UserService.java
+++ b/backend/src/main/java/org/fabt/auth/service/UserService.java
@@ -1,0 +1,175 @@
+package org.fabt.auth.service;
+
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import org.fabt.auth.api.CreateUserRequest;
+import org.fabt.auth.api.UpdateUserRequest;
+import org.fabt.auth.domain.User;
+import org.fabt.auth.repository.UserRepository;
+import org.fabt.notification.service.NotificationService;
+import org.fabt.shared.audit.AuditDetails;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.web.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * User lifecycle management — create, edit, deactivate, reactivate.
+ * Publishes audit events for role/dvAccess/status changes.
+ * Increments tokenVersion to invalidate JWTs on security-relevant changes.
+ */
+@Service
+public class UserService {
+
+    private static final Logger log = LoggerFactory.getLogger(UserService.class);
+
+    private final UserRepository userRepository;
+    private final PasswordService passwordService;
+    private final NotificationService notificationService;
+    private final ApplicationEventPublisher eventPublisher;
+
+    public UserService(UserRepository userRepository, PasswordService passwordService,
+                       NotificationService notificationService,
+                       ApplicationEventPublisher eventPublisher) {
+        this.userRepository = userRepository;
+        this.passwordService = passwordService;
+        this.notificationService = notificationService;
+        this.eventPublisher = eventPublisher;
+    }
+
+    @Transactional
+    public User createUser(CreateUserRequest request) {
+        UUID tenantId = TenantContext.getTenantId();
+
+        User user = new User();
+        user.setTenantId(tenantId);
+        user.setEmail(request.email());
+        user.setDisplayName(request.displayName());
+        user.setPasswordHash(request.password() != null ? passwordService.hash(request.password()) : null);
+        user.setRoles(request.roles() != null ? request.roles() : new String[0]);
+        user.setDvAccess(request.dvAccess() != null && request.dvAccess());
+        user.setCreatedAt(Instant.now());
+        user.setUpdatedAt(Instant.now());
+
+        return userRepository.save(user);
+    }
+
+    @Transactional(readOnly = true)
+    public List<User> listUsers() {
+        UUID tenantId = TenantContext.getTenantId();
+        return userRepository.findByTenantId(tenantId);
+    }
+
+    @Transactional(readOnly = true)
+    public User getUser(UUID id) {
+        UUID tenantId = TenantContext.getTenantId();
+        User user = userRepository.findById(id)
+                .orElseThrow(() -> new NoSuchElementException("User not found: " + id));
+        if (!user.getTenantId().equals(tenantId)) {
+            throw new NoSuchElementException("User not found: " + id);
+        }
+        return user;
+    }
+
+    @Transactional
+    public User updateUser(UUID id, UpdateUserRequest request, UUID actorUserId, String ipAddress) {
+        User user = getUser(id);
+        boolean tokenInvalidated = false;
+
+        // Track changes for audit
+        String[] oldRoles = user.getRoles();
+        boolean oldDvAccess = user.isDvAccess();
+
+        if (request.displayName() != null) {
+            user.setDisplayName(request.displayName());
+        }
+        if (request.email() != null) {
+            user.setEmail(request.email());
+        }
+        if (request.roles() != null && !Arrays.equals(oldRoles, request.roles())) {
+            user.setRoles(request.roles());
+            user.setTokenVersion(user.getTokenVersion() + 1);
+            tokenInvalidated = true;
+            publishAuditEvent(actorUserId, id, "ROLE_CHANGED",
+                    new AuditDetails(oldRoles, request.roles()), ipAddress);
+            log.info("User {} roles changed from {} to {} by {}", id,
+                    Arrays.toString(oldRoles), Arrays.toString(request.roles()), actorUserId);
+        }
+        if (request.dvAccess() != null && oldDvAccess != request.dvAccess()) {
+            user.setDvAccess(request.dvAccess());
+            user.setTokenVersion(user.getTokenVersion() + 1);
+            tokenInvalidated = true;
+            publishAuditEvent(actorUserId, id, "DV_ACCESS_CHANGED",
+                    new AuditDetails(oldDvAccess, request.dvAccess()), ipAddress);
+            log.info("User {} dvAccess changed from {} to {} by {}", id,
+                    oldDvAccess, request.dvAccess(), actorUserId);
+        }
+        user.setUpdatedAt(Instant.now());
+
+        User saved = userRepository.save(user);
+
+        if (tokenInvalidated) {
+            log.info("Token version incremented to {} for user {} — existing JWTs invalidated",
+                    saved.getTokenVersion(), id);
+        }
+
+        return saved;
+    }
+
+    @Transactional
+    public User deactivateUser(UUID id, UUID actorUserId, String ipAddress) {
+        User user = getUser(id);
+
+        if (!user.isActive()) {
+            throw new IllegalStateException("User is already deactivated: " + id);
+        }
+
+        user.setStatus("DEACTIVATED");
+        user.setTokenVersion(user.getTokenVersion() + 1);
+        user.setUpdatedAt(Instant.now());
+
+        User saved = userRepository.save(user);
+
+        // Disconnect SSE stream if connected
+        notificationService.completeEmitter(id);
+
+        publishAuditEvent(actorUserId, id, "USER_DEACTIVATED", null, ipAddress);
+        log.info("User {} deactivated by {}", id, actorUserId);
+
+        return saved;
+    }
+
+    @Transactional
+    public User reactivateUser(UUID id, UUID actorUserId, String ipAddress) {
+        User user = getUser(id);
+
+        if (user.isActive()) {
+            throw new IllegalStateException("User is already active: " + id);
+        }
+
+        user.setStatus("ACTIVE");
+        user.setTokenVersion(user.getTokenVersion() + 1);
+        user.setUpdatedAt(Instant.now());
+
+        User saved = userRepository.save(user);
+
+        publishAuditEvent(actorUserId, id, "USER_REACTIVATED", null, ipAddress);
+        log.info("User {} reactivated by {}", id, actorUserId);
+
+        return saved;
+    }
+
+    private void publishAuditEvent(UUID actorUserId, UUID targetUserId, String action,
+                                    Object details, String ipAddress) {
+        eventPublisher.publishEvent(new AuditEventRecord(
+                actorUserId, targetUserId, action, details, ipAddress));
+    }
+
+}

--- a/backend/src/main/java/org/fabt/notification/service/NotificationService.java
+++ b/backend/src/main/java/org/fabt/notification/service/NotificationService.java
@@ -97,6 +97,23 @@ public class NotificationService {
     }
 
     /**
+     * Complete a specific user's emitter. Used when a user is deactivated
+     * to immediately disconnect their SSE notification stream.
+     */
+    public void completeEmitter(UUID userId) {
+        EmitterEntry entry = emitters.remove(userId);
+        if (entry != null) {
+            try {
+                entry.emitter().complete();
+                activeConnections.decrementAndGet();
+                log.debug("SSE emitter completed for deactivated user {}", userId);
+            } catch (Exception e) {
+                log.debug("Error completing emitter for user {}: {}", userId, e.getMessage());
+            }
+        }
+    }
+
+    /**
      * Complete all active emitters. Used during test cleanup and graceful shutdown
      * to ensure Tomcat doesn't block waiting for SSE requests to finish.
      */

--- a/backend/src/main/java/org/fabt/shared/audit/AuditDetails.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditDetails.java
@@ -1,0 +1,6 @@
+package org.fabt.shared.audit;
+
+/**
+ * Audit details for changes that track old and new values.
+ */
+public record AuditDetails(Object oldValue, Object newValue) {}

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventEntity.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventEntity.java
@@ -1,0 +1,48 @@
+package org.fabt.shared.audit;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import org.fabt.shared.config.JsonString;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Table;
+
+@Table("audit_events")
+public class AuditEventEntity {
+
+    @Id
+    private UUID id;
+    private Instant timestamp;
+    private UUID actorUserId;
+    private UUID targetUserId;
+    private String action;
+    private JsonString details;
+    private String ipAddress;
+
+    public AuditEventEntity() {}
+
+    public AuditEventEntity(UUID actorUserId, UUID targetUserId, String action,
+                            JsonString details, String ipAddress) {
+        this.actorUserId = actorUserId;
+        this.targetUserId = targetUserId;
+        this.action = action;
+        this.details = details;
+        this.ipAddress = ipAddress;
+        this.timestamp = Instant.now();
+    }
+
+    public UUID getId() { return id; }
+    public void setId(UUID id) { this.id = id; }
+    public Instant getTimestamp() { return timestamp; }
+    public void setTimestamp(Instant timestamp) { this.timestamp = timestamp; }
+    public UUID getActorUserId() { return actorUserId; }
+    public void setActorUserId(UUID actorUserId) { this.actorUserId = actorUserId; }
+    public UUID getTargetUserId() { return targetUserId; }
+    public void setTargetUserId(UUID targetUserId) { this.targetUserId = targetUserId; }
+    public String getAction() { return action; }
+    public void setAction(String action) { this.action = action; }
+    public JsonString getDetails() { return details; }
+    public void setDetails(JsonString details) { this.details = details; }
+    public String getIpAddress() { return ipAddress; }
+    public void setIpAddress(String ipAddress) { this.ipAddress = ipAddress; }
+}

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventRecord.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventRecord.java
@@ -1,0 +1,11 @@
+package org.fabt.shared.audit;
+
+import java.util.UUID;
+
+/**
+ * Audit event published via Spring ApplicationEventPublisher.
+ * Lives in shared.audit so any module can publish without creating
+ * a dependency on the auth module.
+ */
+public record AuditEventRecord(UUID actorUserId, UUID targetUserId, String action,
+                                Object details, String ipAddress) {}

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventService.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventService.java
@@ -1,0 +1,60 @@
+package org.fabt.shared.audit;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.fabt.shared.audit.repository.AuditEventRepository;
+import org.fabt.shared.config.JsonString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Persists audit events asynchronously. Listens for AuditEventRecord
+ * published via Spring ApplicationEventPublisher from UserService
+ * (and future services that need audit logging).
+ */
+@Service
+public class AuditEventService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditEventService.class);
+
+    private final AuditEventRepository repository;
+    private final ObjectMapper objectMapper;
+
+    public AuditEventService(AuditEventRepository repository, ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.objectMapper = objectMapper;
+    }
+
+    @EventListener
+    public void onAuditEvent(AuditEventRecord event) {
+        try {
+            JsonString details = null;
+            if (event.details() != null) {
+                details = new JsonString(objectMapper.writeValueAsString(event.details()));
+            }
+
+            AuditEventEntity entity = new AuditEventEntity(
+                    event.actorUserId(),
+                    event.targetUserId(),
+                    event.action(),
+                    details,
+                    event.ipAddress());
+
+            repository.save(entity);
+            log.debug("Audit event persisted: action={}, actor={}, target={}",
+                    event.action(), event.actorUserId(), event.targetUserId());
+        } catch (Exception e) {
+            log.error("Failed to persist audit event: action={}, error={}",
+                    event.action(), e.getMessage());
+        }
+    }
+
+    public List<AuditEventEntity> findByTargetUserId(UUID targetUserId) {
+        return repository.findByTargetUserId(targetUserId);
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/audit/api/AuditEventController.java
+++ b/backend/src/main/java/org/fabt/shared/audit/api/AuditEventController.java
@@ -1,0 +1,64 @@
+package org.fabt.shared.audit.api;
+
+import java.util.List;
+
+import org.fabt.shared.audit.AuditEventEntity;
+import org.fabt.shared.audit.AuditEventService;
+import java.util.UUID;
+
+import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/audit-events")
+@PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+public class AuditEventController {
+
+    private final AuditEventService auditEventService;
+
+    public AuditEventController(AuditEventService auditEventService) {
+        this.auditEventService = auditEventService;
+    }
+
+    @Operation(
+            summary = "Query audit events for a target user",
+            description = "Returns audit events for the specified user in reverse chronological order. " +
+                    "Includes role changes, dvAccess changes, deactivation/reactivation, password resets. " +
+                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+    )
+    @GetMapping
+    public ResponseEntity<List<AuditEventResponse>> getAuditEvents(
+            @RequestParam UUID targetUserId) {
+        List<AuditEventResponse> events = auditEventService.findByTargetUserId(targetUserId)
+                .stream()
+                .map(AuditEventResponse::from)
+                .toList();
+        return ResponseEntity.ok(events);
+    }
+
+    public record AuditEventResponse(
+            UUID id,
+            String timestamp,
+            UUID actorUserId,
+            UUID targetUserId,
+            String action,
+            String details,
+            String ipAddress
+    ) {
+        public static AuditEventResponse from(AuditEventEntity entity) {
+            return new AuditEventResponse(
+                    entity.getId(),
+                    entity.getTimestamp() != null ? entity.getTimestamp().toString() : null,
+                    entity.getActorUserId(),
+                    entity.getTargetUserId(),
+                    entity.getAction(),
+                    entity.getDetails() != null ? entity.getDetails().value() : null,
+                    entity.getIpAddress());
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/audit/repository/AuditEventRepository.java
+++ b/backend/src/main/java/org/fabt/shared/audit/repository/AuditEventRepository.java
@@ -1,0 +1,15 @@
+package org.fabt.shared.audit.repository;
+
+import java.util.List;
+
+import org.fabt.shared.audit.AuditEventEntity;
+import java.util.UUID;
+
+import org.springframework.data.jdbc.repository.query.Query;
+import org.springframework.data.repository.CrudRepository;
+
+public interface AuditEventRepository extends CrudRepository<AuditEventEntity, UUID> {
+
+    @Query("SELECT * FROM audit_events WHERE target_user_id = :targetUserId ORDER BY timestamp DESC LIMIT 100")
+    List<AuditEventEntity> findByTargetUserId(UUID targetUserId);
+}

--- a/backend/src/main/java/org/fabt/shared/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/org/fabt/shared/security/JwtAuthenticationFilter.java
@@ -66,16 +66,33 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             // has microsecond precision. Truncate both to seconds for a fair comparison —
             // otherwise a token issued in the same second as the password change would be
             // incorrectly rejected because iat=12:00:00.000 < password_changed_at=12:00:00.456.
-            if (claims.issuedAt() != null) {
-                User user = userRepository.findById(claims.userId()).orElse(null);
-                if (user != null && user.getPasswordChangedAt() != null
-                        && claims.issuedAt().truncatedTo(java.time.temporal.ChronoUnit.SECONDS)
-                                .isBefore(user.getPasswordChangedAt().truncatedTo(java.time.temporal.ChronoUnit.SECONDS))) {
-                    log.debug("JWT rejected: issued before password change for user {}", claims.userId());
-                    SecurityContextHolder.clearContext();
-                    filterChain.doFilter(request, response);
-                    return;
-                }
+            User user = userRepository.findById(claims.userId()).orElse(null);
+
+            // Reject tokens for deactivated users
+            if (user != null && !user.isActive()) {
+                log.debug("JWT rejected: user {} is deactivated", claims.userId());
+                SecurityContextHolder.clearContext();
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // Reject tokens with stale token version (role change, dvAccess change, deactivation)
+            if (user != null && claims.tokenVersion() != user.getTokenVersion()) {
+                log.debug("JWT rejected: token version {} does not match current {} for user {}",
+                        claims.tokenVersion(), user.getTokenVersion(), claims.userId());
+                SecurityContextHolder.clearContext();
+                filterChain.doFilter(request, response);
+                return;
+            }
+
+            // Reject tokens issued before password change
+            if (claims.issuedAt() != null && user != null && user.getPasswordChangedAt() != null
+                    && claims.issuedAt().truncatedTo(java.time.temporal.ChronoUnit.SECONDS)
+                            .isBefore(user.getPasswordChangedAt().truncatedTo(java.time.temporal.ChronoUnit.SECONDS))) {
+                log.debug("JWT rejected: issued before password change for user {}", claims.userId());
+                SecurityContextHolder.clearContext();
+                filterChain.doFilter(request, response);
+                return;
             }
 
             UsernamePasswordAuthenticationToken authentication =

--- a/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
@@ -153,6 +153,9 @@ public class SecurityConfig {
                         // Import — COC_ADMIN or PLATFORM_ADMIN
                         .requestMatchers("/api/v1/import/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
 
+                        // Audit events — COC_ADMIN or PLATFORM_ADMIN
+                        .requestMatchers("/api/v1/audit-events/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+
                         // SSE notifications — any authenticated role (token via query param)
                         .requestMatchers("/api/v1/notifications/stream").authenticated()
 

--- a/backend/src/main/resources/db/migration/V28__add_user_status_and_token_version.sql
+++ b/backend/src/main/resources/db/migration/V28__add_user_status_and_token_version.sql
@@ -1,0 +1,10 @@
+-- V28: Add status and token_version to app_user for user deactivation and JWT invalidation.
+-- status: ACTIVE (default) or DEACTIVATED. Deactivated users cannot log in.
+-- token_version: incremented on role change, dvAccess change, or deactivation.
+--   JwtAuthenticationFilter compares JWT 'ver' claim against this value.
+
+ALTER TABLE app_user ADD COLUMN status VARCHAR(20) NOT NULL DEFAULT 'ACTIVE';
+ALTER TABLE app_user ADD COLUMN token_version INTEGER NOT NULL DEFAULT 0;
+
+-- Grant to fabt_app role (RLS-restricted application role)
+GRANT SELECT, INSERT, UPDATE, DELETE ON app_user TO fabt_app;

--- a/backend/src/main/resources/db/migration/V29__create_audit_events.sql
+++ b/backend/src/main/resources/db/migration/V29__create_audit_events.sql
@@ -1,0 +1,22 @@
+-- V29: Audit events table for admin action tracking.
+-- Records who changed what, when, and from where.
+-- Retained indefinitely (security audit trail, not subject to GDPR erasure).
+
+CREATE TABLE audit_events (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    timestamp TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    actor_user_id UUID NOT NULL,
+    target_user_id UUID,
+    action VARCHAR(50) NOT NULL,
+    details JSONB,
+    ip_address VARCHAR(45)
+);
+
+-- BRIN index on timestamp for efficient range queries on append-only data
+CREATE INDEX idx_audit_events_timestamp ON audit_events USING BRIN (timestamp);
+
+-- Index for querying audit events by target user
+CREATE INDEX idx_audit_events_target_user ON audit_events (target_user_id);
+
+-- Grant to fabt_app role
+GRANT SELECT, INSERT ON audit_events TO fabt_app;

--- a/backend/src/test/java/org/fabt/ArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/ArchitectureTest.java
@@ -29,7 +29,8 @@ class ArchitectureTest {
                             "org.fabt.availability..",
                             "org.fabt.reservation..",
                             "org.fabt.surge..",
-                            "org.fabt.analytics.."
+                            "org.fabt.analytics..",
+                            "org.fabt.notification.."
                     ).as("Shared kernel (except security) must not depend on any domain module");
 
     @ArchTest
@@ -263,6 +264,25 @@ class ArchitectureTest {
                             "org.fabt.reservation.domain..",
                             "org.fabt.surge.domain.."
                     ).as("Referral module must not access other modules' domain entities");
+
+    // --- Notification module boundary (v0.18.0) ---
+
+    @ArchTest
+    static final ArchRule notification_should_not_access_other_repositories =
+            noClasses().that().resideInAPackage("org.fabt.notification..")
+                    .should().dependOnClassesThat().resideInAnyPackage(
+                            "org.fabt.tenant.repository..",
+                            "org.fabt.auth.repository..",
+                            "org.fabt.shelter.repository..",
+                            "org.fabt.dataimport.repository..",
+                            "org.fabt.subscription.repository..",
+                            "org.fabt.availability.repository..",
+                            "org.fabt.reservation.repository..",
+                            "org.fabt.referral.repository..",
+                            "org.fabt.surge.repository..",
+                            "org.fabt.hmis.repository..",
+                            "org.fabt.analytics.repository.."
+                    ).as("Notification module must not access other modules' repositories");
 
     // --- API controllers must reside in api packages ---
 

--- a/backend/src/test/java/org/fabt/auth/UserManagementIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/auth/UserManagementIntegrationTest.java
@@ -1,0 +1,228 @@
+package org.fabt.auth;
+
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.auth.api.UserResponse;
+import org.fabt.auth.domain.User;
+import org.fabt.auth.repository.UserRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for user management: edit, deactivate, reactivate,
+ * token versioning, and audit trail.
+ */
+class UserManagementIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private TestAuthHelper authHelper;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    void setUp() {
+        authHelper.setupTestTenant();
+        authHelper.setupAdminUser();
+    }
+
+    @Test
+    @DisplayName("T-16: Edit user roles increments tokenVersion")
+    void editUserRoles_incrementsTokenVersion() {
+        // Create a user to edit
+        User outreach = authHelper.setupOutreachWorkerUser();
+        int originalVersion = outreach.getTokenVersion();
+
+        // Edit roles via API
+        String body = """
+                {"roles": ["COORDINATOR"], "dvAccess": false}
+                """;
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        ResponseEntity<UserResponse> response = restTemplate.exchange(
+                "/api/v1/users/" + outreach.getId(),
+                HttpMethod.PUT,
+                new HttpEntity<>(body, headers),
+                UserResponse.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody()).isNotNull();
+        assertThat(response.getBody().roles()).containsExactly("COORDINATOR");
+
+        // Verify tokenVersion incremented in DB
+        User updated = userRepository.findById(outreach.getId()).orElseThrow();
+        assertThat(updated.getTokenVersion()).isGreaterThan(originalVersion);
+    }
+
+    @Test
+    @DisplayName("T-17: Deactivate user, login rejected with 401")
+    void deactivateUser_loginRejected() {
+        // Create a dedicated user for this test
+        User testUser = authHelper.setupUserWithDvAccess(
+                "deactivate-test@test.fabt.org", "Deactivate Test", new String[]{"OUTREACH_WORKER"});
+
+        // Deactivate via API
+        String statusBody = """
+                {"status": "DEACTIVATED"}
+                """;
+        HttpHeaders adminHeaders = authHelper.adminHeaders();
+        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        ResponseEntity<UserResponse> deactivateResponse = restTemplate.exchange(
+                "/api/v1/users/" + testUser.getId() + "/status",
+                HttpMethod.PATCH,
+                new HttpEntity<>(statusBody, adminHeaders),
+                UserResponse.class);
+
+        assertThat(deactivateResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(deactivateResponse.getBody().status()).isEqualTo("DEACTIVATED");
+
+        // Attempt login — should be rejected
+        String loginBody = """
+                {"email": "deactivate-test@test.fabt.org", "password": "%s", "tenantSlug": "%s"}
+                """.formatted(TestAuthHelper.TEST_PASSWORD, authHelper.getTestTenantSlug());
+
+        ResponseEntity<String> loginResponse = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                new HttpEntity<>(loginBody, jsonHeaders()),
+                String.class);
+
+        assertThat(loginResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(loginResponse.getBody()).contains("deactivated");
+    }
+
+    @Test
+    @DisplayName("T-18: Deactivated user's JWT rejected via stale tokenVersion")
+    void deactivatedUser_jwtRejected() {
+        User testUser = authHelper.setupUserWithDvAccess(
+                "jwt-reject-test@test.fabt.org", "JWT Reject Test", new String[]{"OUTREACH_WORKER"});
+
+        // Get a valid token before deactivation
+        HttpHeaders userHeaders = authHelper.headersForUser(testUser);
+
+        // Verify the token works
+        ResponseEntity<String> beforeResponse = restTemplate.exchange(
+                "/api/v1/queries/beds",
+                HttpMethod.POST,
+                new HttpEntity<>("{}", userHeaders),
+                String.class);
+        assertThat(beforeResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+
+        // Deactivate the user
+        String statusBody = """
+                {"status": "DEACTIVATED"}
+                """;
+        HttpHeaders adminHeaders = authHelper.adminHeaders();
+        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+        restTemplate.exchange(
+                "/api/v1/users/" + testUser.getId() + "/status",
+                HttpMethod.PATCH,
+                new HttpEntity<>(statusBody, adminHeaders),
+                UserResponse.class);
+
+        // The old token should now be rejected (tokenVersion mismatch)
+        ResponseEntity<String> afterResponse = restTemplate.exchange(
+                "/api/v1/queries/beds",
+                HttpMethod.POST,
+                new HttpEntity<>("{}", userHeaders),
+                String.class);
+        assertThat(afterResponse.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+    }
+
+    @Test
+    @DisplayName("T-19: Audit events persisted on role change and deactivation")
+    void auditEvents_persistedOnChanges() {
+        User testUser = authHelper.setupUserWithDvAccess(
+                "audit-test@test.fabt.org", "Audit Test", new String[]{"OUTREACH_WORKER"});
+
+        HttpHeaders adminHeaders = authHelper.adminHeaders();
+        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        // Change roles
+        restTemplate.exchange(
+                "/api/v1/users/" + testUser.getId(),
+                HttpMethod.PUT,
+                new HttpEntity<>("{\"roles\": [\"COORDINATOR\"]}", adminHeaders),
+                UserResponse.class);
+
+        // Deactivate
+        restTemplate.exchange(
+                "/api/v1/users/" + testUser.getId() + "/status",
+                HttpMethod.PATCH,
+                new HttpEntity<>("{\"status\": \"DEACTIVATED\"}", adminHeaders),
+                UserResponse.class);
+
+        // Query audit events
+        ResponseEntity<String> auditResponse = restTemplate.exchange(
+                "/api/v1/audit-events?targetUserId=" + testUser.getId(),
+                HttpMethod.GET,
+                new HttpEntity<>(adminHeaders),
+                String.class);
+
+        assertThat(auditResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(auditResponse.getBody()).contains("ROLE_CHANGED");
+        assertThat(auditResponse.getBody()).contains("USER_DEACTIVATED");
+    }
+
+    @Test
+    @DisplayName("T-20: Reactivate user, login works again")
+    void reactivateUser_loginWorks() {
+        User testUser = authHelper.setupUserWithDvAccess(
+                "reactivate-test@test.fabt.org", "Reactivate Test", new String[]{"OUTREACH_WORKER"});
+
+        HttpHeaders adminHeaders = authHelper.adminHeaders();
+        adminHeaders.setContentType(MediaType.APPLICATION_JSON);
+
+        // Deactivate
+        restTemplate.exchange(
+                "/api/v1/users/" + testUser.getId() + "/status",
+                HttpMethod.PATCH,
+                new HttpEntity<>("{\"status\": \"DEACTIVATED\"}", adminHeaders),
+                UserResponse.class);
+
+        // Verify login fails
+        String loginBody = """
+                {"email": "reactivate-test@test.fabt.org", "password": "%s", "tenantSlug": "%s"}
+                """.formatted(TestAuthHelper.TEST_PASSWORD, authHelper.getTestTenantSlug());
+
+        ResponseEntity<String> failedLogin = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                new HttpEntity<>(loginBody, jsonHeaders()),
+                String.class);
+        assertThat(failedLogin.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+
+        // Reactivate
+        restTemplate.exchange(
+                "/api/v1/users/" + testUser.getId() + "/status",
+                HttpMethod.PATCH,
+                new HttpEntity<>("{\"status\": \"ACTIVE\"}", adminHeaders),
+                UserResponse.class);
+
+        // Login should work now
+        ResponseEntity<String> successLogin = restTemplate.postForEntity(
+                "/api/v1/auth/login",
+                new HttpEntity<>(loginBody, jsonHeaders()),
+                String.class);
+        assertThat(successLogin.getStatusCode()).isEqualTo(HttpStatus.OK);
+    }
+
+    private HttpHeaders jsonHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+}

--- a/docs/FOR-DEVELOPERS.md
+++ b/docs/FOR-DEVELOPERS.md
@@ -553,9 +553,16 @@ All endpoints are under `/api/v1`. Authentication is via JWT Bearer token (from 
 | Method | Path | Auth | Description |
 |---|---|---|---|
 | `POST` | `/api/v1/users` | COC_ADMIN+ | Create user (dvAccess defaults false) |
-| `GET` | `/api/v1/users` | COC_ADMIN+ | List users in tenant |
+| `GET` | `/api/v1/users` | COC_ADMIN+ | List users in tenant (includes status field) |
 | `GET` | `/api/v1/users/{id}` | COC_ADMIN+ | Get user by ID |
-| `PUT` | `/api/v1/users/{id}` | COC_ADMIN+ | Update user (roles, dvAccess) |
+| `PUT` | `/api/v1/users/{id}` | COC_ADMIN+ | Update user (displayName, email, roles, dvAccess). Role/dvAccess changes increment tokenVersion, invalidating existing JWTs |
+| `PATCH` | `/api/v1/users/{id}/status` | COC_ADMIN+ | Deactivate or reactivate user. Body: `{"status": "DEACTIVATED"}` or `{"status": "ACTIVE"}`. Disconnects SSE on deactivation |
+
+### Audit Events
+
+| Method | Path | Auth | Description |
+|---|---|---|---|
+| `GET` | `/api/v1/audit-events?targetUserId={id}` | COC_ADMIN+ | Query audit events for a user (role changes, deactivation, password resets) in reverse chronological order |
 
 ### API Keys
 

--- a/docs/asyncapi.yaml
+++ b/docs/asyncapi.yaml
@@ -673,3 +673,35 @@ components:
           type: string
           enum: [ACCEPTED, REJECTED]
           description: Shelter response. Present on dv-referral.responded events only.
+
+  # -----------------------------------------------------------------------
+  # User lifecycle events (v0.19.0 — admin-user-management)
+  # -----------------------------------------------------------------------
+
+  UserLifecyclePayload:
+    type: object
+    description: |
+      Payload for user lifecycle events: deactivation, reactivation, role change.
+      Published to the EventBus when admin actions modify user accounts.
+      Consumed by NotificationService (SSE disconnect on deactivation) and
+      AuditEventService (persistence to audit_events table).
+    properties:
+      user_id:
+        type: string
+        format: uuid
+        description: UUID of the affected user.
+      tenant_id:
+        type: string
+        format: uuid
+        description: Continuum of Care tenant.
+      action:
+        type: string
+        enum: [USER_DEACTIVATED, USER_REACTIVATED, ROLE_CHANGED, DV_ACCESS_CHANGED]
+        description: The admin action performed.
+      actor_user_id:
+        type: string
+        format: uuid
+        description: UUID of the admin who performed the action.
+      details:
+        type: object
+        description: Old/new values (e.g., old_roles, new_roles).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -695,6 +695,32 @@ Rate limited: 10 attempts per 15 minutes per IP (`rate-limit-admin-reset` bucket
 
 ---
 
+## User Deactivation
+
+### Procedure
+1. Admin navigates to Administration → Users tab
+2. Clicks "Edit" on the user row → drawer opens
+3. Clicks "Deactivate" → confirmation dialog appears
+4. Confirms → user status set to DEACTIVATED
+
+### What happens on deactivation
+- `token_version` incremented → all existing JWTs immediately rejected
+- SSE notification stream disconnected (if connected)
+- Login attempts return "Account deactivated. Contact your administrator."
+- Audit event recorded: action=USER_DEACTIVATED, actor, timestamp, IP
+
+### Reactivation
+- Same flow: Edit → "Reactivate" button (green, replaces Deactivate)
+- `token_version` incremented again → user must log in fresh
+- Audit event recorded: action=USER_REACTIVATED
+
+### JWT invalidation troubleshooting
+**Symptom:** User reports "still logged in" after role change or deactivation
+**Cause:** JWT claims cache (Caffeine, 30s TTL) may hold stale claims
+**Resolution:** Token version check runs on every request. Maximum delay is the cache TTL (30s). If the user's client doesn't refresh within 30s, force-expire by incrementing `token_version` again.
+
+---
+
 ## SSE Notifications
 
 ### Architecture

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -79,12 +79,36 @@ Table app_user {
   display_name  varchar     [not null]
   roles         "text[]"    [not null, note: 'Array of Role enum values']
   dv_access     boolean     [not null, default: false, note: 'Allowed to see DV-shelter data']
+  status        varchar(20) [not null, default: 'ACTIVE', note: 'ACTIVE or DEACTIVATED']
+  token_version integer     [not null, default: 0, note: 'Incremented on role/dvAccess/status change to invalidate JWTs']
+  password_changed_at timestamptz [note: 'V27 — set on password change, JWTs issued before this are rejected']
   created_at    timestamptz [not null, default: `now()`]
   updated_at    timestamptz [not null, default: `now()`]
 
   indexes {
     (tenant_id, email) [unique, name: 'uq_app_user_tenant_email']
   }
+}
+
+// ---------------------------------------------------------------------------
+// V29 — Audit Events
+// ---------------------------------------------------------------------------
+
+Table audit_events {
+  id              uuid        [pk, note: 'gen_random_uuid()']
+  timestamp       timestamptz [not null, default: `clock_timestamp()`]
+  actor_user_id   uuid        [not null]
+  target_user_id  uuid
+  action          varchar(50) [not null, note: 'ROLE_CHANGED, USER_DEACTIVATED, USER_REACTIVATED, DV_ACCESS_CHANGED, PASSWORD_RESET']
+  details         jsonb       [note: 'Old/new values, context']
+  ip_address      varchar(45) [note: 'IPv4 or IPv6']
+
+  indexes {
+    timestamp [type: brin, name: 'idx_audit_events_timestamp']
+    target_user_id [name: 'idx_audit_events_target_user']
+  }
+
+  note: 'Append-only audit trail. Retained indefinitely.'
 }
 
 // ---------------------------------------------------------------------------

--- a/e2e/playwright/tests/user-management.spec.ts
+++ b/e2e/playwright/tests/user-management.spec.ts
@@ -1,0 +1,127 @@
+import { test, expect } from '../fixtures/auth.fixture';
+
+/**
+ * User Management — Playwright E2E tests.
+ * Tests the edit drawer, deactivation, reactivation, and status badges.
+ */
+
+test.describe('User Management', () => {
+
+  test('Edit button visible on each user row', async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await expect(adminPage.locator('main')).toBeVisible();
+
+    // Users tab is default — edit buttons should be present
+    const editButtons = adminPage.locator('[data-testid^="edit-user-"]');
+    await expect(editButtons.first()).toBeVisible();
+  });
+
+  test('Clicking Edit opens the user edit drawer', async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await adminPage.waitForTimeout(1000);
+
+    // Click first edit button
+    const editButton = adminPage.locator('[data-testid^="edit-user-"]').first();
+    await editButton.click();
+
+    // Drawer should open
+    const drawer = adminPage.locator('[data-testid="user-edit-drawer"]');
+    await expect(drawer).toBeVisible();
+
+    // Fields should be populated
+    const nameInput = drawer.locator('[data-testid="user-edit-displayName"]');
+    await expect(nameInput).toBeVisible();
+    const nameValue = await nameInput.inputValue();
+    expect(nameValue.length).toBeGreaterThan(0);
+  });
+
+  test('Edit user display name, save, verify change', async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await adminPage.waitForTimeout(1000);
+
+    // Edit the deactivated test user (safe — doesn't affect other tests)
+    const editButton = adminPage.locator('[data-testid="edit-user-former@dev.fabt.org"]');
+    if (await editButton.count() > 0) {
+      await editButton.click();
+      await adminPage.waitForTimeout(300);
+
+      const drawer = adminPage.locator('[data-testid="user-edit-drawer"]');
+      await expect(drawer).toBeVisible();
+
+      // Change display name (non-destructive edit)
+      const nameInput = drawer.locator('[data-testid="user-edit-displayName"]');
+      await nameInput.fill('Updated Staff Member');
+
+      // Save
+      await drawer.locator('[data-testid="user-edit-save"]').click();
+      await adminPage.waitForTimeout(1000);
+
+      // Restore original name
+      await editButton.click();
+      await adminPage.waitForTimeout(300);
+      await drawer.locator('[data-testid="user-edit-displayName"]').fill('Former Staff Member');
+      await drawer.locator('[data-testid="user-edit-save"]').click();
+      await adminPage.waitForTimeout(500);
+    }
+  });
+
+  test('Deactivate button shows confirmation dialog', async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await adminPage.waitForTimeout(1000);
+
+    const editButton = adminPage.locator('[data-testid^="edit-user-"]').first();
+    await editButton.click();
+    await adminPage.waitForTimeout(300);
+
+    const drawer = adminPage.locator('[data-testid="user-edit-drawer"]');
+    const deactivateBtn = drawer.locator('[data-testid="user-deactivate-button"]');
+
+    // Only test if user is active (has deactivate button)
+    if (await deactivateBtn.count() > 0) {
+      await deactivateBtn.click();
+      await adminPage.waitForTimeout(300);
+
+      // Confirmation dialog should appear
+      const confirmDialog = adminPage.locator('[data-testid="deactivate-confirm-dialog"]');
+      await expect(confirmDialog).toBeVisible();
+
+      // Cancel — don't actually deactivate seed users
+      await confirmDialog.locator('button', { hasText: /cancel/i }).click();
+      await expect(confirmDialog).not.toBeVisible();
+    }
+  });
+
+  test('Status badge visible on user rows', async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await adminPage.waitForTimeout(1000);
+
+    // Status column should show Active/Deactivated badges
+    const statusHeader = adminPage.locator('th', { hasText: /Status|Estado/ });
+    await expect(statusHeader).toBeVisible();
+  });
+
+  test('Drawer closes on Escape key', async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await adminPage.waitForTimeout(1000);
+
+    const editButton = adminPage.locator('[data-testid^="edit-user-"]').first();
+    await editButton.click();
+
+    const drawer = adminPage.locator('[data-testid="user-edit-drawer"]');
+    await expect(drawer).toBeVisible();
+
+    await adminPage.keyboard.press('Escape');
+    await expect(drawer).not.toBeVisible();
+  });
+
+  test('Drawer has accessible dialog role', async ({ adminPage }) => {
+    await adminPage.goto('/admin');
+    await adminPage.waitForTimeout(1000);
+
+    const editButton = adminPage.locator('[data-testid^="edit-user-"]').first();
+    await editButton.click();
+
+    const drawer = adminPage.locator('[data-testid="user-edit-drawer"]');
+    await expect(drawer).toHaveAttribute('role', 'dialog');
+  });
+});

--- a/frontend/src/components/UserEditDrawer.tsx
+++ b/frontend/src/components/UserEditDrawer.tsx
@@ -1,0 +1,328 @@
+import { useState, useEffect, useRef } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { api } from '../services/api';
+import { text, weight } from '../theme/typography';
+
+interface User {
+  id: string;
+  email: string;
+  displayName: string;
+  roles: string[];
+  dvAccess: boolean;
+  status: string;
+}
+
+interface UserEditDrawerProps {
+  user: User | null;
+  onClose: () => void;
+  onSaved: () => void;
+}
+
+const AVAILABLE_ROLES = ['OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN'];
+
+export function UserEditDrawer({ user, onClose, onSaved }: UserEditDrawerProps) {
+  const intl = useIntl();
+  const drawerRef = useRef<HTMLDivElement>(null);
+  const [displayName, setDisplayName] = useState('');
+  const [email, setEmail] = useState('');
+  const [roles, setRoles] = useState<string[]>([]);
+  const [dvAccess, setDvAccess] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [success, setSuccess] = useState<string | null>(null);
+
+  // Confirmation dialog for deactivation
+  const [showDeactivateConfirm, setShowDeactivateConfirm] = useState(false);
+  const [statusChanging, setStatusChanging] = useState(false);
+
+  // Populate form when user changes
+  useEffect(() => {
+    if (user) {
+      setDisplayName(user.displayName || '');
+      setEmail(user.email || '');
+      setRoles([...user.roles]);
+      setDvAccess(user.dvAccess);
+      setError(null);
+      setSuccess(null);
+      setShowDeactivateConfirm(false);
+    }
+  }, [user]);
+
+  // Escape to close
+  useEffect(() => {
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && user) onClose();
+    }
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [user, onClose]);
+
+  if (!user) return null;
+
+  const handleSave = async () => {
+    setSaving(true);
+    setError(null);
+    setSuccess(null);
+    try {
+      await api.put(`/api/v1/users/${user.id}`, {
+        displayName,
+        email,
+        roles,
+        dvAccess,
+      });
+      setSuccess(intl.formatMessage({ id: 'admin.user.saved' }));
+      onSaved();
+    } catch (err: unknown) {
+      const apiErr = err as { message?: string };
+      setError(apiErr.message || intl.formatMessage({ id: 'admin.user.saveError' }));
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleStatusChange = async (newStatus: string) => {
+    setStatusChanging(true);
+    setError(null);
+    try {
+      await api.patch(`/api/v1/users/${user.id}/status`, { status: newStatus });
+      setShowDeactivateConfirm(false);
+      onSaved();
+      onClose();
+    } catch (err: unknown) {
+      const apiErr = err as { message?: string };
+      setError(apiErr.message || intl.formatMessage({ id: 'admin.user.saveError' }));
+    } finally {
+      setStatusChanging(false);
+    }
+  };
+
+  const toggleRole = (role: string) => {
+    setRoles((prev) =>
+      prev.includes(role) ? prev.filter((r) => r !== role) : [...prev, role]
+    );
+  };
+
+  const isDeactivated = user.status === 'DEACTIVATED';
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        onClick={onClose}
+        style={{
+          position: 'fixed', inset: 0, backgroundColor: 'rgba(0,0,0,0.3)', zIndex: 1000,
+        }}
+      />
+      {/* Drawer */}
+      <div
+        ref={drawerRef}
+        role="dialog"
+        aria-label={intl.formatMessage({ id: 'admin.user.editTitle' })}
+        data-testid="user-edit-drawer"
+        style={{
+          position: 'fixed', top: 0, right: 0, bottom: 0, width: '400px', maxWidth: '90vw',
+          backgroundColor: '#ffffff', boxShadow: '-4px 0 20px rgba(0,0,0,0.15)',
+          zIndex: 1001, display: 'flex', flexDirection: 'column', overflow: 'hidden',
+        }}
+      >
+        {/* Header */}
+        <div style={{
+          padding: '16px 20px', borderBottom: '1px solid #e5e7eb',
+          display: 'flex', justifyContent: 'space-between', alignItems: 'center',
+        }}>
+          <h2 style={{ margin: 0, fontSize: text.lg, fontWeight: weight.bold }}>
+            <FormattedMessage id="admin.user.editTitle" />
+          </h2>
+          <button onClick={onClose} aria-label="Close" style={{
+            background: 'none', border: 'none', fontSize: '20px', cursor: 'pointer', color: '#6b7280',
+          }}>×</button>
+        </div>
+
+        {/* Status badge */}
+        <div style={{ padding: '12px 20px', borderBottom: '1px solid #f3f4f6' }}>
+          <span style={{
+            display: 'inline-block', padding: '4px 10px', borderRadius: 12,
+            fontSize: text.xs, fontWeight: weight.semibold,
+            backgroundColor: isDeactivated ? '#fef2f2' : '#f0fdf4',
+            color: isDeactivated ? '#dc2626' : '#166534',
+          }}>
+            {isDeactivated
+              ? intl.formatMessage({ id: 'admin.user.statusDeactivated' })
+              : intl.formatMessage({ id: 'admin.user.statusActive' })}
+          </span>
+        </div>
+
+        {/* Form */}
+        <div style={{ flex: 1, overflowY: 'auto', padding: '20px' }}>
+          {/* Display Name */}
+          <label style={{ display: 'block', marginBottom: 16 }}>
+            <span style={{ fontSize: text.sm, fontWeight: weight.semibold, color: '#374151', display: 'block', marginBottom: 4 }}>
+              <FormattedMessage id="admin.displayName" />
+            </span>
+            <input
+              value={displayName}
+              onChange={(e) => setDisplayName(e.target.value)}
+              data-testid="user-edit-displayName"
+              style={{
+                width: '100%', padding: '10px 12px', border: '1px solid #d1d5db',
+                borderRadius: 6, fontSize: text.base, boxSizing: 'border-box',
+              }}
+            />
+          </label>
+
+          {/* Email */}
+          <label style={{ display: 'block', marginBottom: 16 }}>
+            <span style={{ fontSize: text.sm, fontWeight: weight.semibold, color: '#374151', display: 'block', marginBottom: 4 }}>
+              <FormattedMessage id="admin.email" />
+            </span>
+            <input
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              data-testid="user-edit-email"
+              style={{
+                width: '100%', padding: '10px 12px', border: '1px solid #d1d5db',
+                borderRadius: 6, fontSize: text.base, boxSizing: 'border-box',
+              }}
+            />
+          </label>
+
+          {/* Roles */}
+          <fieldset style={{ border: 'none', padding: 0, marginBottom: 16 }}>
+            <legend style={{ fontSize: text.sm, fontWeight: weight.semibold, color: '#374151', marginBottom: 8 }}>
+              <FormattedMessage id="admin.roles" />
+            </legend>
+            {AVAILABLE_ROLES.map((role) => (
+              <label key={role} style={{ display: 'flex', alignItems: 'center', gap: 8, marginBottom: 6, cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={roles.includes(role)}
+                  onChange={() => toggleRole(role)}
+                  data-testid={`user-edit-role-${role}`}
+                  style={{ width: 18, height: 18 }}
+                />
+                <span style={{ fontSize: text.sm }}>{role.replace('_', ' ')}</span>
+              </label>
+            ))}
+          </fieldset>
+
+          {/* DV Access */}
+          <label style={{ display: 'flex', alignItems: 'center', gap: 10, marginBottom: 20, cursor: 'pointer' }}>
+            <input
+              type="checkbox"
+              checked={dvAccess}
+              onChange={(e) => setDvAccess(e.target.checked)}
+              data-testid="user-edit-dvAccess"
+              style={{ width: 18, height: 18 }}
+            />
+            <span style={{ fontSize: text.sm, fontWeight: weight.semibold, color: '#374151' }}>
+              <FormattedMessage id="admin.dvAccess" />
+            </span>
+          </label>
+
+          {/* Error / Success */}
+          {error && (
+            <div style={{ backgroundColor: '#fef2f2', color: '#dc2626', padding: '10px 14px', borderRadius: 8, marginBottom: 12, fontSize: text.sm }}>
+              {error}
+            </div>
+          )}
+          {success && (
+            <div style={{ backgroundColor: '#f0fdf4', color: '#166534', padding: '10px 14px', borderRadius: 8, marginBottom: 12, fontSize: text.sm }}>
+              {success}
+            </div>
+          )}
+        </div>
+
+        {/* Footer actions */}
+        <div style={{ padding: '16px 20px', borderTop: '1px solid #e5e7eb', display: 'flex', gap: 10, flexWrap: 'wrap' }}>
+          <button
+            onClick={handleSave}
+            disabled={saving}
+            data-testid="user-edit-save"
+            style={{
+              flex: 1, padding: '10px 16px', backgroundColor: '#1a56db', color: '#ffffff',
+              border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: text.sm,
+              fontWeight: weight.semibold, minHeight: 44, opacity: saving ? 0.6 : 1,
+            }}
+          >
+            {saving ? '...' : <FormattedMessage id="common.save" />}
+          </button>
+
+          {isDeactivated ? (
+            <button
+              onClick={() => handleStatusChange('ACTIVE')}
+              disabled={statusChanging}
+              data-testid="user-reactivate-button"
+              style={{
+                padding: '10px 16px', backgroundColor: '#047857', color: '#ffffff',
+                border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: text.sm,
+                fontWeight: weight.semibold, minHeight: 44,
+              }}
+            >
+              <FormattedMessage id="admin.user.reactivate" />
+            </button>
+          ) : (
+            <button
+              onClick={() => setShowDeactivateConfirm(true)}
+              data-testid="user-deactivate-button"
+              style={{
+                padding: '10px 16px', backgroundColor: 'transparent', color: '#dc2626',
+                border: '1px solid #dc2626', borderRadius: 6, cursor: 'pointer',
+                fontSize: text.sm, fontWeight: weight.semibold, minHeight: 44,
+              }}
+            >
+              <FormattedMessage id="admin.user.deactivate" />
+            </button>
+          )}
+        </div>
+
+        {/* Deactivation confirmation dialog */}
+        {showDeactivateConfirm && (
+          <div style={{
+            position: 'absolute', inset: 0, backgroundColor: 'rgba(0,0,0,0.4)',
+            display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 1002,
+          }}>
+            <div
+              role="alertdialog"
+              aria-label={intl.formatMessage({ id: 'admin.user.deactivateConfirmTitle' })}
+              data-testid="deactivate-confirm-dialog"
+              style={{
+                backgroundColor: '#ffffff', borderRadius: 12, padding: '24px',
+                maxWidth: 360, boxShadow: '0 8px 30px rgba(0,0,0,0.2)',
+              }}
+            >
+              <h3 style={{ margin: '0 0 12px', fontSize: text.base, fontWeight: weight.bold }}>
+                <FormattedMessage id="admin.user.deactivateConfirmTitle" />
+              </h3>
+              <p style={{ margin: '0 0 20px', fontSize: text.sm, color: '#6b7280' }}>
+                <FormattedMessage id="admin.user.deactivateConfirmMessage" values={{ name: user.displayName }} />
+              </p>
+              <div style={{ display: 'flex', gap: 10, justifyContent: 'flex-end' }}>
+                <button
+                  onClick={() => setShowDeactivateConfirm(false)}
+                  style={{
+                    padding: '8px 16px', backgroundColor: 'transparent', border: '1px solid #d1d5db',
+                    borderRadius: 6, cursor: 'pointer', fontSize: text.sm, minHeight: 40,
+                  }}
+                >
+                  <FormattedMessage id="common.cancel" />
+                </button>
+                <button
+                  onClick={() => handleStatusChange('DEACTIVATED')}
+                  disabled={statusChanging}
+                  data-testid="deactivate-confirm-button"
+                  style={{
+                    padding: '8px 16px', backgroundColor: '#dc2626', color: '#ffffff',
+                    border: 'none', borderRadius: 6, cursor: 'pointer', fontSize: text.sm,
+                    fontWeight: weight.semibold, minHeight: 40,
+                  }}
+                >
+                  {statusChanging ? '...' : <FormattedMessage id="admin.user.deactivate" />}
+                </button>
+              </div>
+            </div>
+          </div>
+        )}
+      </div>
+    </>
+  );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -283,6 +283,18 @@
   "password.reset.ssoOnly": "This user authenticates via SSO. Password cannot be reset here.",
   "password.reset.error": "Failed to reset password. Please try again.",
 
+  "admin.user.edit": "Edit",
+  "admin.user.editTitle": "Edit User",
+  "admin.user.saved": "User updated",
+  "admin.user.saveError": "Failed to update user",
+  "admin.user.deactivate": "Deactivate",
+  "admin.user.reactivate": "Reactivate",
+  "admin.user.statusHeader": "Status",
+  "admin.user.statusActive": "Active",
+  "admin.user.statusDeactivated": "Deactivated",
+  "admin.user.deactivateConfirmTitle": "Deactivate User",
+  "admin.user.deactivateConfirmMessage": "{name} will be unable to log in. Their existing sessions will be terminated immediately. This can be reversed.",
+
   "notifications.title": "Notifications",
   "notifications.empty": "No notifications",
   "notifications.bell": "Notifications",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -283,6 +283,18 @@
   "password.reset.ssoOnly": "Este usuario se autentica mediante SSO. La contraseña no se puede restablecer aquí.",
   "password.reset.error": "Error al restablecer la contraseña. Inténtelo de nuevo.",
 
+  "admin.user.edit": "Editar",
+  "admin.user.editTitle": "Editar Usuario",
+  "admin.user.saved": "Usuario actualizado",
+  "admin.user.saveError": "Error al actualizar el usuario",
+  "admin.user.deactivate": "Desactivar",
+  "admin.user.reactivate": "Reactivar",
+  "admin.user.statusHeader": "Estado",
+  "admin.user.statusActive": "Activo",
+  "admin.user.statusDeactivated": "Desactivado",
+  "admin.user.deactivateConfirmTitle": "Desactivar Usuario",
+  "admin.user.deactivateConfirmMessage": "{name} no podrá iniciar sesión. Sus sesiones activas serán terminadas inmediatamente. Esto puede revertirse.",
+
   "notifications.title": "Notificaciones",
   "notifications.empty": "Sin notificaciones",
   "notifications.bell": "Notificaciones",

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback, useContext, lazy, Suspense } from 're
 import { FormattedMessage, useIntl } from 'react-intl';
 import { api } from '../services/api';
 import { DataAge } from '../components/DataAge';
+import { UserEditDrawer } from '../components/UserEditDrawer';
 import { AuthContext } from '../auth/AuthContext';
 import { font, text, weight } from '../theme/typography';
 
@@ -16,6 +17,7 @@ interface User {
   displayName: string;
   roles: string[];
   dvAccess: boolean;
+  status: string;
 }
 
 interface ShelterListItem {
@@ -359,6 +361,7 @@ function UsersTab() {
   const [formRoles, setFormRoles] = useState<string[]>([]);
   const [formDvAccess, setFormDvAccess] = useState(false);
   const [submitting, setSubmitting] = useState(false);
+  const [editUser, setEditUser] = useState<User | null>(null);
   const [resetUser, setResetUser] = useState<User | null>(null);
   const [resetPassword, setResetPassword] = useState('');
   const [resetConfirm, setResetConfirm] = useState('');
@@ -536,6 +539,7 @@ function UsersTab() {
                 <th style={thStyle}><FormattedMessage id="admin.displayName" /></th>
                 <th style={thStyle}><FormattedMessage id="admin.roles" /></th>
                 <th style={thStyle}><FormattedMessage id="admin.dvAccess" /></th>
+                <th style={thStyle}><FormattedMessage id="admin.user.statusHeader" /></th>
                 <th style={thStyle}></th>
               </tr>
             </thead>
@@ -551,6 +555,31 @@ function UsersTab() {
                     <StatusBadge active={u.dvAccess} yesId="admin.active" noId="admin.inactive" />
                   </td>
                   <td style={tdStyle(i)}>
+                    <StatusBadge
+                      active={u.status !== 'DEACTIVATED'}
+                      yesId="admin.user.statusActive"
+                      noId="admin.user.statusDeactivated"
+                    />
+                  </td>
+                  <td style={{ ...tdStyle(i), display: 'flex', gap: 6, flexWrap: 'nowrap' }}>
+                    <button
+                      onClick={() => setEditUser(u)}
+                      data-testid={`edit-user-${u.email}`}
+                      style={{
+                        padding: '6px 12px',
+                        backgroundColor: 'transparent',
+                        color: '#1a56db',
+                        border: '1px solid #1a56db',
+                        borderRadius: 6,
+                        fontSize: text.xs,
+                        fontWeight: weight.semibold,
+                        cursor: 'pointer',
+                        minHeight: 32,
+                        whiteSpace: 'nowrap',
+                      }}
+                    >
+                      <FormattedMessage id="admin.user.edit" />
+                    </button>
                     <button
                       onClick={() => { setResetUser(u); setResetError(null); setResetSuccess(null); setResetPassword(''); setResetConfirm(''); }}
                       data-testid={`reset-password-${u.email}`}
@@ -637,6 +666,13 @@ function UsersTab() {
           </div>
         </div>
       )}
+
+      {/* User Edit Drawer */}
+      <UserEditDrawer
+        user={editUser}
+        onClose={() => setEditUser(null)}
+        onSaved={() => { fetchUsers(); setEditUser(null); }}
+      />
     </div>
   );
 }

--- a/infra/scripts/seed-data.sql
+++ b/infra/scripts/seed-data.sql
@@ -51,6 +51,20 @@ VALUES (
     NOW(), NOW()
 ) ON CONFLICT (tenant_id, email) DO NOTHING;
 
+-- Deactivated user (for admin panel screenshots and testing)
+INSERT INTO app_user (id, tenant_id, email, password_hash, display_name, roles, dv_access, status, created_at, updated_at)
+VALUES (
+    'b0000000-0000-0000-0000-000000000004',
+    'a0000000-0000-0000-0000-000000000001',
+    'former@dev.fabt.org',
+    '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+    'Former Staff Member',
+    ARRAY['OUTREACH_WORKER'],
+    false,
+    'DEACTIVATED',
+    NOW(), NOW()
+) ON CONFLICT (tenant_id, email) DO NOTHING;
+
 -- Sample OAuth2 provider (Google, for local testing — replace client ID/secret with real values)
 INSERT INTO tenant_oauth2_provider (id, tenant_id, provider_name, client_id, client_secret_encrypted, issuer_uri, enabled, created_at)
 VALUES (


### PR DESCRIPTION
## Summary

- **User edit drawer** — slide-out panel from admin Users table. Edit display name, email, roles (multi-select), dvAccess toggle. Role/dvAccess changes increment tokenVersion, invalidating existing JWTs immediately.
- **User deactivation** — soft-delete with status field (ACTIVE/DEACTIVATED). Deactivated users can't log in, their JWTs are rejected, their SSE stream is disconnected. Confirmation dialog. Admin can reactivate.
- **JWT token versioning** — new `ver` claim in JWT. JwtAuthenticationFilter checks against DB `token_version`. Increment on role change, dvAccess change, deactivation, reactivation.
- **Audit trail** — new `audit_events` table. Records role changes, dvAccess changes, deactivation, reactivation, password resets. Query endpoint: `GET /api/v1/audit-events?targetUserId={id}`.
- **UserService refactored** — extracted from controller (was tech debt: business logic + @Transactional in controller layer).
- **ArchUnit** — notification module boundary rule added (22 rules total). Audit package restructured for boundary compliance (shared.audit.api, shared.audit.repository).

### Test Results
| Suite | Result |
|-------|--------|
| Backend | 278 tests, 0 failures |
| Playwright | 150 passed, 2 skipped |
| ArchUnit | 22 rules, all passing |
| ESLint + TSC | Clean |

## Test plan
- [ ] Edit user: open drawer, change role, save — verify tokenVersion incremented
- [ ] Deactivate user: confirm dialog, verify login rejected, verify JWT rejected
- [ ] Reactivate: verify login works again
- [ ] Audit events: query after role change + deactivation, verify both recorded
- [ ] Status badge visible on user rows (Active/Deactivated)
- [ ] Run `mvn test` — 278 tests pass
- [ ] Run `npx playwright test` — 150 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)