### PR TITLE
Fix #35: Replace opacity with proper colors for WCAG contrast

### DIFF
--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -265,7 +265,7 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
         </h1>
         <div style={{ display: 'flex', alignItems: 'center', gap: '12px' }}>
           {user && (
-            <span style={{ fontSize: text.base, opacity: 0.9 }}>
+            <span style={{ fontSize: text.base, color: color.headerText }}>
               {user.displayName || user.tenantName || ''}
             </span>
           )}

--- a/frontend/src/pages/AdminPanel.tsx
+++ b/frontend/src/pages/AdminPanel.tsx
@@ -1276,7 +1276,7 @@ function SurgeTab() {
             <FormattedMessage id="surge.banner" />
           </div>
           <div style={{ fontSize: text.md, fontWeight: weight.medium, marginBottom: 8 }}>{activeSurge.reason}</div>
-          <div style={{ fontSize: text.xs, opacity: 0.85, marginBottom: 12 }}>
+          <div style={{ fontSize: text.xs, color: color.textTertiary, marginBottom: 12 }}>
             <FormattedMessage id="surge.since" />: {new Date(activeSurge.activatedAt).toLocaleString()}
           </div>
           <button onClick={() => deactivateSurge(activeSurge.id)} style={{

--- a/frontend/src/pages/OutreachSearch.tsx
+++ b/frontend/src/pages/OutreachSearch.tsx
@@ -783,7 +783,7 @@ export function OutreachSearch() {
                           padding: '6px 12px', borderRadius: 6, border: 'none',
                           backgroundColor: color.dv, color: color.textInverse, fontSize: text.xs, fontWeight: weight.bold,
                           cursor: isOnline ? 'pointer' : 'default', minHeight: 44, minWidth: 44,
-                          opacity: isOnline ? 1 : 0.5,
+                          ...(isOnline ? {} : { backgroundColor: color.borderLight, color: color.textMuted }),
                         }}
                       >
                         <FormattedMessage id="search.requestReferral" />


### PR DESCRIPTION
## Summary
- Offline referral button: replace `opacity: 0.5` with explicit disabled colors (already has `aria-disabled`)
- Header display name: replace `opacity: 0.9` with `color.headerText`
- Surge timestamp: replace `opacity: 0.85` with `color.textTertiary`

`opacity` on text is fragile for WCAG — it depends on computed color after blending. Explicit color tokens guarantee contrast ratios.

## Test plan
- [x] TypeScript build clean
- [x] 8 accessibility tests pass (axe-core, all pages)
- [x] 6 color system tests pass (light mode, dark mode, contrast)
- [x] 8 offline guard tests pass (referral button styling change)
- [ ] CI scans

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)