### PR TITLE
Offline honesty: single-queue architecture for bed holds and availability

### DIFF
--- a/backend/src/main/java/org/fabt/reservation/api/ReservationController.java
+++ b/backend/src/main/java/org/fabt/reservation/api/ReservationController.java
@@ -17,6 +17,7 @@ import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -43,11 +44,13 @@ public class ReservationController {
     @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
     public ResponseEntity<ReservationResponse> create(
             @Valid @RequestBody CreateReservationRequest request,
+            @RequestHeader(value = "X-Idempotency-Key", required = false) String idempotencyKey,
             Authentication authentication) {
         UUID userId = UUID.fromString(authentication.getName());
         Reservation reservation = reservationService.createReservation(
-                request.shelterId(), request.populationType(), request.notes(), userId);
-        return ResponseEntity.status(HttpStatus.CREATED).body(ReservationResponse.from(reservation));
+                request.shelterId(), request.populationType(), request.notes(), userId, idempotencyKey);
+        HttpStatus status = reservation.isIdempotentMatch() ? HttpStatus.OK : HttpStatus.CREATED;
+        return ResponseEntity.status(status).body(ReservationResponse.from(reservation));
     }
 
     @Operation(

--- a/backend/src/main/java/org/fabt/reservation/domain/Reservation.java
+++ b/backend/src/main/java/org/fabt/reservation/domain/Reservation.java
@@ -16,6 +16,10 @@ public class Reservation {
     private Instant cancelledAt;
     private Instant createdAt;
     private String notes;
+    private String idempotencyKey;
+
+    /** Transient flag — true when returned from an idempotent key match (not persisted). */
+    private transient boolean idempotentMatch;
 
     public Reservation() {
     }
@@ -73,4 +77,10 @@ public class Reservation {
 
     public String getNotes() { return notes; }
     public void setNotes(String notes) { this.notes = notes; }
+
+    public String getIdempotencyKey() { return idempotencyKey; }
+    public void setIdempotencyKey(String idempotencyKey) { this.idempotencyKey = idempotencyKey; }
+
+    public boolean isIdempotentMatch() { return idempotentMatch; }
+    public void setIdempotentMatch(boolean idempotentMatch) { this.idempotentMatch = idempotentMatch; }
 }

--- a/backend/src/main/java/org/fabt/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/org/fabt/reservation/repository/ReservationRepository.java
@@ -33,6 +33,7 @@ public class ReservationRepository {
         Timestamp createdAt = rs.getTimestamp("created_at");
         r.setCreatedAt(createdAt != null ? createdAt.toInstant() : null);
         r.setNotes(rs.getString("notes"));
+        r.setIdempotencyKey(rs.getString("idempotency_key"));
         return r;
     };
 
@@ -43,8 +44,8 @@ public class ReservationRepository {
     public Reservation insert(Reservation reservation) {
         List<Reservation> results = jdbcTemplate.query(
                 """
-                INSERT INTO reservation (shelter_id, tenant_id, population_type, user_id, status, expires_at, notes)
-                VALUES (?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO reservation (shelter_id, tenant_id, population_type, user_id, status, expires_at, notes, idempotency_key)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
                 RETURNING *
                 """,
                 ROW_MAPPER,
@@ -54,9 +55,19 @@ public class ReservationRepository {
                 reservation.getUserId(),
                 reservation.getStatus().name(),
                 Timestamp.from(reservation.getExpiresAt()),
-                reservation.getNotes()
+                reservation.getNotes(),
+                reservation.getIdempotencyKey()
         );
         return results.isEmpty() ? reservation : results.get(0);
+    }
+
+    public Optional<Reservation> findActiveByUserIdAndIdempotencyKey(UUID userId, String idempotencyKey) {
+        List<Reservation> results = jdbcTemplate.query(
+                "SELECT * FROM reservation WHERE user_id = ? AND idempotency_key = ? AND status = 'HELD'",
+                ROW_MAPPER,
+                userId, idempotencyKey
+        );
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
     public Optional<Reservation> findByIdAndTenantId(UUID id, UUID tenantId) {

--- a/backend/src/main/java/org/fabt/reservation/service/ReservationService.java
+++ b/backend/src/main/java/org/fabt/reservation/service/ReservationService.java
@@ -6,6 +6,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.UUID;
 
 import tools.jackson.databind.JsonNode;
@@ -63,7 +64,24 @@ public class ReservationService implements HeldReservationCleaner {
 
     @Transactional
     public Reservation createReservation(UUID shelterId, String populationType, String notes, UUID userId) {
+        return createReservation(shelterId, populationType, notes, userId, null);
+    }
+
+    @Transactional
+    public Reservation createReservation(UUID shelterId, String populationType, String notes, UUID userId, String idempotencyKey) {
         UUID tenantId = TenantContext.getTenantId();
+
+        // Idempotency check: if key provided, return existing active hold instead of creating duplicate
+        if (idempotencyKey != null && !idempotencyKey.isBlank()) {
+            Optional<Reservation> existing = reservationRepository.findActiveByUserIdAndIdempotencyKey(userId, idempotencyKey);
+            if (existing.isPresent()) {
+                log.info("Idempotent hold replay: returning existing reservation {} for key {}",
+                        existing.get().getId(), idempotencyKey);
+                Reservation existingRes = existing.get();
+                existingRes.setIdempotentMatch(true);
+                return existingRes;
+            }
+        }
 
         // Acquire advisory lock to prevent concurrent double-hold (TC-3.2).
         // Only one transaction can hold this lock per shelter+populationType at a time.
@@ -91,6 +109,7 @@ public class ReservationService implements HeldReservationCleaner {
 
         // Create reservation
         Reservation reservation = new Reservation(shelterId, tenantId, populationType, userId, expiresAt, notes);
+        reservation.setIdempotencyKey(idempotencyKey);
         Reservation saved = reservationRepository.insert(reservation);
 
         // Re-read latest snapshot to get the most current state (concurrent hold protection).

--- a/backend/src/main/resources/db/migration/V30__add_reservation_idempotency_key.sql
+++ b/backend/src/main/resources/db/migration/V30__add_reservation_idempotency_key.sql
@@ -1,0 +1,3 @@
+-- Add idempotency key to reservation table for offline queue deduplication.
+-- Nullable: requests without a key behave as before.
+ALTER TABLE reservation ADD COLUMN idempotency_key VARCHAR(36);

--- a/backend/src/test/java/org/fabt/reservation/ReservationIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/reservation/ReservationIntegrationTest.java
@@ -334,6 +334,67 @@ class ReservationIntegrationTest extends BaseIntegrationTest {
     }
 
     // -------------------------------------------------------------------------
+    // 9.11: Idempotency key — first creates, second returns existing
+    // -------------------------------------------------------------------------
+
+    @Test
+    void test_holdWithIdempotencyKey_createOnFirst_returnExistingOnSecond() {
+        HttpHeaders headers = authHelper.outreachWorkerHeaders();
+        String idempotencyKey = UUID.randomUUID().toString();
+        headers.set("X-Idempotency-Key", idempotencyKey);
+
+        // First request — creates a new hold
+        ResponseEntity<Map<String, Object>> first = createReservation(shelterId, headers, "SINGLE_ADULT");
+        assertThat(first.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String firstId = (String) first.getBody().get("id");
+
+        // Second request with same key — should return existing hold, not create new
+        ResponseEntity<Map<String, Object>> second = createReservation(shelterId, headers, "SINGLE_ADULT");
+        assertThat(second.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String secondId = (String) second.getBody().get("id");
+
+        assertThat(secondId).isEqualTo(firstId);
+    }
+
+    // -------------------------------------------------------------------------
+    // 9.12: Without idempotency key — creates normally (no regression)
+    // -------------------------------------------------------------------------
+
+    @Test
+    void test_holdWithoutIdempotencyKey_createsNormally() {
+        HttpHeaders headers = authHelper.outreachWorkerHeaders();
+
+        ResponseEntity<Map<String, Object>> response = createReservation(shelterId, headers, "SINGLE_ADULT");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody().get("status")).isEqualTo("HELD");
+    }
+
+    // -------------------------------------------------------------------------
+    // 9.13: Same idempotency key, different user — creates separately
+    // -------------------------------------------------------------------------
+
+    @Test
+    void test_holdWithIdempotencyKey_differentUser_createsSeparately() {
+        String idempotencyKey = UUID.randomUUID().toString();
+
+        // First user creates hold
+        HttpHeaders outreachHeaders = authHelper.outreachWorkerHeaders();
+        outreachHeaders.set("X-Idempotency-Key", idempotencyKey);
+        ResponseEntity<Map<String, Object>> first = createReservation(shelterId, outreachHeaders, "SINGLE_ADULT");
+        assertThat(first.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String firstId = (String) first.getBody().get("id");
+
+        // Different user (cocAdmin) creates hold with same key — should be a new hold
+        HttpHeaders adminHeaders = authHelper.cocAdminHeaders();
+        adminHeaders.set("X-Idempotency-Key", idempotencyKey);
+        ResponseEntity<Map<String, Object>> second = createReservation(shelterId, adminHeaders, "SINGLE_ADULT");
+        assertThat(second.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        String secondId = (String) second.getBody().get("id");
+
+        assertThat(secondId).isNotEqualTo(firstId);
+    }
+
+    // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
 

--- a/docs/FOR-COORDINATORS.md
+++ b/docs/FOR-COORDINATORS.md
@@ -62,7 +62,7 @@ Structural details like your shelter's name, address, and DV status are managed 
 
 ## What If My Shelter Does Not Have WiFi?
 
-The platform is built as a Progressive Web App (PWA). If you lose your internet connection while updating, the app saves your work locally and sends it when you reconnect. You can also update from a phone using mobile data if your desktop is offline.
+The platform is built as a Progressive Web App (PWA). When you lose connectivity, bed holds and availability updates are queued locally. When you reconnect, the app sends them automatically. If a bed was taken while you were offline, you'll see a notification. Check the queue indicator in the header to see pending actions. You can also update from a phone using mobile data if your desktop is offline.
 
 If your shelter has no internet at all, talk to your CoC administrator. The system can still list your shelter with a phone number so outreach workers know to call you directly.
 
@@ -108,7 +108,7 @@ For broader issues, the project maintains community support through GitHub. See 
 | What does it cost me? | Nothing. Hosting is covered by your CoC or agency. |
 | How many taps to update beds? | Three. |
 | How long does a bed hold last? | 90 minutes by default (configurable by your CoC admin). |
-| What if I lose internet mid-update? | The app saves locally and syncs when you reconnect. |
+| What if I lose internet mid-update? | Updates are queued locally and sent when you reconnect. Check the queue indicator in the header. |
 | Who sets up my shelter? | Your CoC administrator. |
 | Can I just share bed counts, no reservations? | Yes. |
 

--- a/e2e/gatling/src/gatling/java/fabt/OfflineReplaySimulation.java
+++ b/e2e/gatling/src/gatling/java/fabt/OfflineReplaySimulation.java
@@ -1,0 +1,282 @@
+package fabt;
+
+import io.gatling.javaapi.core.ScenarioBuilder;
+
+import java.time.Duration;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Supplier;
+import java.util.stream.Stream;
+
+import static io.gatling.javaapi.core.CoreDsl.*;
+import static io.gatling.javaapi.http.HttpDsl.http;
+import static io.gatling.javaapi.http.HttpDsl.status;
+
+/**
+ * OfflineReplaySimulation — exercises the offline queue replay path.
+ *
+ * Simulates what happens when a shelter's WiFi comes back and multiple
+ * coordinators/outreach workers reconnect simultaneously, replaying
+ * their queued actions.
+ *
+ * Scenario A: 5 users replay holds for the SAME shelter simultaneously.
+ *   Tests advisory lock contention (pg_advisory_xact_lock serialization).
+ *   SLO: p95 < 2000ms, 0% duplicates.
+ *
+ * Scenario B: Same user replays same idempotency key 5 times rapidly.
+ *   Tests dedup short-circuit (must skip advisory lock entirely).
+ *   SLO: p95 < 100ms (after the first create).
+ *
+ * Scenario C: 5 users replay mixed actions (holds + availability updates).
+ *   Tests connection pool pressure with mixed lock/no-lock operations.
+ *   SLO: p95 < 1000ms, < 1% errors.
+ */
+public class OfflineReplaySimulation extends FabtSimulation {
+
+    // Use a real shelter with availability
+    private static final String TARGET_SHELTER = "d0000000-0000-0000-0000-000000000002"; // Capital Boulevard Family Center
+    private static final String MIXED_SHELTER = "d0000000-0000-0000-0000-000000000004"; // Oak City Community Shelter
+
+    // Track idempotency keys for verification
+    private static final AtomicInteger holdCount = new AtomicInteger(0);
+
+    // -------------------------------------------------------------------------
+    // Scenario A: Concurrent hold replay — same shelter, different users
+    // Simulates: 5 outreach workers reconnect after WiFi outage, all held beds
+    // at the same shelter while offline, all replay simultaneously.
+    // -------------------------------------------------------------------------
+
+    Iterator<Map<String, Object>> concurrentHoldFeeder = Stream.generate(
+            (Supplier<Map<String, Object>>) () -> {
+                String key = UUID.randomUUID().toString();
+                return Map.of(
+                        "idempotencyKey", key,
+                        "body", String.format(
+                                "{\"shelterId\":\"%s\",\"populationType\":\"SINGLE_ADULT\"}",
+                                TARGET_SHELTER)
+                );
+            }
+    ).iterator();
+
+    ScenarioBuilder scenarioA = scenario("A: Concurrent Hold Replay (same shelter)")
+            .feed(concurrentHoldFeeder)
+            .exec(
+                    http("POST reservation (concurrent replay)")
+                            .post("/api/v1/reservations")
+                            .header("Authorization", "Bearer " + OUTREACH_TOKEN)
+                            .header("X-Idempotency-Key", "#{idempotencyKey}")
+                            .body(StringBody("#{body}"))
+                            .check(status().in(201, 409)) // 201 = created, 409 = no beds left (expected under contention)
+            );
+
+    // -------------------------------------------------------------------------
+    // Scenario B: Idempotent replay — same key, rapid fire
+    // Simulates: app-level queue replays a hold, but user triggers online event
+    // again before the first replay completes (belt-and-suspenders dedup).
+    // The backend should return the existing reservation without acquiring
+    // the advisory lock.
+    // -------------------------------------------------------------------------
+
+    private static final String IDEMPOTENT_KEY = UUID.randomUUID().toString();
+
+    ScenarioBuilder scenarioB = scenario("B: Idempotent Replay (same key)")
+            .exec(
+                    // First call creates the reservation
+                    http("POST reservation (first - creates)")
+                            .post("/api/v1/reservations")
+                            .header("Authorization", "Bearer " + OUTREACH_TOKEN)
+                            .header("X-Idempotency-Key", IDEMPOTENT_KEY)
+                            .body(StringBody(String.format(
+                                    "{\"shelterId\":\"%s\",\"populationType\":\"YOUTH_18_24\"}",
+                                    TARGET_SHELTER)))
+                            .check(status().in(201, 409))
+            )
+            .pause(Duration.ofMillis(50))
+            .repeat(4).on(
+                    exec(
+                            // Subsequent calls should short-circuit via idempotency check
+                            http("POST reservation (idempotent replay)")
+                                    .post("/api/v1/reservations")
+                                    .header("Authorization", "Bearer " + OUTREACH_TOKEN)
+                                    .header("X-Idempotency-Key", IDEMPOTENT_KEY)
+                                    .body(StringBody(String.format(
+                                            "{\"shelterId\":\"%s\",\"populationType\":\"YOUTH_18_24\"}",
+                                            TARGET_SHELTER)))
+                                    .check(status().in(200, 409)) // 200 = idempotent match, 409 = beds gone
+                    ).pause(Duration.ofMillis(20))
+            );
+
+    // -------------------------------------------------------------------------
+    // Scenario C: Mixed replay storm — holds + availability interleaved
+    // Simulates: coordinators and outreach workers reconnect simultaneously,
+    // replaying a mix of bed holds (advisory lock) and availability updates
+    // (no advisory lock). Tests connection pool under mixed workload.
+    // -------------------------------------------------------------------------
+
+    Iterator<Map<String, Object>> mixedFeeder = Stream.generate(
+            (Supplier<Map<String, Object>>) () -> {
+                String key = UUID.randomUUID().toString();
+                int occupied = 5 + (int) (Math.random() * 40);
+                return Map.of(
+                        "idempotencyKey", key,
+                        "occupied", String.valueOf(occupied)
+                );
+            }
+    ).iterator();
+
+    ScenarioBuilder scenarioC = scenario("C: Mixed Replay Storm")
+            .feed(mixedFeeder)
+            // Action 1: Hold a bed (advisory lock path)
+            .exec(
+                    http("POST reservation (mixed - hold)")
+                            .post("/api/v1/reservations")
+                            .header("Authorization", "Bearer " + OUTREACH_TOKEN)
+                            .header("X-Idempotency-Key", "#{idempotencyKey}")
+                            .body(StringBody(String.format(
+                                    "{\"shelterId\":\"%s\",\"populationType\":\"SINGLE_ADULT\"}",
+                                    MIXED_SHELTER)))
+                            .check(status().in(201, 409))
+            )
+            .pause(Duration.ofMillis(100))
+            // Action 2: Availability update (no advisory lock)
+            .exec(
+                    http("PATCH availability (mixed - update)")
+                            .patch(String.format("/api/v1/shelters/%s/availability", MIXED_SHELTER))
+                            .header("Authorization", "Bearer " + COCADMIN_TOKEN)
+                            .body(StringBody("{\"populationType\":\"SINGLE_ADULT\",\"bedsTotal\":50,\"bedsOccupied\":#{occupied},\"bedsOnHold\":0,\"acceptingNewGuests\":true}"))
+                            .check(status().is(200))
+            )
+            .pause(Duration.ofMillis(100))
+            // Action 3: Another hold (different population type)
+            .exec(
+                    http("POST reservation (mixed - hold 2)")
+                            .post("/api/v1/reservations")
+                            .header("Authorization", "Bearer " + OUTREACH_TOKEN)
+                            .header("X-Idempotency-Key", UUID.randomUUID().toString())
+                            .body(StringBody(String.format(
+                                    "{\"shelterId\":\"%s\",\"populationType\":\"FAMILY_WITH_CHILDREN\"}",
+                                    MIXED_SHELTER)))
+                            .check(status().in(201, 409))
+            );
+
+    // -------------------------------------------------------------------------
+    // Scenario D: Shelter WiFi outage — 10 users, same shelter
+    // Realistic large-shelter scenario (e.g., Capital Boulevard, 50 beds,
+    // 8-10 staff). All reconnect within ~100ms.
+    // -------------------------------------------------------------------------
+
+    Iterator<Map<String, Object>> shelterOutageFeeder = Stream.generate(
+            (Supplier<Map<String, Object>>) () -> Map.of(
+                    "idempotencyKey", UUID.randomUUID().toString(),
+                    "body", String.format(
+                            "{\"shelterId\":\"%s\",\"populationType\":\"SINGLE_ADULT\"}",
+                            TARGET_SHELTER)
+            )
+    ).iterator();
+
+    ScenarioBuilder scenarioD = scenario("D: Shelter WiFi Outage (10 users)")
+            .feed(shelterOutageFeeder)
+            .exec(
+                    http("POST reservation (shelter outage)")
+                            .post("/api/v1/reservations")
+                            .header("Authorization", "Bearer " + OUTREACH_TOKEN)
+                            .header("X-Idempotency-Key", "#{idempotencyKey}")
+                            .body(StringBody("#{body}"))
+                            .check(status().in(201, 409))
+            );
+
+    // -------------------------------------------------------------------------
+    // Scenario E: Citywide ISP outage — 20 users across 4 shelters
+    // Tests connection pool pressure with distributed advisory lock contention.
+    // 20 users = 100% of HikariCP pool (default 20).
+    // -------------------------------------------------------------------------
+
+    private static final String[] CITY_SHELTERS = {
+            "d0000000-0000-0000-0000-000000000001",
+            "d0000000-0000-0000-0000-000000000002",
+            "d0000000-0000-0000-0000-000000000004",
+            "d0000000-0000-0000-0000-000000000006",
+    };
+
+    Iterator<Map<String, Object>> cityOutageFeeder = Stream.generate(
+            (Supplier<Map<String, Object>>) () -> {
+                String shelter = CITY_SHELTERS[(int) (Math.random() * CITY_SHELTERS.length)];
+                return Map.of(
+                        "idempotencyKey", UUID.randomUUID().toString(),
+                        "shelterId", shelter,
+                        "body", String.format(
+                                "{\"shelterId\":\"%s\",\"populationType\":\"SINGLE_ADULT\"}",
+                                shelter)
+                );
+            }
+    ).iterator();
+
+    ScenarioBuilder scenarioE = scenario("E: Citywide ISP Outage (20 users, 4 shelters)")
+            .feed(cityOutageFeeder)
+            .exec(
+                    http("POST reservation (citywide outage)")
+                            .post("/api/v1/reservations")
+                            .header("Authorization", "Bearer " + OUTREACH_TOKEN)
+                            .header("X-Idempotency-Key", "#{idempotencyKey}")
+                            .body(StringBody("#{body}"))
+                            .check(status().in(201, 409))
+            );
+
+    // -------------------------------------------------------------------------
+    // Setup: run scenarios sequentially to isolate metrics.
+    // -------------------------------------------------------------------------
+
+    {
+        setUp(
+                // A: 5 concurrent users, all at once
+                scenarioA.injectOpen(atOnceUsers(5)),
+
+                // B: 1 user doing idempotent replays (after A)
+                scenarioB.injectOpen(
+                        nothingFor(Duration.ofSeconds(10)),
+                        atOnceUsers(1)
+                ),
+
+                // C: 5 users with mixed workloads (after B)
+                scenarioC.injectOpen(
+                        nothingFor(Duration.ofSeconds(20)),
+                        atOnceUsers(5)
+                ),
+
+                // D: 10 users, same shelter (shelter WiFi outage)
+                scenarioD.injectOpen(
+                        nothingFor(Duration.ofSeconds(30)),
+                        atOnceUsers(10)
+                ),
+
+                // E: 20 users, 4 shelters (citywide ISP outage — pool pressure test)
+                scenarioE.injectOpen(
+                        nothingFor(Duration.ofSeconds(40)),
+                        atOnceUsers(20)
+                )
+        ).protocols(httpProtocol)
+                .assertions(
+                        // A: 5-user advisory lock contention
+                        details("POST reservation (concurrent replay)")
+                                .responseTime().percentile(95.0).lt(2000),
+
+                        // B: idempotent replay short-circuit
+                        details("POST reservation (idempotent replay)")
+                                .responseTime().percentile(95.0).lt(100),
+
+                        // C: mixed workload — no unexpected errors
+                        details("PATCH availability (mixed - update)")
+                                .failedRequests().percent().lt(1.0),
+
+                        // D: 10-user shelter outage — advisory lock under real load
+                        details("POST reservation (shelter outage)")
+                                .responseTime().percentile(95.0).lt(3000),
+
+                        // E: 20-user citywide outage — connection pool must not exhaust
+                        details("POST reservation (citywide outage)")
+                                .responseTime().percentile(95.0).lt(5000)
+                );
+    }
+}

--- a/e2e/playwright/tests/offline-behavior.spec.ts
+++ b/e2e/playwright/tests/offline-behavior.spec.ts
@@ -1,104 +1,613 @@
 import { test, expect } from '../fixtures/auth.fixture';
+import type { Page } from '@playwright/test';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the offline queue from IndexedDB using the app's own module.
+ * Falls back to direct IDB access if the export isn't available.
+ */
+async function getQueuedActions(page: Page) {
+  return page.evaluate(async () => {
+    return new Promise<unknown[]>((resolve, reject) => {
+      const request = indexedDB.open('fabt-offline-queue', 2);
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const db = request.result;
+        if (!db.objectStoreNames.contains('actions')) { resolve([]); return; }
+        const tx = db.transaction('actions', 'readonly');
+        const store = tx.objectStore('actions');
+        const getAll = store.getAll();
+        getAll.onsuccess = () => resolve(getAll.result);
+        getAll.onerror = () => reject(getAll.error);
+      };
+      request.onupgradeneeded = () => {
+        request.result.close();
+        resolve([]);
+      };
+    });
+  });
+}
+
+/**
+ * Go offline: block network + dispatch offline DOM event.
+ * Playwright's setOffline() does NOT fire DOM events or change navigator.onLine.
+ */
+async function goOffline(page: Page) {
+  await page.context().setOffline(true);
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'onLine', { value: false, writable: true, configurable: true });
+    window.dispatchEvent(new Event('offline'));
+  });
+  await page.waitForTimeout(300);
+}
+
+/**
+ * Go online: restore network + dispatch online DOM event.
+ * Waits for jitter + replay (up to 4 seconds).
+ */
+async function goOnline(page: Page, waitMs = 4000) {
+  await page.context().setOffline(false);
+  await page.evaluate(() => {
+    Object.defineProperty(navigator, 'onLine', { value: true, writable: true, configurable: true });
+    window.dispatchEvent(new Event('online'));
+  });
+  await page.waitForTimeout(waitMs);
+}
+
+/**
+ * Enqueue a synthetic action directly into IndexedDB.
+ */
+async function enqueueSynthetic(page: Page, action: {
+  id: string; idempotencyKey: string; type: string; url: string; method: string; body: string; timestamp: number;
+}) {
+  await page.evaluate(async (a) => {
+    const request = indexedDB.open('fabt-offline-queue', 2);
+    await new Promise<void>((resolve, reject) => {
+      request.onerror = () => reject(request.error);
+      request.onsuccess = () => {
+        const db = request.result;
+        const tx = db.transaction('actions', 'readwrite');
+        tx.objectStore('actions').add(a);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      };
+      request.onupgradeneeded = (event) => {
+        const db = (event.target as IDBOpenDBRequest).result;
+        const store = db.createObjectStore('actions', { keyPath: 'id' });
+        store.createIndex('by-timestamp', 'timestamp');
+      };
+    });
+  }, action);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 test.describe('Offline Behavior', () => {
   test('offline banner appears on connectivity loss', async ({ outreachPage }) => {
     await outreachPage.goto('/outreach');
     await outreachPage.waitForSelector('main', { timeout: 10000 });
 
-    // Go offline
-    await outreachPage.context().setOffline(true);
-    await outreachPage.waitForTimeout(1000);
+    await goOffline(outreachPage);
 
-    // Offline banner should appear
     const banner = outreachPage.locator('text=/offline/i');
     await expect(banner).toBeVisible({ timeout: 5000 });
 
-    // Restore
-    await outreachPage.context().setOffline(false);
+    await goOnline(outreachPage);
   });
 
   test('search results remain visible while offline (stale cache)', async ({ outreachPage }) => {
     await outreachPage.goto('/outreach');
-    // Wait for results to load
     await outreachPage.waitForSelector('main div[style*="border"]', { timeout: 10000 });
 
-    // Go offline
-    await outreachPage.context().setOffline(true);
-    await outreachPage.waitForTimeout(1000);
+    await goOffline(outreachPage);
 
-    // Results should still be visible (served from cache)
     const mainContent = outreachPage.locator('main');
     await expect(mainContent).not.toBeEmpty();
-    // Should not show a blank error page
     await expect(outreachPage.locator('main')).not.toContainText(/500|internal server error/i);
 
-    // Restore
-    await outreachPage.context().setOffline(false);
+    await goOnline(outreachPage);
   });
 
-  // NOTE: The previous "queued availability update replays on reconnect" test was
-  // removed because it only asserted the page didn't crash — it made zero assertions
-  // about actual queue/replay behavior. Real offline queue tests will be added in
-  // the offline-honesty change when the queue is properly wired to holds/availability.
-  // See: openspec/changes/offline-honesty/
+  // -------------------------------------------------------------------------
+  // Availability update queued and replayed
+  // -------------------------------------------------------------------------
+  test('queued availability update replays on reconnect', async ({ coordinatorPage }) => {
+    await coordinatorPage.goto('/coordinator');
+    await coordinatorPage.waitForSelector('[data-testid^="shelter-card-"]', { timeout: 10000 });
 
-  /**
-   * Hospital PWA test — service worker blocked by IT policy.
-   *
-   * Dr. James Whitfield's use case: hospital-managed Windows laptop with
-   * locked-down Chrome. Service worker registration may be blocked.
-   * The app must function for search and hold without the service worker.
-   *
-   * We simulate this by unregistering all service workers and blocking
-   * future registration, then verify the core flow still works.
-   */
-  test('app functions when service worker is blocked (hospital use case)', async ({ outreachPage }) => {
-    // Unregister any existing service workers
-    await outreachPage.evaluate(async () => {
-      if ('serviceWorker' in navigator) {
-        const registrations = await navigator.serviceWorker.getRegistrations();
-        for (const reg of registrations) {
-          await reg.unregister();
-        }
-        // Block future registrations by overriding
-        (navigator.serviceWorker as any).register = () => Promise.reject(new Error('SW blocked by IT policy'));
+    // Click a shelter that HAS availability data (avail badge visible)
+    const shelterWithAvail = coordinatorPage.locator('[data-testid^="shelter-card-"]', {
+      has: coordinatorPage.locator('[data-testid^="avail-badge-"]'),
+    }).first();
+    await shelterWithAvail.click();
+    await coordinatorPage.waitForTimeout(2000);
+
+    const saveBtn = coordinatorPage.locator('[data-testid^="save-avail-"]').first();
+    await expect(saveBtn).toBeVisible({ timeout: 5000 });
+
+    await goOffline(coordinatorPage);
+
+    await saveBtn.click();
+    await coordinatorPage.waitForTimeout(1000);
+
+    const actions = await getQueuedActions(coordinatorPage);
+    expect(actions.length).toBeGreaterThanOrEqual(1);
+    const queuedAction = actions[0] as { type: string; idempotencyKey: string };
+    expect(queuedAction.type).toBe('UPDATE_AVAILABILITY');
+    expect(queuedAction.idempotencyKey).toBeTruthy();
+
+    await goOnline(coordinatorPage, 5000);
+
+    const actionsAfter = await getQueuedActions(coordinatorPage);
+    expect(actionsAfter.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Hold queued and replayed
+  // -------------------------------------------------------------------------
+  test('hold queued offline and replayed on reconnect', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('[data-testid^="hold-bed-"]', { timeout: 15000 });
+
+    await goOffline(outreachPage);
+
+    const holdBtn = outreachPage.locator('[data-testid^="hold-bed-"]').first();
+    await holdBtn.click();
+    await outreachPage.waitForTimeout(1000);
+
+    const queuedText = outreachPage.locator('text=/Hold queued/i');
+    await expect(queuedText).toBeVisible({ timeout: 5000 });
+
+    const actions = await getQueuedActions(outreachPage);
+    expect(actions.length).toBeGreaterThanOrEqual(1);
+    const holdAction = (actions as { type: string }[]).find(a => a.type === 'HOLD_BED');
+    expect(holdAction).toBeTruthy();
+
+    await goOnline(outreachPage, 5000);
+
+    const actionsAfter = await getQueuedActions(outreachPage);
+    const remainingHolds = (actionsAfter as { type: string }[]).filter(a => a.type === 'HOLD_BED');
+    expect(remainingHolds.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Hold expiry
+  // -------------------------------------------------------------------------
+  test('expired hold is skipped on replay with notification', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('main', { timeout: 10000 });
+
+    await enqueueSynthetic(outreachPage, {
+      id: 'test-expired-hold',
+      idempotencyKey: 'test-key-expired',
+      type: 'HOLD_BED',
+      url: '/api/v1/reservations',
+      method: 'POST',
+      body: JSON.stringify({ shelterId: '00000000-0000-0000-0000-000000000001', populationType: 'SINGLE_ADULT' }),
+      timestamp: Date.now() - (120 * 60 * 1000), // 2 hours ago
+    });
+
+    const actionsBefore = await getQueuedActions(outreachPage);
+    expect(actionsBefore.length).toBeGreaterThanOrEqual(1);
+
+    // Trigger replay via explicit online event (no need for setOffline cycle)
+    await outreachPage.evaluate(() => window.dispatchEvent(new Event('online')));
+    await outreachPage.waitForTimeout(4000);
+
+    const actionsAfter = await getQueuedActions(outreachPage);
+    const expiredHold = (actionsAfter as { id: string }[]).find(a => a.id === 'test-expired-hold');
+    expect(expiredHold).toBeUndefined();
+
+    const notification = outreachPage.locator('text=/expired/i');
+    await expect(notification).toBeVisible({ timeout: 5000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Conflict (409) on replay
+  // -------------------------------------------------------------------------
+  test('conflict (409) shows actionable notification on replay', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('main', { timeout: 10000 });
+
+    await outreachPage.route('**/api/v1/reservations', (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 409,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 409, error: 'Conflict', message: 'No beds available' }),
+        });
+      } else {
+        route.continue();
       }
     });
 
-    // Navigate to search — should load normally without SW
-    await outreachPage.goto('/outreach');
-    await outreachPage.waitForTimeout(3000);
+    await enqueueSynthetic(outreachPage, {
+      id: 'test-conflict-hold',
+      idempotencyKey: 'test-key-conflict',
+      type: 'HOLD_BED',
+      url: '/api/v1/reservations',
+      method: 'POST',
+      body: JSON.stringify({ shelterId: '00000000-0000-0000-0000-000000000001', populationType: 'SINGLE_ADULT' }),
+      timestamp: Date.now() - (5 * 60 * 1000),
+    });
 
-    // Search results should load (API calls work without SW)
-    // Shelter results are rendered as buttons with shelter names
-    const shelterCount = outreachPage.locator('text=/shelters? found/i');
+    await outreachPage.evaluate(() => window.dispatchEvent(new Event('online')));
+    await outreachPage.waitForTimeout(4000);
+
+    const actionsAfter = await getQueuedActions(outreachPage);
+    const conflictHold = (actionsAfter as { id: string }[]).find(a => a.id === 'test-conflict-hold');
+    expect(conflictHold).toBeUndefined();
+
+    const notification = outreachPage.locator('text=/taken while offline/i');
+    await expect(notification).toBeVisible({ timeout: 5000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Queue status indicator
+  // -------------------------------------------------------------------------
+  test('queue status badge appears when actions pending and disappears after replay', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('[data-testid^="hold-bed-"]', { timeout: 15000 });
+
+    const badge = outreachPage.locator('[data-testid="queue-status-badge"]');
+    await expect(badge).not.toBeVisible({ timeout: 3000 });
+
+    await goOffline(outreachPage);
+
+    const holdBtn = outreachPage.locator('[data-testid^="hold-bed-"]').first();
+    await holdBtn.click();
+    await outreachPage.waitForTimeout(2500);
+
+    await expect(badge).toBeVisible({ timeout: 5000 });
+    const count = outreachPage.locator('[data-testid="queue-count"]');
+    await expect(count).toHaveText('1');
+
+    await goOnline(outreachPage, 6000);
+
+    await expect(badge).not.toBeVisible({ timeout: 10000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // NEGATIVE: Double online event — no duplicate replay
+  // -------------------------------------------------------------------------
+  test('double online event does not cause duplicate API calls', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('main', { timeout: 10000 });
+
+    // Track API calls and return success for synthetic action
+    const apiCalls: string[] = [];
+    await outreachPage.route('**/api/v1/reservations', (route) => {
+      if (route.request().method() === 'POST') {
+        apiCalls.push('POST');
+        route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'fake-id', status: 'HELD', remainingSeconds: 5400 }) });
+      } else {
+        route.continue();
+      }
+    });
+
+    await enqueueSynthetic(outreachPage, {
+      id: 'test-double-event',
+      idempotencyKey: 'test-key-double',
+      type: 'HOLD_BED',
+      url: '/api/v1/reservations',
+      method: 'POST',
+      body: JSON.stringify({ shelterId: '00000000-0000-0000-0000-000000000001', populationType: 'SINGLE_ADULT' }),
+      timestamp: Date.now() - (60 * 1000), // 1 minute ago
+    });
+
+    // Fire two online events rapidly
+    await outreachPage.evaluate(() => {
+      window.dispatchEvent(new Event('online'));
+      window.dispatchEvent(new Event('online'));
+    });
+    await outreachPage.waitForTimeout(5000);
+
+    // Should have at most 1 POST (concurrent guard prevents double replay)
+    expect(apiCalls.filter(c => c === 'POST').length).toBeLessThanOrEqual(1);
+
+    const actionsAfter = await getQueuedActions(outreachPage);
+    expect(actionsAfter.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // NEGATIVE: Try/catch fallback — online but network fails
+  // -------------------------------------------------------------------------
+  test('hold enqueued when online but network request fails', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('[data-testid^="hold-bed-"]', { timeout: 15000 });
+
+    // Intercept hold API to simulate network failure
+    await outreachPage.route('**/api/v1/reservations', (route) => {
+      if (route.request().method() === 'POST') {
+        route.abort('connectionfailed');
+      } else {
+        route.continue();
+      }
+    });
+
+    // Click hold while nominally online — should trigger try/catch fallback
+    const holdBtn = outreachPage.locator('[data-testid^="hold-bed-"]').first();
+    await holdBtn.click();
+    await outreachPage.waitForTimeout(2000);
+
+    // Verify action was enqueued (fallback worked), not an error displayed
+    const actions = await getQueuedActions(outreachPage);
+    const holdAction = (actions as { type: string }[]).find(a => a.type === 'HOLD_BED');
+    expect(holdAction).toBeTruthy();
+
+    // Should show queued state, not error
+    const queuedText = outreachPage.locator('text=/Hold queued|queued/i');
+    // The reservation panel should show the queued hold
+    const badge = outreachPage.locator('[data-testid="queue-status-badge"]');
+    await expect(badge).toBeVisible({ timeout: 5000 });
+
+    // Clean up: remove route intercept, replay
+    await outreachPage.unroute('**/api/v1/reservations');
+    await outreachPage.evaluate(() => window.dispatchEvent(new Event('online')));
+    await outreachPage.waitForTimeout(5000);
+
+    const actionsAfter = await getQueuedActions(outreachPage);
+    expect(actionsAfter.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Multi-action queue replay — order and multiple state transitions
+  // -------------------------------------------------------------------------
+  test('multiple queued actions replay in order', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('main', { timeout: 10000 });
+
+    // Track API call order and return success for synthetic actions
+    const apiCalls: { method: string; url: string }[] = [];
+    await outreachPage.route('**/api/v1/reservations', (route) => {
+      if (route.request().method() === 'POST') {
+        apiCalls.push({ method: 'POST', url: route.request().url() });
+        route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'fake-id', status: 'HELD', remainingSeconds: 5400 }) });
+      } else { route.continue(); }
+    });
+    await outreachPage.route('**/api/v1/shelters/*/availability', (route) => {
+      if (route.request().method() === 'PATCH') {
+        apiCalls.push({ method: 'PATCH', url: route.request().url() });
+        route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      } else { route.continue(); }
+    });
+
+    // Enqueue 3 actions with staggered timestamps to ensure order
+    const now = Date.now();
+    await enqueueSynthetic(outreachPage, {
+      id: 'multi-1-hold-a',
+      idempotencyKey: 'key-multi-1',
+      type: 'HOLD_BED',
+      url: '/api/v1/reservations',
+      method: 'POST',
+      body: JSON.stringify({ shelterId: '00000000-0000-0000-0000-000000000001', populationType: 'SINGLE_ADULT' }),
+      timestamp: now - 3000, // oldest
+    });
+    await enqueueSynthetic(outreachPage, {
+      id: 'multi-2-avail',
+      idempotencyKey: 'key-multi-2',
+      type: 'UPDATE_AVAILABILITY',
+      url: '/api/v1/shelters/00000000-0000-0000-0000-000000000001/availability',
+      method: 'PATCH',
+      body: JSON.stringify({ populationType: 'SINGLE_ADULT', bedsTotal: 10, bedsOccupied: 5, bedsOnHold: 0, acceptingNewGuests: true }),
+      timestamp: now - 2000, // middle
+    });
+    await enqueueSynthetic(outreachPage, {
+      id: 'multi-3-hold-b',
+      idempotencyKey: 'key-multi-3',
+      type: 'HOLD_BED',
+      url: '/api/v1/reservations',
+      method: 'POST',
+      body: JSON.stringify({ shelterId: '00000000-0000-0000-0000-000000000002', populationType: 'VETERAN' }),
+      timestamp: now - 1000, // newest
+    });
+
+    const actionsBefore = await getQueuedActions(outreachPage);
+    expect(actionsBefore.length).toBe(3);
+
+    // Trigger replay
+    await outreachPage.evaluate(() => window.dispatchEvent(new Event('online')));
+    await outreachPage.waitForTimeout(5000);
+
+    // Verify all 3 replayed — queue should be empty
+    const actionsAfter = await getQueuedActions(outreachPage);
+    expect(actionsAfter.length).toBe(0);
+
+    // Verify API calls arrived in timestamp order
+    expect(apiCalls.length).toBeGreaterThanOrEqual(3);
+    const replayCalls = apiCalls.slice(-3);
+    expect(replayCalls[0].method).toBe('POST'); // hold A (oldest)
+    expect(replayCalls[1].method).toBe('PATCH'); // availability (middle)
+    expect(replayCalls[2].method).toBe('POST'); // hold B (newest)
+  });
+
+  // -------------------------------------------------------------------------
+  // Try/catch fallback for coordinator availability updates
+  // -------------------------------------------------------------------------
+  test('availability update enqueued when online but network fails (coordinator)', async ({ coordinatorPage }) => {
+    await coordinatorPage.goto('/coordinator');
+    await coordinatorPage.waitForSelector('[data-testid^="shelter-card-"]', { timeout: 10000 });
+
+    // Click a shelter that HAS availability data
+    const shelterWithAvail = coordinatorPage.locator('[data-testid^="shelter-card-"]', {
+      has: coordinatorPage.locator('[data-testid^="avail-badge-"]'),
+    }).first();
+    await shelterWithAvail.click();
+    await coordinatorPage.waitForTimeout(2000);
+
+    const saveBtn = coordinatorPage.locator('[data-testid^="save-avail-"]').first();
+    await expect(saveBtn).toBeVisible({ timeout: 5000 });
+
+    // Intercept PATCH to simulate network failure while nominally online
+    await coordinatorPage.route('**/api/v1/shelters/*/availability', (route) => {
+      if (route.request().method() === 'PATCH') {
+        route.abort('connectionfailed');
+      } else {
+        route.continue();
+      }
+    });
+
+    // Submit availability update — should trigger try/catch fallback
+    await saveBtn.click();
+    await coordinatorPage.waitForTimeout(2000);
+
+    // Verify action was enqueued (not just an error)
+    const actions = await getQueuedActions(coordinatorPage);
+    const availAction = (actions as { type: string }[]).find(a => a.type === 'UPDATE_AVAILABILITY');
+    expect(availAction).toBeTruthy();
+
+    // Should show queued message, not generic error
+    const queuedMsg = coordinatorPage.locator('text=/queued/i');
+    await expect(queuedMsg).toBeVisible({ timeout: 3000 });
+
+    // Clean up: remove intercept, replay
+    await coordinatorPage.unroute('**/api/v1/shelters/*/availability');
+    await goOnline(coordinatorPage, 5000);
+
+    const actionsAfter = await getQueuedActions(coordinatorPage);
+    expect(actionsAfter.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // FAILED state rendering (non-409 replay error)
+  // -------------------------------------------------------------------------
+  test('FAILED state shown when replay gets non-409 error', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('main', { timeout: 10000 });
+
+    // Intercept hold API to return 500
+    await outreachPage.route('**/api/v1/reservations', (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({
+          status: 500,
+          contentType: 'application/json',
+          body: JSON.stringify({ status: 500, error: 'Internal Server Error', message: 'Database unavailable' }),
+        });
+      } else {
+        route.continue();
+      }
+    });
+
+    await enqueueSynthetic(outreachPage, {
+      id: 'test-failed-hold',
+      idempotencyKey: 'test-key-failed',
+      type: 'HOLD_BED',
+      url: '/api/v1/reservations',
+      method: 'POST',
+      body: JSON.stringify({ shelterId: '00000000-0000-0000-0000-000000000001', populationType: 'SINGLE_ADULT' }),
+      timestamp: Date.now() - (60 * 1000),
+    });
+
+    // Trigger replay
+    await outreachPage.evaluate(() => window.dispatchEvent(new Event('online')));
+    await outreachPage.waitForTimeout(4000);
+
+    // Action should REMAIN in queue (non-409 = retry later)
+    const actionsAfter = await getQueuedActions(outreachPage);
+    const failedHold = (actionsAfter as { id: string }[]).find(a => a.id === 'test-failed-hold');
+    expect(failedHold).toBeTruthy();
+
+    // Notification should mention failure
+    const notification = outreachPage.locator('text=/failed|retry/i');
+    await expect(notification).toBeVisible({ timeout: 5000 });
+  });
+
+  // -------------------------------------------------------------------------
+  // Replay success notification toast
+  // -------------------------------------------------------------------------
+  test('replay success notification shows action count', async ({ outreachPage }) => {
+    await outreachPage.goto('/outreach');
+    await outreachPage.waitForSelector('main', { timeout: 10000 });
+
+    // Intercept APIs to return success for synthetic actions
+    await outreachPage.route('**/api/v1/reservations', (route) => {
+      if (route.request().method() === 'POST') {
+        route.fulfill({ status: 201, contentType: 'application/json', body: JSON.stringify({ id: 'fake-id', status: 'HELD', remainingSeconds: 5400 }) });
+      } else { route.continue(); }
+    });
+    await outreachPage.route('**/api/v1/shelters/*/availability', (route) => {
+      if (route.request().method() === 'PATCH') {
+        route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+      } else { route.continue(); }
+    });
+
+    // Enqueue 2 actions
+    await enqueueSynthetic(outreachPage, {
+      id: 'toast-1',
+      idempotencyKey: 'key-toast-1',
+      type: 'HOLD_BED',
+      url: '/api/v1/reservations',
+      method: 'POST',
+      body: JSON.stringify({ shelterId: '00000000-0000-0000-0000-000000000001', populationType: 'SINGLE_ADULT' }),
+      timestamp: Date.now() - (60 * 1000),
+    });
+    await enqueueSynthetic(outreachPage, {
+      id: 'toast-2',
+      idempotencyKey: 'key-toast-2',
+      type: 'UPDATE_AVAILABILITY',
+      url: '/api/v1/shelters/00000000-0000-0000-0000-000000000001/availability',
+      method: 'PATCH',
+      body: JSON.stringify({ populationType: 'SINGLE_ADULT', bedsTotal: 10, bedsOccupied: 5, bedsOnHold: 0, acceptingNewGuests: true }),
+      timestamp: Date.now() - (30 * 1000),
+    });
+
+    // Trigger replay
+    await outreachPage.evaluate(() => window.dispatchEvent(new Event('online')));
+    await outreachPage.waitForTimeout(4000);
+
+    // Verify toast notification shows count
+    const toast = outreachPage.locator('text=/2 queued actions sent/i');
+    await expect(toast).toBeVisible({ timeout: 6000 });
+
+    // Queue should be empty
+    const actionsAfter = await getQueuedActions(outreachPage);
+    expect(actionsAfter.length).toBe(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // Hospital use case — service worker blocked (proper API)
+  // -------------------------------------------------------------------------
+  test('app functions when service worker is blocked (hospital use case)', async ({ browser }) => {
+    // Use Playwright's proper API to block service workers BEFORE page load
+    const context = await browser.newContext({ serviceWorkers: 'block' });
+    const page = await context.newPage();
+
+    // Login
+    await page.goto('/login');
+    await page.locator('[data-testid="login-tenant-slug"]').waitFor({ state: 'visible', timeout: 10000 });
+    await page.locator('[data-testid="login-tenant-slug"]').fill('dev-coc');
+    await page.locator('[data-testid="login-email"]').fill('outreach@dev.fabt.org');
+    await page.locator('[data-testid="login-password"]').fill('admin123');
+    await page.locator('[data-testid="login-submit"]').click();
+    await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 10000 });
+
+    // Navigate to search
+    await page.goto('/outreach');
+    await page.waitForTimeout(3000);
+
+    // Search results should load
+    const shelterCount = page.locator('text=/shelters? found/i');
     await expect(shelterCount).toBeVisible({ timeout: 5000 });
 
-    // Search filter should work
-    const searchInput = outreachPage.locator('input[type="search"]');
-    await expect(searchInput).toBeVisible();
-
-    // Population type filter should work
-    const popFilter = outreachPage.locator('select[aria-label="Filter by population type"]');
+    // Filters work
+    const popFilter = page.locator('select[aria-label="Filter by population type"]');
     await expect(popFilter).toBeVisible();
-    await popFilter.selectOption('VETERAN');
-    await outreachPage.waitForTimeout(1000);
 
     // Hold a bed should work
-    const holdBtn = outreachPage.locator('button', { hasText: /Hold This Bed/i }).first();
+    const holdBtn = page.locator('button', { hasText: /Hold This Bed/i }).first();
     if (await holdBtn.count() > 0) {
       await holdBtn.click();
-      await outreachPage.waitForTimeout(2000);
-
-      // Should see reservation or confirmation — not an error
-      const page = outreachPage;
-      const hasReservation = await page.locator('text=/held|holding|expires/i').count();
-      const hasError = await page.locator('text=/500|internal server error|failed/i').count();
+      await page.waitForTimeout(2000);
+      const hasError = await page.locator('text=/500|internal server error/i').count();
       expect(hasError).toBe(0);
-      // Hold may or may not succeed (depends on bed availability) but should not crash
     }
 
-    // Verify no SW-related errors crashed the page
-    await expect(outreachPage.locator('main')).not.toBeEmpty();
+    await expect(page.locator('main')).not.toBeEmpty();
+    await context.close();
   });
 });

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -31,11 +31,13 @@
         "eslint": "^9.39.4",
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.5.2",
+        "fake-indexeddb": "^6.2.5",
         "globals": "^17.4.0",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.57.0",
         "vite": "^7.3.1",
-        "vite-plugin-pwa": "^1.2.0"
+        "vite-plugin-pwa": "^1.2.0",
+        "vitest": "^4.1.2"
       }
     },
     "node_modules/@apideck/better-ajv-errors": {
@@ -3063,6 +3065,17 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
     "node_modules/@types/d3-array": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
@@ -3124,6 +3137,13 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
       "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/estree": {
@@ -3520,6 +3540,149 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.2.tgz",
+      "integrity": "sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.2.tgz",
+      "integrity": "sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "4.1.2",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.21"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@vitest/mocker/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.2.tgz",
+      "integrity": "sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.2.tgz",
+      "integrity": "sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "4.1.2",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.2.tgz",
+      "integrity": "sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "magic-string": "^0.30.21",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.2.tgz",
+      "integrity": "sha512-DU4fBnbVCJGNBwVA6xSToNXrkZNSiw59H8tcuUspVMsBDBST4nfvsPsEHDHGtWRRnqBERBQu7TrTKskmjqTXKA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.2.tgz",
+      "integrity": "sha512-xw2/TiX82lQHA06cgbqRKFb5lCAy3axQ4H4SoUFhUsg+wztiet+co86IAMDtF6Vm1hc7J6j09oh/rgDn+JdKIQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "4.1.2",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3620,6 +3783,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/async": {
@@ -3859,6 +4032,16 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -4374,6 +4557,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-module-lexer": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.0.0.tgz",
+      "integrity": "sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
@@ -4716,6 +4906,26 @@
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
       "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
       "license": "MIT"
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.2.5.tgz",
+      "integrity": "sha512-CGnyrvbhPlWYMngksqrSSUT1BAVP49dZocrHuK0SvtR0D5TMs5wP0o3j7jexDJW01KSadjBp1M/71o/KR3nD1w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -6160,6 +6370,17 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -6301,6 +6522,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -6974,6 +7202,13 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/signal-exit": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
@@ -7047,6 +7282,20 @@
       "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
       "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
       "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.0.0.tgz",
+      "integrity": "sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==",
       "dev": true,
       "license": "MIT"
     },
@@ -7269,6 +7518,23 @@
       "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==",
       "license": "MIT"
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.0.4.tgz",
+      "integrity": "sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -7284,6 +7550,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/tr46": {
@@ -7778,6 +8054,98 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/vitest": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.2.tgz",
+      "integrity": "sha512-xjR1dMTVHlFLh98JE3i/f/WePqJsah4A0FK9cc8Ehp9Udk0AZk6ccpIZhh1qJ/yxVWRZ+Q54ocnD8TXmkhspGg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "4.1.2",
+        "@vitest/mocker": "4.1.2",
+        "@vitest/pretty-format": "4.1.2",
+        "@vitest/runner": "4.1.2",
+        "@vitest/snapshot": "4.1.2",
+        "@vitest/spy": "4.1.2",
+        "@vitest/utils": "4.1.2",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.2",
+        "@vitest/browser-preview": "4.1.2",
+        "@vitest/browser-webdriverio": "4.1.2",
+        "@vitest/ui": "4.1.2",
+        "happy-dom": "*",
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        },
+        "vite": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/vitest/node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
     "node_modules/webidl-conversions": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-4.0.2.tgz",
@@ -7900,6 +8268,23 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/word-wrap": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,10 +36,12 @@
     "eslint": "^9.39.4",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.5.2",
+    "fake-indexeddb": "^6.2.5",
     "globals": "^17.4.0",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.57.0",
     "vite": "^7.3.1",
-    "vite-plugin-pwa": "^1.2.0"
+    "vite-plugin-pwa": "^1.2.0",
+    "vitest": "^4.1.2"
   }
 }

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -1,15 +1,17 @@
-import { type ReactNode, useState, useEffect, useRef } from 'react';
+import { type ReactNode, useState, useEffect, useRef, useCallback } from 'react';
 import { useNavigate, useLocation } from 'react-router-dom';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { useAuth } from '../auth/useAuth';
 import { getDefaultRouteForRoles } from '../auth/AuthGuard';
 import { LocaleSelector } from './LocaleSelector';
 import { NotificationBell } from './NotificationBell';
+import { QueueStatusIndicator } from './QueueStatusIndicator';
 import { ConnectionStatusBanner } from './ConnectionStatusBanner';
 import { OfflineBanner } from './OfflineBanner';
 import { SessionTimeoutWarning } from './SessionTimeoutWarning';
 import { ChangePasswordModal } from './ChangePasswordModal';
 import { useNotifications } from '../hooks/useNotifications';
+import { replayQueue, getQueueSize, isReplaying, type ReplayResult } from '../services/offlineQueue';
 import { text, weight } from '../theme/typography';
 import { color } from '../theme/colors';
 
@@ -74,6 +76,76 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
   const intl = useIntl();
   const [changePasswordOpen, setChangePasswordOpen] = useState(false);
   const { notifications, unreadCount, markRead, markAllRead, dismiss, connected } = useNotifications();
+  const [queueSize, setQueueSize] = useState(0);
+
+  const refreshQueueSize = useCallback(async () => {
+    try {
+      const size = await getQueueSize();
+      setQueueSize(size);
+    } catch { /* IndexedDB unavailable */ }
+  }, []);
+
+  // Poll queue size every 2 seconds
+  useEffect(() => {
+    refreshQueueSize();
+    const interval = setInterval(refreshQueueSize, 2000);
+    return () => clearInterval(interval);
+  }, [refreshQueueSize]);
+
+  // Replay queued actions on reconnect
+  useEffect(() => {
+    let replayScheduled = false;
+
+    const handleOnline = async () => {
+      // Synchronous guard: prevent multiple online events from scheduling parallel replays
+      if (replayScheduled) return;
+      replayScheduled = true;
+
+      try {
+        // Jittered delay to prevent thundering herd when multiple coordinators
+        // reconnect simultaneously after a WiFi outage (0-2 seconds)
+        const jitterMs = Math.floor(Math.random() * 2000);
+        await new Promise(r => setTimeout(r, jitterMs));
+
+        // Double-check: if another mechanism already started replay, skip
+        if (isReplaying()) { replayScheduled = false; return; }
+
+        // Signal that replay is starting so components can show SENDING state
+        window.dispatchEvent(new CustomEvent('fabt-queue-replaying'));
+
+        const result = await replayQueue();
+        refreshQueueSize();
+
+        // Notify components (e.g., OutreachSearch) of replay outcomes
+        window.dispatchEvent(new CustomEvent<ReplayResult>('fabt-queue-replayed', { detail: result }));
+
+        const messages: string[] = [];
+        if (result.succeeded > 0) {
+          messages.push(`${result.succeeded} queued action${result.succeeded > 1 ? 's' : ''} sent`);
+        }
+        if (result.expired.length > 0) {
+          messages.push(`${result.expired.length} hold${result.expired.length > 1 ? 's' : ''} expired while offline`);
+        }
+        if (result.conflicts.length > 0) {
+          messages.push(`${result.conflicts.length} bed${result.conflicts.length > 1 ? 's were' : ' was'} taken while offline`);
+        }
+        if (result.failed > 0) {
+          messages.push(`${result.failed} action${result.failed > 1 ? 's' : ''} failed — will retry`);
+        }
+        // Show summary as a brief notification if anything happened
+        if (messages.length > 0) {
+          setReplayMessage(messages.join('. ') + '.');
+          setTimeout(() => setReplayMessage(null), 6000);
+        }
+      } catch { /* replay failed, actions remain in queue for next attempt */ }
+      finally { replayScheduled = false; }
+    };
+
+    window.addEventListener('online', handleOnline);
+    return () => window.removeEventListener('online', handleOnline);
+  }, [refreshQueueSize]);
+
+  const [replayMessage, setReplayMessage] = useState<string | null>(null);
 
   const handleLogout = () => {
     logout();
@@ -138,6 +210,23 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
       </div>
 
       <OfflineBanner />
+      {replayMessage && (
+        <div
+          role="status"
+          aria-live="polite"
+          style={{
+            padding: '10px 20px',
+            backgroundColor: color.bgHighlight,
+            color: color.primaryText,
+            fontSize: text.sm,
+            fontWeight: weight.medium,
+            textAlign: 'center',
+            borderBottom: `1px solid ${color.primaryLight}`,
+          }}
+        >
+          {replayMessage}
+        </div>
+      )}
       <SessionTimeoutWarning expiresIn={expiresIn} onLogout={handleLogout} />
       <ChangePasswordModal
         open={changePasswordOpen}
@@ -174,6 +263,7 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
             </span>
           )}
           <LocaleSelector locale={locale} onLocaleChange={onLocaleChange} />
+          <QueueStatusIndicator count={queueSize} />
           <NotificationBell
             notifications={notifications}
             unreadCount={unreadCount}

--- a/frontend/src/components/QueueStatusIndicator.tsx
+++ b/frontend/src/components/QueueStatusIndicator.tsx
@@ -1,0 +1,115 @@
+import { useState } from 'react';
+import { FormattedMessage, useIntl } from 'react-intl';
+import { getQueuedActions, type QueuedAction } from '../services/offlineQueue';
+import { text, weight } from '../theme/typography';
+import { color } from '../theme/colors';
+
+interface QueueStatusIndicatorProps {
+  count: number;
+}
+
+const ACTION_LABEL_KEYS: Record<string, string> = {
+  HOLD_BED: 'queue.holdBed',
+  UPDATE_AVAILABILITY: 'queue.updateAvailability',
+};
+
+export function QueueStatusIndicator({ count }: QueueStatusIndicatorProps) {
+  const intl = useIntl();
+  const [open, setOpen] = useState(false);
+  const [actions, setActions] = useState<QueuedAction[]>([]);
+
+  if (count === 0) return null;
+
+  const handleClick = async () => {
+    if (!open) {
+      const items = await getQueuedActions();
+      setActions(items);
+    }
+    setOpen(!open);
+  };
+
+  return (
+    <div style={{ position: 'relative' }}>
+      <button
+        onClick={handleClick}
+        data-testid="queue-status-badge"
+        aria-label={intl.formatMessage({ id: 'queue.pending' }, { count })}
+        style={{
+          position: 'relative',
+          background: 'transparent',
+          border: '1px solid rgba(255,255,255,0.3)',
+          borderRadius: 8,
+          padding: '6px 10px',
+          cursor: 'pointer',
+          color: color.headerText,
+          fontSize: text.sm,
+          fontWeight: weight.bold,
+          minHeight: 44,
+          minWidth: 44,
+          display: 'flex',
+          alignItems: 'center',
+          gap: 4,
+        }}
+      >
+        <span aria-hidden="true" style={{ fontSize: text.base }}>&#9202;</span>
+        <span data-testid="queue-count">{count}</span>
+      </button>
+
+      {open && (
+        <div
+          data-testid="queue-panel"
+          style={{
+            position: 'absolute',
+            top: '100%',
+            right: 0,
+            marginTop: 8,
+            width: 280,
+            backgroundColor: color.bg,
+            border: `1px solid ${color.border}`,
+            borderRadius: 12,
+            boxShadow: '0 4px 20px rgba(0,0,0,0.15)',
+            zIndex: 1000,
+            padding: '12px 16px',
+          }}
+        >
+          <h4 style={{
+            margin: '0 0 8px', fontSize: text.sm, fontWeight: weight.bold,
+            color: color.text, textTransform: 'uppercase', letterSpacing: '0.04em',
+          }}>
+            <FormattedMessage id="queue.title" />
+          </h4>
+          {actions.length === 0 ? (
+            <div style={{ fontSize: text.xs, color: color.textMuted }}>
+              <FormattedMessage id="queue.empty" />
+            </div>
+          ) : (
+            actions.map((action) => {
+              const minutesAgo = Math.floor((Date.now() - action.timestamp) / 60000);
+              const labelKey = ACTION_LABEL_KEYS[action.type] || 'queue.unknownAction';
+              return (
+                <div
+                  key={action.id}
+                  style={{
+                    padding: '8px 0',
+                    borderBottom: `1px solid ${color.borderLight}`,
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                  }}
+                >
+                  <span style={{ fontSize: text.xs, fontWeight: weight.semibold, color: color.text }}>
+                    <span aria-hidden="true" style={{ color: color.warning, marginRight: 4 }}>&#128336;</span>
+                    <FormattedMessage id={labelKey} />
+                  </span>
+                  <span style={{ fontSize: text['2xs'], color: color.textMuted }}>
+                    <FormattedMessage id="queue.queuedAgo" values={{ minutes: minutesAgo }} />
+                  </span>
+                </div>
+              );
+            })
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -18,7 +18,7 @@
   "nav.search": "Search Beds",
   "nav.admin": "Administration",
   "nav.logout": "Sign Out",
-  "offline.banner": "You are offline — your last search is still available. Actions will sync when connection returns.",
+  "offline.banner": "You are offline. Cached searches are still visible. Bed holds and updates will be queued and sent when you reconnect.",
   "data.age.fresh": "Fresh",
   "data.age.aging": "Aging",
   "data.age.stale": "Stale",
@@ -345,5 +345,18 @@
   "notifications.referralRejected": "A shelter rejected your referral",
   "notifications.unknown": "Notification",
   "notifications.reconnecting": "Reconnecting to live updates…",
-  "notifications.reconnected": "Reconnected"
+  "notifications.reconnected": "Reconnected",
+
+  "queue.pending": "{count, plural, one {# pending action} other {# pending actions}}",
+  "queue.title": "Queued Actions",
+  "queue.empty": "No queued actions",
+  "queue.holdBed": "Hold bed",
+  "queue.updateAvailability": "Update availability",
+  "queue.unknownAction": "Queued action",
+  "queue.queuedAgo": "Queued {minutes}m ago",
+  "search.holdQueued": "Hold queued — will send when online",
+  "search.holdExpired": "Hold request expired (queued {minutes} min ago). Search again?",
+  "search.holdConflict": "Bed was taken while offline. Search again?",
+  "search.holdFailed.retry": "Could not reach server. Will retry automatically.",
+  "coord.updateQueued": "Update queued — will send when online"
 }

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -18,7 +18,7 @@
   "nav.search": "Buscar Camas",
   "nav.admin": "Administración",
   "nav.logout": "Cerrar Sesión",
-  "offline.banner": "Sin conexión — tu última búsqueda sigue disponible. Las acciones se sincronizarán cuando se restablezca la conexión.",
+  "offline.banner": "Estás sin conexión. Las búsquedas guardadas siguen visibles. Las reservas y actualizaciones se pondrán en cola y se enviarán cuando te reconectes.",
   "data.age.fresh": "Reciente",
   "data.age.aging": "Envejeciendo",
   "data.age.stale": "Desactualizado",
@@ -345,5 +345,18 @@
   "notifications.referralRejected": "Un refugio rechazó su referencia",
   "notifications.unknown": "Notificación",
   "notifications.reconnecting": "Reconectando a actualizaciones en vivo…",
-  "notifications.reconnected": "Reconectado"
+  "notifications.reconnected": "Reconectado",
+
+  "queue.pending": "{count, plural, one {# acción pendiente} other {# acciones pendientes}}",
+  "queue.title": "Acciones en Cola",
+  "queue.empty": "No hay acciones en cola",
+  "queue.holdBed": "Reservar cama",
+  "queue.updateAvailability": "Actualizar disponibilidad",
+  "queue.unknownAction": "Acción en cola",
+  "queue.queuedAgo": "En cola hace {minutes}m",
+  "search.holdQueued": "Reserva en cola — se enviará cuando estés en línea",
+  "search.holdExpired": "La reserva expiró (en cola hace {minutes} min). ¿Buscar de nuevo?",
+  "search.holdConflict": "La cama fue ocupada mientras estabas sin conexión. ¿Buscar de nuevo?",
+  "search.holdFailed.retry": "No se pudo conectar al servidor. Se reintentará automáticamente.",
+  "coord.updateQueued": "Actualización en cola — se enviará cuando estés en línea"
 }

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,6 +3,17 @@ import { createRoot } from 'react-dom/client'
 import './global.css'
 import App from './App'
 
+// Request persistent storage to protect IndexedDB offline queue from browser eviction.
+// Mobile browsers can silently wipe storage under memory pressure — this asks the
+// browser to keep our data. If denied, the queue still works but is not eviction-proof.
+if (navigator.storage?.persist) {
+  navigator.storage.persist().then((granted) => {
+    if (!granted) {
+      console.warn('[FABT] Persistent storage not granted — offline queue may be evicted under storage pressure');
+    }
+  });
+}
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/frontend/src/pages/CoordinatorDashboard.tsx
+++ b/frontend/src/pages/CoordinatorDashboard.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { api } from '../services/api';
+import { enqueueAction } from '../services/offlineQueue';
 import { DataAge } from '../components/DataAge';
 import { text, weight, leading } from '../theme/typography';
 import { color } from '../theme/colors';
@@ -195,21 +196,38 @@ export function CoordinatorDashboard() {
     if (!avail) return;
     setAvailSaving(popType);
     setError(null);
+    const payload = {
+      populationType: popType,
+      bedsTotal: avail.bedsTotal,
+      bedsOccupied: avail.bedsOccupied,
+      bedsOnHold: avail.bedsOnHold,
+      acceptingNewGuests: true,
+      overflowBeds: avail.overflowBeds,
+    };
     try {
-      await api.patch(`/api/v1/shelters/${shelterId}/availability`, {
-        populationType: popType,
-        bedsTotal: avail.bedsTotal,
-        bedsOccupied: avail.bedsOccupied,
-        bedsOnHold: avail.bedsOnHold,
-        acceptingNewGuests: true,
-        overflowBeds: avail.overflowBeds,
-      });
+      if (!navigator.onLine) {
+        await enqueueAction('UPDATE_AVAILABILITY', `/api/v1/shelters/${shelterId}/availability`, 'PATCH', payload);
+        setAvailSaved(popType);
+        setError(intl.formatMessage({ id: 'coord.updateQueued', defaultMessage: 'Update queued — will send when online' }));
+        setTimeout(() => setAvailSaved(null), 1500);
+        return;
+      }
+      await api.patch(`/api/v1/shelters/${shelterId}/availability`, payload);
       setAvailSaved(popType);
       // Refresh shelter list for updated summary
       fetchShelters();
       setTimeout(() => setAvailSaved(null), 1500);
     } catch {
-      setError(intl.formatMessage({ id: 'coord.error' }));
+      // Online but request failed — enqueue as fallback
+      try {
+        await enqueueAction('UPDATE_AVAILABILITY', `/api/v1/shelters/${shelterId}/availability`, 'PATCH', payload);
+        setAvailSaved(popType);
+        setError(intl.formatMessage({ id: 'coord.updateQueued', defaultMessage: 'Update queued — will send when online' }));
+        setTimeout(() => setAvailSaved(null), 1500);
+      } catch {
+        // IndexedDB also failed — show error as last resort
+        setError(intl.formatMessage({ id: 'coord.error' }));
+      }
     } finally {
       setAvailSaving(null);
     }

--- a/frontend/src/pages/OutreachSearch.tsx
+++ b/frontend/src/pages/OutreachSearch.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback, useRef } from 'react';
 import { FormattedMessage, useIntl } from 'react-intl';
 import { api } from '../services/api';
+import { enqueueAction, type ReplayResult } from '../services/offlineQueue';
 import { DataAge } from '../components/DataAge';
 import { text, weight, leading } from '../theme/typography';
 import { color } from '../theme/colors';
@@ -156,6 +157,16 @@ export function OutreachSearch() {
   const [showReservations, setShowReservations] = useState(false);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
+  // Queued holds state (offline)
+  interface QueuedHold {
+    shelterId: string;
+    populationType: string;
+    idempotencyKey: string;
+    timestamp: number;
+    status: 'QUEUED' | 'SENDING' | 'CONFIRMED' | 'CONFLICTED' | 'EXPIRED' | 'FAILED';
+  }
+  const [queuedHolds, setQueuedHolds] = useState<QueuedHold[]>([]);
+
   // DV referral state
   const [referralModal, setReferralModal] = useState<{ shelterId: string; popType: string } | null>(null);
   const [referralForm, setReferralForm] = useState({ householdSize: 1, urgency: 'STANDARD', specialNeeds: '', callbackNumber: '' });
@@ -193,6 +204,64 @@ export function OutreachSearch() {
   }, []);
 
   useEffect(() => { fetchReservations(); }, [fetchReservations]);
+
+  // Listen for replay lifecycle events from Layout
+  useEffect(() => {
+    const handleReplaying = () => {
+      setQueuedHolds((prev) => prev.map((h) =>
+        h.status === 'QUEUED' ? { ...h, status: 'SENDING' as const } : h
+      ));
+    };
+    window.addEventListener('fabt-queue-replaying', handleReplaying);
+    return () => window.removeEventListener('fabt-queue-replaying', handleReplaying);
+  }, []);
+
+  useEffect(() => {
+    const handleReplay = (e: Event) => {
+      const result = (e as CustomEvent<ReplayResult>).detail;
+
+      setQueuedHolds((prev) => {
+        let updated = [...prev];
+
+        for (const action of result.succeededActions) {
+          if (action.type === 'HOLD_BED') {
+            updated = updated.map((h) =>
+              h.idempotencyKey === action.idempotencyKey ? { ...h, status: 'CONFIRMED' as const } : h
+            );
+          }
+        }
+        for (const action of result.expired) {
+          if (action.type === 'HOLD_BED') {
+            updated = updated.map((h) =>
+              h.idempotencyKey === action.idempotencyKey ? { ...h, status: 'EXPIRED' as const } : h
+            );
+          }
+        }
+        for (const action of result.conflicts) {
+          if (action.type === 'HOLD_BED') {
+            updated = updated.map((h) =>
+              h.idempotencyKey === action.idempotencyKey ? { ...h, status: 'CONFLICTED' as const } : h
+            );
+          }
+        }
+        for (const action of result.failedActions) {
+          if (action.type === 'HOLD_BED') {
+            updated = updated.map((h) =>
+              h.idempotencyKey === action.idempotencyKey ? { ...h, status: 'FAILED' as const } : h
+            );
+          }
+        }
+
+        return updated.filter((h) => h.status !== 'CONFIRMED');
+      });
+
+      fetchReservations();
+      fetchBeds();
+    };
+
+    window.addEventListener('fabt-queue-replayed', handleReplay);
+    return () => window.removeEventListener('fabt-queue-replayed', handleReplay);
+  }, [fetchReservations, fetchBeds]);
 
   // Fetch DV referrals
   const fetchReferrals = useCallback(async () => {
@@ -267,6 +336,21 @@ export function OutreachSearch() {
     setHoldingShelterId(shelterId);
     setHoldPopType(popType);
     try {
+      if (!navigator.onLine) {
+        const key = await enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {
+          shelterId,
+          populationType: popType,
+        });
+        setQueuedHolds(prev => [...prev, {
+          shelterId,
+          populationType: popType,
+          idempotencyKey: key,
+          timestamp: Date.now(),
+          status: 'QUEUED',
+        }]);
+        setShowReservations(true);
+        return;
+      }
       await api.post('/api/v1/reservations', {
         shelterId,
         populationType: popType,
@@ -275,7 +359,25 @@ export function OutreachSearch() {
       await fetchBeds();
       setShowReservations(true);
     } catch {
-      setError(intl.formatMessage({ id: 'search.holdFailed' }));
+      // Online but request failed (navigator.onLine lied, or network is flaky).
+      // Enqueue as fallback rather than showing error — replay will handle it.
+      try {
+        const key = await enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {
+          shelterId,
+          populationType: popType,
+        });
+        setQueuedHolds(prev => [...prev, {
+          shelterId,
+          populationType: popType,
+          idempotencyKey: key,
+          timestamp: Date.now(),
+          status: 'QUEUED',
+        }]);
+        setShowReservations(true);
+      } catch {
+        // IndexedDB also failed — show error as last resort
+        setError(intl.formatMessage({ id: 'search.holdFailed' }));
+      }
     } finally {
       setHoldingShelterId(null);
       setHoldPopType(null);
@@ -435,7 +537,7 @@ export function OutreachSearch() {
       {loading && <Spinner />}
 
       {/* Active Reservations Panel */}
-      {reservations.filter(r => r.status === 'HELD').length > 0 && (
+      {(reservations.filter(r => r.status === 'HELD').length > 0 || queuedHolds.length > 0) && (
         <div style={{ marginBottom: 16 }}>
           <button
             onClick={() => setShowReservations(!showReservations)}
@@ -446,11 +548,72 @@ export function OutreachSearch() {
               display: 'flex', justifyContent: 'space-between', alignItems: 'center',
             }}
           >
-            <span><FormattedMessage id="reservations.title" /> ({reservations.filter(r => r.status === 'HELD').length})</span>
+            <span><FormattedMessage id="reservations.title" /> ({reservations.filter(r => r.status === 'HELD').length + queuedHolds.length})</span>
             <span>{showReservations ? '▲' : '▼'}</span>
           </button>
           {showReservations && (
             <div style={{ border: `2px solid ${color.border}`, borderTop: 'none', borderRadius: '0 0 12px 12px', padding: '12px 16px' }}>
+              {/* Queued holds (offline) */}
+              {queuedHolds.map((qh) => {
+                const shelterResult = results.find(r => r.shelterId === qh.shelterId);
+                const minutesAgo = Math.floor((Date.now() - qh.timestamp) / 60000);
+                return (
+                  <div key={qh.idempotencyKey} data-testid={`queued-hold-${qh.shelterId}`} style={{
+                    padding: '12px 0', borderBottom: `1px solid ${color.borderLight}`,
+                    display: 'flex', justifyContent: 'space-between', alignItems: 'center', flexWrap: 'wrap', gap: 8,
+                  }}>
+                    <div>
+                      <div style={{ fontWeight: weight.bold, fontSize: text.base, color: color.text }}>
+                        {shelterResult?.shelterName || qh.shelterId.substring(0, 8)}
+                      </div>
+                      <div style={{ fontSize: text.xs, color: color.textTertiary }}>
+                        {getPopulationTypeLabel(qh.populationType, intl)}
+                      </div>
+                      <div aria-live="polite" style={{ fontSize: text.sm, fontWeight: weight.bold, marginTop: 4 }}>
+                        {qh.status === 'QUEUED' && (
+                          <span style={{ color: color.warning }}>
+                            &#128336; <FormattedMessage id="search.holdQueued" />
+                          </span>
+                        )}
+                        {qh.status === 'SENDING' && (
+                          <span style={{ color: color.primary }}>
+                            &#8635; Syncing...
+                          </span>
+                        )}
+                        {qh.status === 'CONFLICTED' && (
+                          <span style={{ color: color.error }}>
+                            <FormattedMessage id="search.holdConflict" />
+                          </span>
+                        )}
+                        {qh.status === 'EXPIRED' && (
+                          <span style={{ color: color.textMuted }}>
+                            <FormattedMessage id="search.holdExpired" values={{ minutes: minutesAgo }} />
+                          </span>
+                        )}
+                        {qh.status === 'FAILED' && (
+                          <span style={{ color: color.warning }}>
+                            &#8635; <FormattedMessage id="search.holdFailed.retry" defaultMessage="Could not reach server. Will retry automatically." />
+                          </span>
+                        )}
+                      </div>
+                    </div>
+                    {(qh.status === 'CONFLICTED' || qh.status === 'EXPIRED') && (
+                      <button
+                        onClick={() => {
+                          setQueuedHolds(prev => prev.filter(h => h.idempotencyKey !== qh.idempotencyKey));
+                          window.scrollTo({ top: 0, behavior: 'smooth' });
+                        }}
+                        style={{
+                          padding: '8px 14px', borderRadius: 8, border: `2px solid ${color.border}`,
+                          backgroundColor: color.bg, color: color.primaryText, fontSize: text.sm, fontWeight: weight.bold, cursor: 'pointer',
+                        }}
+                      >
+                        <FormattedMessage id="search.title" />
+                      </button>
+                    )}
+                  </div>
+                );
+              })}
               {reservations.filter(r => r.status === 'HELD').map((res) => {
                 const mins = Math.floor(res.remainingSeconds / 60);
                 const secs = res.remainingSeconds % 60;

--- a/frontend/src/services/offlineQueue.test.ts
+++ b/frontend/src/services/offlineQueue.test.ts
@@ -1,0 +1,226 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import 'fake-indexeddb/auto';
+import { IDBFactory } from 'fake-indexeddb';
+
+// We need to reset the global indexedDB for each test
+// to avoid cross-test DB state leaking
+let offlineQueue: typeof import('./offlineQueue');
+
+async function loadModule() {
+  // Reset indexedDB globally so each test gets a fresh DB
+  globalThis.indexedDB = new IDBFactory();
+  // Re-import the module fresh (bypass vi cache)
+  vi.resetModules();
+  offlineQueue = await import('./offlineQueue');
+  offlineQueue._resetForTesting();
+}
+
+// Mock the api module
+const mockPost = vi.fn().mockResolvedValue({});
+const mockPatch = vi.fn().mockResolvedValue({});
+
+class MockApiError extends Error {
+  status: number;
+  error: string;
+  constructor(response: { status: number; error: string; message: string }) {
+    super(response.message);
+    this.name = 'ApiError';
+    this.status = response.status;
+    this.error = response.error;
+  }
+}
+
+vi.mock('./api', () => ({
+  api: {
+    post: mockPost,
+    put: vi.fn().mockResolvedValue({}),
+    patch: mockPatch,
+    delete: vi.fn().mockResolvedValue({}),
+    get: vi.fn().mockResolvedValue({}),
+  },
+  ApiError: MockApiError,
+}));
+
+beforeEach(async () => {
+  mockPost.mockReset().mockResolvedValue({});
+  mockPatch.mockReset().mockResolvedValue({});
+  await loadModule();
+});
+
+describe('enqueueAction', () => {
+  it('enqueues an action and returns an idempotency key', async () => {
+    const key = await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', { shelterId: '123' });
+
+    expect(key).toBeTruthy();
+    expect(typeof key).toBe('string');
+    expect(key.length).toBe(36); // UUID format
+
+    const size = await offlineQueue.getQueueSize();
+    expect(size).toBe(1);
+  });
+
+  it('generates unique idempotency keys for each action', async () => {
+    const key1 = await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+    const key2 = await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    expect(key1).not.toBe(key2);
+  });
+
+  it('stores actions retrievable in timestamp order', async () => {
+    await offlineQueue.enqueueAction('UPDATE_AVAILABILITY', '/api/v1/shelters/1/availability', 'PATCH', { bedsOccupied: 5 });
+    // Small delay to ensure different timestamps
+    await new Promise(r => setTimeout(r, 5));
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', { shelterId: '1' });
+
+    const actions = await offlineQueue.getQueuedActions();
+    expect(actions.length).toBe(2);
+    expect(actions[0].type).toBe('UPDATE_AVAILABILITY');
+    expect(actions[1].type).toBe('HOLD_BED');
+    expect(actions[0].timestamp).toBeLessThan(actions[1].timestamp);
+  });
+
+  it('serializes body to JSON string', async () => {
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', { shelterId: 'abc', populationType: 'VETERAN' });
+
+    const actions = await offlineQueue.getQueuedActions();
+    expect(actions[0].body).toBe('{"shelterId":"abc","populationType":"VETERAN"}');
+  });
+});
+
+describe('replayQueue', () => {
+  it('replays actions and removes them from queue on success', async () => {
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', { shelterId: '1' });
+    await offlineQueue.enqueueAction('UPDATE_AVAILABILITY', '/api/v1/shelters/1/availability', 'PATCH', { bedsOccupied: 5 });
+
+    const result = await offlineQueue.replayQueue();
+
+    expect(result.succeeded).toBe(2);
+    expect(result.failed).toBe(0);
+    expect(result.succeededActions.length).toBe(2);
+    expect(await offlineQueue.getQueueSize()).toBe(0);
+  });
+
+  it('includes X-Idempotency-Key header when replaying', async () => {
+    const key = await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    await offlineQueue.replayQueue();
+
+    expect(mockPost).toHaveBeenCalledWith(
+      '/api/v1/reservations',
+      {},
+      { headers: { 'X-Idempotency-Key': key } }
+    );
+  });
+
+  it('skips expired HOLD_BED actions', async () => {
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    // Small delay so the action's timestamp is at least 2ms old
+    await new Promise(r => setTimeout(r, 5));
+
+    // holdDuration=1ms, buffer=0 means anything older than 1ms is expired
+    const result = await offlineQueue.replayQueue(1, 0);
+
+    expect(result.expired.length).toBe(1);
+    expect(result.succeeded).toBe(0);
+    expect(mockPost).not.toHaveBeenCalled();
+    expect(await offlineQueue.getQueueSize()).toBe(0);
+  });
+
+  it('replays HOLD_BED that is NOT yet expired', async () => {
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    // holdDuration=2hrs, buffer=5min — action just created, well within window
+    const result = await offlineQueue.replayQueue(2 * 60 * 60 * 1000, 5 * 60 * 1000);
+
+    expect(result.succeeded).toBe(1);
+    expect(result.expired.length).toBe(0);
+  });
+
+  it('never expires UPDATE_AVAILABILITY actions', async () => {
+    await offlineQueue.enqueueAction('UPDATE_AVAILABILITY', '/api/v1/shelters/1/availability', 'PATCH', {});
+
+    // Even with holdDuration=0, availability updates should still replay
+    const result = await offlineQueue.replayQueue(0, 0);
+
+    expect(result.succeeded).toBe(1);
+    expect(result.expired.length).toBe(0);
+  });
+
+  it('handles 409 conflict — removes action and adds to conflicts', async () => {
+    mockPost.mockRejectedValueOnce(new MockApiError({ status: 409, error: 'Conflict', message: 'No beds' }));
+
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    const result = await offlineQueue.replayQueue();
+
+    expect(result.conflicts.length).toBe(1);
+    expect(result.succeeded).toBe(0);
+    expect(result.failed).toBe(0);
+    expect(await offlineQueue.getQueueSize()).toBe(0); // removed from queue
+  });
+
+  it('handles non-409 error — action remains in queue for retry', async () => {
+    mockPost.mockRejectedValueOnce(new Error('Network error'));
+
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    const result = await offlineQueue.replayQueue();
+
+    expect(result.failed).toBe(1);
+    expect(result.failedActions.length).toBe(1);
+    expect(result.succeeded).toBe(0);
+    expect(await offlineQueue.getQueueSize()).toBe(1); // still in queue
+  });
+
+  it('concurrent replay guard — second call returns empty result', async () => {
+    // Make the first replay slow
+    mockPost.mockImplementation(() => new Promise(r => setTimeout(() => r({}), 100)));
+
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    // Start two replays concurrently
+    const [result1, result2] = await Promise.all([
+      offlineQueue.replayQueue(),
+      offlineQueue.replayQueue(),
+    ]);
+
+    // One should succeed, one should be empty (guard)
+    const totalSucceeded = result1.succeeded + result2.succeeded;
+    expect(totalSucceeded).toBe(1);
+
+    // The guarded one has all zeros
+    const guarded = result1.succeeded === 0 ? result1 : result2;
+    expect(guarded.succeeded).toBe(0);
+    expect(guarded.failed).toBe(0);
+    expect(guarded.expired.length).toBe(0);
+    expect(guarded.conflicts.length).toBe(0);
+  });
+
+  it('isReplaying returns correct state', async () => {
+    expect(offlineQueue.isReplaying()).toBe(false);
+
+    mockPost.mockImplementation(() => new Promise(r => setTimeout(() => r({}), 50)));
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+
+    const replayPromise = offlineQueue.replayQueue();
+    // Can't reliably test mid-flight state without more complex setup,
+    // but after completion it should be false
+    await replayPromise;
+    expect(offlineQueue.isReplaying()).toBe(false);
+  });
+});
+
+describe('getQueueSize', () => {
+  it('returns 0 for empty queue', async () => {
+    expect(await offlineQueue.getQueueSize()).toBe(0);
+  });
+
+  it('returns correct count after enqueuing', async () => {
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+    await offlineQueue.enqueueAction('HOLD_BED', '/api/v1/reservations', 'POST', {});
+    await offlineQueue.enqueueAction('UPDATE_AVAILABILITY', '/api/v1/shelters/1/availability', 'PATCH', {});
+
+    expect(await offlineQueue.getQueueSize()).toBe(3);
+  });
+});

--- a/frontend/src/services/offlineQueue.ts
+++ b/frontend/src/services/offlineQueue.ts
@@ -3,9 +3,10 @@ import { api, ApiError } from './api';
 
 interface QueuedAction {
   id: string;
+  idempotencyKey: string;
   type: string;
   url: string;
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE';
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE';
   body?: string;
   timestamp: number;
 }
@@ -19,7 +20,7 @@ interface OfflineQueueDB extends DBSchema {
 }
 
 const DB_NAME = 'fabt-offline-queue';
-const DB_VERSION = 1;
+const DB_VERSION = 2; // Bumped for idempotencyKey field
 const STORE_NAME = 'actions';
 
 let dbPromise: Promise<IDBPDatabase<OfflineQueueDB>> | null = null;
@@ -27,9 +28,12 @@ let dbPromise: Promise<IDBPDatabase<OfflineQueueDB>> | null = null;
 function getDb(): Promise<IDBPDatabase<OfflineQueueDB>> {
   if (!dbPromise) {
     dbPromise = openDB<OfflineQueueDB>(DB_NAME, DB_VERSION, {
-      upgrade(db) {
-        const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
-        store.createIndex('by-timestamp', 'timestamp');
+      upgrade(db, oldVersion) {
+        if (oldVersion < 1) {
+          const store = db.createObjectStore(STORE_NAME, { keyPath: 'id' });
+          store.createIndex('by-timestamp', 'timestamp');
+        }
+        // V2: idempotencyKey added to the record — no schema change needed (field on value)
       },
     });
   }
@@ -40,15 +44,21 @@ function generateId(): string {
   return `${Date.now()}-${Math.random().toString(36).substring(2, 9)}`;
 }
 
+function generateIdempotencyKey(): string {
+  return crypto.randomUUID();
+}
+
 export async function enqueueAction(
   type: string,
   url: string,
-  method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
   body?: unknown
-): Promise<void> {
+): Promise<string> {
   const db = await getDb();
+  const idempotencyKey = generateIdempotencyKey();
   const action: QueuedAction = {
     id: generateId(),
+    idempotencyKey,
     type,
     url,
     method,
@@ -56,15 +66,49 @@ export async function enqueueAction(
     timestamp: Date.now(),
   };
   await db.add(STORE_NAME, action);
+  return idempotencyKey;
 }
 
 export interface ReplayResult {
   succeeded: number;
   failed: number;
+  succeededActions: QueuedAction[];
+  expired: QueuedAction[];
   conflicts: QueuedAction[];
+  failedActions: QueuedAction[];
 }
 
-export async function replayQueue(): Promise<ReplayResult> {
+let replaying = false;
+
+/**
+ * Replay queued actions. Hold actions older than (holdDurationMs - bufferMs) are skipped as expired.
+ * Includes a concurrent replay guard — if called while already running, returns early with empty result.
+ * @param holdDurationMs tenant hold duration in ms (default 90 minutes)
+ * @param bufferMs buffer before expiry to skip (default 5 minutes)
+ */
+export async function replayQueue(
+  holdDurationMs: number = 90 * 60 * 1000,
+  bufferMs: number = 5 * 60 * 1000
+): Promise<ReplayResult> {
+  if (replaying) {
+    return { succeeded: 0, failed: 0, succeededActions: [], expired: [], conflicts: [], failedActions: [] };
+  }
+  replaying = true;
+  try {
+    return await _replayQueueImpl(holdDurationMs, bufferMs);
+  } finally {
+    replaying = false;
+  }
+}
+
+export function isReplaying(): boolean {
+  return replaying;
+}
+
+async function _replayQueueImpl(
+  holdDurationMs: number,
+  bufferMs: number
+): Promise<ReplayResult> {
   const db = await getDb();
   const tx = db.transaction(STORE_NAME, 'readonly');
   const index = tx.store.index('by-timestamp');
@@ -74,19 +118,42 @@ export async function replayQueue(): Promise<ReplayResult> {
   const result: ReplayResult = {
     succeeded: 0,
     failed: 0,
+    succeededActions: [],
+    expired: [],
     conflicts: [],
+    failedActions: [],
   };
 
+  const now = Date.now();
+
   for (const action of actions) {
+    // Hold expiry check: skip HOLD_BED actions older than (holdDuration - buffer)
+    if (action.type === 'HOLD_BED' && (now - action.timestamp > holdDurationMs - bufferMs)) {
+      result.expired.push(action);
+      const deleteTx = db.transaction(STORE_NAME, 'readwrite');
+      await deleteTx.store.delete(action.id);
+      await deleteTx.done;
+      continue;
+    }
+
     try {
       const parsedBody = action.body ? JSON.parse(action.body) : undefined;
+      const headers: Record<string, string> = {};
+
+      // Include idempotency key for deduplication
+      if (action.idempotencyKey) {
+        headers['X-Idempotency-Key'] = action.idempotencyKey;
+      }
 
       switch (action.method) {
         case 'POST':
-          await api.post(action.url, parsedBody);
+          await api.post(action.url, parsedBody, { headers });
           break;
         case 'PUT':
-          await api.put(action.url, parsedBody);
+          await api.put(action.url, parsedBody, headers);
+          break;
+        case 'PATCH':
+          await api.patch(action.url, parsedBody, headers);
           break;
         case 'DELETE':
           await api.delete(action.url);
@@ -99,6 +166,7 @@ export async function replayQueue(): Promise<ReplayResult> {
       await deleteTx.store.delete(action.id);
       await deleteTx.done;
       result.succeeded++;
+      result.succeededActions.push(action);
     } catch (error) {
       if (error instanceof ApiError && error.status === 409) {
         result.conflicts.push(action);
@@ -107,6 +175,7 @@ export async function replayQueue(): Promise<ReplayResult> {
         await deleteTx.done;
       } else {
         result.failed++;
+        result.failedActions.push(action);
       }
     }
   }
@@ -118,3 +187,20 @@ export async function getQueueSize(): Promise<number> {
   const db = await getDb();
   return db.count(STORE_NAME);
 }
+
+export async function getQueuedActions(): Promise<QueuedAction[]> {
+  const db = await getDb();
+  const tx = db.transaction(STORE_NAME, 'readonly');
+  const index = tx.store.index('by-timestamp');
+  const actions = await index.getAll();
+  await tx.done;
+  return actions;
+}
+
+/** Reset module state — for testing only. */
+export function _resetForTesting(): void {
+  dbPromise = null;
+  replaying = false;
+}
+
+export type { QueuedAction };

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,0 +1,31 @@
+/// <reference lib="webworker" />
+import { precacheAndRoute } from 'workbox-precaching';
+import { registerRoute } from 'workbox-routing';
+import { NetworkFirst } from 'workbox-strategies';
+
+declare let self: ServiceWorkerGlobalScope;
+
+// Precache static assets (injected by vite-plugin-pwa)
+precacheAndRoute(self.__WB_MANIFEST);
+
+// Runtime cache: GET /api/v1/* — NetworkFirst with 5-second timeout
+// Offline resilience for mutations (POST/PATCH) is handled entirely by the
+// app-level IndexedDB queue (offlineQueue.ts), not by the service worker.
+// This avoids dual-queue deduplication complexity and keeps offline behavior
+// fully testable in Playwright. See design.md "Architecture decision: single queue".
+registerRoute(
+  ({ url, request }) =>
+    url.pathname.startsWith('/api/v1/') && request.method === 'GET',
+  new NetworkFirst({
+    cacheName: 'api-cache',
+    networkTimeoutSeconds: 5,
+    plugins: [
+      {
+        cacheWillUpdate: async ({ response }) => {
+          // Only cache successful responses
+          return response && response.status === 200 ? response : null;
+        },
+      },
+    ],
+  })
+);

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -6,7 +6,11 @@ export default defineConfig({
   plugins: [
     react(),
     VitePWA({
+      strategies: 'injectManifest',
+      srcDir: 'src',
+      filename: 'sw.ts',
       registerType: 'autoUpdate',
+      injectRegister: 'auto',
       manifest: {
         name: 'Finding A Bed Tonight',
         short_name: 'FABT',
@@ -19,20 +23,9 @@ export default defineConfig({
           { src: '/icon-512.png', sizes: '512x512', type: 'image/png' }
         ]
       },
-      workbox: {
+      injectManifest: {
         globPatterns: ['**/*.{js,css,html,ico,png,svg}'],
-        runtimeCaching: [
-          {
-            urlPattern: /^https?:\/\/.*\/api\/v1\/.*/,
-            handler: 'NetworkFirst',
-            options: {
-              cacheName: 'api-cache',
-              networkTimeoutSeconds: 5,
-              expiration: { maxEntries: 100, maxAgeSeconds: 300 }
-            }
-          }
-        ]
-      }
+      },
     })
   ],
   server: {

--- a/infra/docker/nginx.conf
+++ b/infra/docker/nginx.conf
@@ -66,5 +66,6 @@ server {
         add_header Referrer-Policy "strict-origin-when-cross-origin" always;
         add_header Permissions-Policy "geolocation=(), microphone=(), camera=()" always;
         add_header Cross-Origin-Embedder-Policy "require-corp" always;
+        add_header Cross-Origin-Resource-Policy "same-origin" always;
     }
 }


### PR DESCRIPTION
## Summary

- Wire offline queue to bed holds and availability updates — the two operations Darius and Sandra need to survive signal loss
- Single app-level IndexedDB queue (removed Workbox BackgroundSync — untestable dual-queue replaced with try/catch fallback)
- Backend idempotency key on POST /reservations prevents duplicate holds from replay (Flyway V30)
- Reconnect replay with 0-2s jitter + concurrent guard prevents thundering herd
- 6-state UI for queued actions (QUEUED/SENDING/CONFIRMED/CONFLICTED/EXPIRED/FAILED)
- QueueStatusIndicator badge in header, honest offline banner copy (en/es)
- Persistent storage request protects IndexedDB from browser eviction
- nginx CORP header fix for static assets (found via nginx E2E testing)
- React hook ordering fix for production build (found via Playwright trace analysis)

## Architecture Decision

Removed Workbox BackgroundSyncPlugin in favor of a single app-level queue after review by Riley Cho (QA), Sam Okafor (Performance), and Alex Chen (Architecture). BackgroundSync was untestable in Playwright, created dual-replay deduplication risk, and only covered a narrow edge case now handled by the try/catch fallback pattern. See design.md for full rationale.

## Test Plan

- [x] 328 backend integration tests (0 failures)
- [x] 15 Vitest unit tests for offlineQueue.ts (expiry boundaries, conflicts, concurrent guard)
- [x] 14 Playwright E2E tests through nginx proxy (explicit DOM event dispatch)
- [x] Negative tests: double-event guard, online-but-fails fallback, 409 conflict, expired hold, FAILED state, multi-action replay order, hospital SW-blocked
- [x] 5 Gatling performance scenarios:
  - Concurrent replay (5 users, same shelter): p95 = 260ms
  - Idempotent dedup short-circuit: p95 = 55ms  
  - Mixed storm (holds + availability): 0% errors
  - Shelter WiFi outage (10 users): p95 = 304ms
  - Citywide ISP outage (20 users, 4 shelters): p95 = 298ms
- [x] All Playwright tests use explicit `online`/`offline` DOM event dispatch (lesson from SSE stabilization)
- [x] All E2E tests pass through nginx proxy (lesson from SSE buffering bug)

🤖 Generated with [Claude Code](https://claude.com/claude-code)