### PR TITLE
Fix DemoGuard SSH tunnel bypass via nginx traffic source detection

### DIFF
--- a/backend/src/main/java/org/fabt/shared/security/DemoGuardFilter.java
+++ b/backend/src/main/java/org/fabt/shared/security/DemoGuardFilter.java
@@ -75,19 +75,30 @@ public class DemoGuardFilter extends OncePerRequestFilter {
             return;
         }
 
-        // Admin bypass: SSH tunnel traffic is identified by having ONLY private/localhost
-        // IPs in the request chain. Public traffic through Cloudflare → host nginx always
-        // has a real public IP in X-Forwarded-For.
+        // Admin bypass: two detection mechanisms (Design D2).
         //
-        // Paths:
-        //   :8080 tunnel → backend directly:  remoteAddr=127.0.0.1, no XFF
-        //   :8081 tunnel → container nginx:   remoteAddr=docker-bridge, XFF=127.0.0.1
-        //   Public → Cloudflare → host nginx → container nginx: XFF=<real-public-IP>, ...
+        // Primary (via container nginx): X-FABT-Traffic-Source header.
+        //   - Container nginx sets this via a map directive based on XFF presence.
+        //   - "tunnel" = no incoming XFF (SSH tunnel to :8081, nothing upstream).
+        //   - "public" = incoming XFF present (Cloudflare → host nginx → container nginx).
+        //   - proxy_set_header REPLACES client-sent values — forgery impossible.
+        //   - Security: port 8081 is 127.0.0.1-only, iptables DROP policy blocks external.
+        //
+        // Fallback (port 8080 direct): IP-chain check.
+        //   - Direct curl to :8080 doesn't go through nginx, so no header is set.
+        //   - Falls back to checking remoteAddr + XFF are all private/localhost.
+        String trafficSource = request.getHeader("X-FABT-Traffic-Source");
         String forwardedFor = request.getHeader("X-Forwarded-For");
         String remoteAddr = request.getRemoteAddr();
 
+        if ("tunnel".equals(trafficSource)) {
+            log.info("Demo guard bypassed: tunnel traffic (X-FABT-Traffic-Source=tunnel), remoteAddr={}", remoteAddr);
+            filterChain.doFilter(request, response);
+            return;
+        }
+
         if (isInternalTraffic(remoteAddr, forwardedFor)) {
-            log.debug("Demo guard bypassed: internal traffic, remoteAddr={}, xff={}", remoteAddr, forwardedFor);
+            log.info("Demo guard bypassed: internal IP chain, remoteAddr={}, xff={}", remoteAddr, forwardedFor);
             filterChain.doFilter(request, response);
             return;
         }
@@ -104,7 +115,7 @@ public class DemoGuardFilter extends OncePerRequestFilter {
         }
 
         // Block: not allowlisted, not localhost, not tunnel
-        log.info("Demo guard blocked: {} {} from {}", method, path, remoteAddr);
+        log.info("Demo guard blocked: {} {} from {} (source={})", method, path, remoteAddr, trafficSource);
         response.setStatus(403);
         response.setContentType(MediaType.APPLICATION_JSON_VALUE);
         response.getWriter().write(

--- a/infra/docker/00-rate-limit.conf
+++ b/infra/docker/00-rate-limit.conf
@@ -7,3 +7,18 @@
 # avoid OWASP WSTG-INFO-02 findings in security scans.
 
 limit_req_zone $binary_remote_addr zone=public_api:1m rate=10r/m;
+
+# ─── DemoGuard traffic source detection ───
+# SSH tunnel traffic arrives at container nginx with NO X-Forwarded-For header
+# (nothing upstream to add one). Public traffic through Cloudflare → host nginx
+# always arrives WITH X-Forwarded-For already set.
+#
+# Security model:
+#   - Port 8081 is bound to 127.0.0.1 only (verified via ss -tlnp)
+#   - iptables default policy DROP, only 22/80/443 allowed (80/443 Cloudflare IPs only)
+#   - proxy_set_header always REPLACES client-sent values — forgery impossible
+#   - If host nginx is ever reconfigured to NOT add XFF, all traffic gets "tunnel" — test after changes
+map $http_x_forwarded_for $fabt_traffic_source {
+    default  "public";
+    ""       "tunnel";
+}

--- a/infra/docker/nginx.conf
+++ b/infra/docker/nginx.conf
@@ -24,6 +24,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-FABT-Traffic-Source $fabt_traffic_source;
         proxy_buffering off;
         proxy_cache off;
         proxy_read_timeout 86400s;
@@ -43,6 +44,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-FABT-Traffic-Source $fabt_traffic_source;
     }
 
     # Proxy API requests to backend
@@ -52,6 +54,7 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_set_header X-FABT-Traffic-Source $fabt_traffic_source;
     }
 
     # Proxy actuator requests


### PR DESCRIPTION
## Summary

Fixes the SSH tunnel admin bypass for DemoGuard so administrators can perform admin operations through the browser UI when tunneled to the demo site.

**Root cause:** The IP-chain check in `isInternalTraffic()` failed for tunnel traffic through container nginx due to XFF header behavior.

**Fix:** nginx `map` directive detects traffic source based on XFF presence:
- No XFF (SSH tunnel) → `X-FABT-Traffic-Source: tunnel` → bypass
- XFF present (Cloudflare/public) → `X-FABT-Traffic-Source: public` → guard applies

**Security:** Port 8081 bound to 127.0.0.1, iptables DROP policy, `proxy_set_header` replaces client values (forgery impossible).

## Test plan
- [x] Public path with XFF → 403 demo_restricted
- [x] Tunnel path without XFF → 201 Created (bypass works)
- [x] Forged header + XFF → 403 (nginx overwrites to "public")
- [x] Port 8080 direct → 200 (IP-chain fallback)
- [x] Safe mutations with XFF → 200 (allowlist works)
- [x] Backend: 388 tests pass
- [x] Log verification: source=public/tunnel confirmed in backend logs
- [ ] CI scans
- [ ] Post-deploy: 3-part smoke test (public blocked, tunnel UI works, public still protected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)