### PR TITLE
Fix #49, #50: CI test reliability — response validation + build-info

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -53,7 +53,7 @@ jobs:
 
       - name: Build backend
         working-directory: backend
-        run: mvn compile -q --batch-mode --no-transfer-progress
+        run: mvn spring-boot:build-info compile -q --batch-mode --no-transfer-progress
 
       - name: Start backend
         run: |
@@ -148,7 +148,7 @@ jobs:
 
       - name: Build backend
         working-directory: backend
-        run: mvn compile -q --batch-mode --no-transfer-progress
+        run: mvn spring-boot:build-info compile -q --batch-mode --no-transfer-progress
 
       - name: Start backend
         run: |

--- a/backend/src/test/java/org/fabt/availability/BedAvailabilityHardeningTest.java
+++ b/backend/src/test/java/org/fabt/availability/BedAvailabilityHardeningTest.java
@@ -62,10 +62,13 @@ class BedAvailabilityHardeningTest extends BaseIntegrationTest {
         ResponseEntity<String> response = restTemplate.exchange(
                 "/api/v1/shelters", HttpMethod.POST,
                 new HttpEntity<>(body, headers), String.class);
+        assertEquals(HttpStatus.CREATED, response.getStatusCode(),
+                "POST /shelters should return 201 — body: " + response.getBody());
         String responseBody = response.getBody();
-        assertNotNull(responseBody);
-        // Extract shelter ID from response
-        String idStr = responseBody.substring(responseBody.indexOf("\"id\":\"") + 6, responseBody.indexOf("\"", responseBody.indexOf("\"id\":\"") + 6));
+        assertNotNull(responseBody, "Response body should not be null");
+        int idStart = responseBody.indexOf("\"id\":\"") + 6;
+        assertTrue(idStart > 5, "Field 'id' not found in response: " + responseBody);
+        String idStr = responseBody.substring(idStart, responseBody.indexOf("\"", idStart));
         return UUID.fromString(idStr);
     }
 

--- a/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
@@ -4,6 +4,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.fabt.BaseIntegrationTest;
 import org.fabt.TestAuthHelper;
 import org.fabt.hmis.domain.HmisInventoryRecord;
@@ -231,7 +233,10 @@ class HmisBridgeIntegrationTest extends BaseIntegrationTest {
                 }
                 """, name, dvShelter, dvShelter ? "DV_SURVIVOR" : "SINGLE_ADULT",
                 dvShelter ? "DV_SURVIVOR" : "SINGLE_ADULT");
-        restTemplate.exchange("/api/v1/shelters", HttpMethod.POST,
+        ResponseEntity<String> resp = restTemplate.exchange("/api/v1/shelters", HttpMethod.POST,
                 new HttpEntity<>(body, adminHeaders), String.class);
+        if (resp.getStatusCode() != HttpStatus.CREATED && resp.getStatusCode() != HttpStatus.CONFLICT) {
+            throw new AssertionError("POST /shelters returned " + resp.getStatusCode() + " — body: " + resp.getBody());
+        }
     }
 }

--- a/backend/src/test/java/org/fabt/referral/DvReferralIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/referral/DvReferralIntegrationTest.java
@@ -492,6 +492,8 @@ class DvReferralIntegrationTest extends BaseIntegrationTest {
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/shelters", HttpMethod.POST,
                 new HttpEntity<>(body, adminHeaders), String.class);
+        assertEquals(HttpStatus.CREATED, resp.getStatusCode(),
+                "POST /shelters should return 201 — body: " + resp.getBody());
         return UUID.fromString(extractField(resp.getBody(), "id"));
     }
 
@@ -520,7 +522,9 @@ class DvReferralIntegrationTest extends BaseIntegrationTest {
 
     private String extractField(String json, String field) {
         int idx = json.indexOf("\"" + field + "\":\"");
-        if (idx < 0) return null;
+        if (idx < 0) {
+            throw new AssertionError("Field '" + field + "' not found in response: " + json);
+        }
         int start = idx + field.length() + 4;
         int end = json.indexOf("\"", start);
         return json.substring(start, end);

--- a/backend/src/test/java/org/fabt/security/CrossTenantIsolationTest.java
+++ b/backend/src/test/java/org/fabt/security/CrossTenantIsolationTest.java
@@ -295,10 +295,14 @@ class CrossTenantIsolationTest extends BaseIntegrationTest {
                 HttpMethod.POST,
                 new HttpEntity<>(body, headers),
                 String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getStatusCode())
+                .as("POST /shelters should return 201 — body: %s", response.getBody())
+                .isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getBody()).as("Response body should not be null").isNotNull();
 
         String responseBody = response.getBody();
         int idStart = responseBody.indexOf("\"id\":\"") + 6;
+        assertThat(idStart).as("Field 'id' not found in response: %s", responseBody).isGreaterThan(5);
         int idEnd = responseBody.indexOf("\"", idStart);
         return UUID.fromString(responseBody.substring(idStart, idEnd));
     }

--- a/backend/src/test/java/org/fabt/shelter/DvAddressRedactionTest.java
+++ b/backend/src/test/java/org/fabt/shelter/DvAddressRedactionTest.java
@@ -264,8 +264,12 @@ class DvAddressRedactionTest extends BaseIntegrationTest {
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/shelters", HttpMethod.POST,
                 new HttpEntity<>(body, adminHeaders), String.class);
+        assertEquals(HttpStatus.CREATED, resp.getStatusCode(),
+                "POST /shelters should return 201 — body: " + resp.getBody());
         String respBody = resp.getBody();
+        assertNotNull(respBody, "Response body should not be null");
         int idx = respBody.indexOf("\"id\":\"") + 6;
+        assertTrue(idx > 5, "Field 'id' not found in response: " + respBody);
         return UUID.fromString(respBody.substring(idx, respBody.indexOf("\"", idx)));
     }
 

--- a/e2e/playwright/tests/app-version.spec.ts
+++ b/e2e/playwright/tests/app-version.spec.ts
@@ -7,23 +7,17 @@ import { test as authTest } from '../fixtures/auth.fixture';
  * Verifies version is visible on the login page (unauthenticated)
  * and in the authenticated layout footer.
  *
- * NOTE: Version endpoint requires BuildProperties (build-info Maven goal).
- * In dev mode without a Maven build, the endpoint may not exist —
- * tests skip gracefully if version is not available.
+ * NOTE: Version endpoint requires BuildProperties (spring-boot:build-info goal).
+ * The E2E CI workflow must include this goal — if not, these tests FAIL
+ * (not skip) to expose the configuration gap.
  */
 
 base.describe('Version on Login Page', () => {
   base('version is visible in login page footer', async ({ page }) => {
     await page.goto('/login');
-    await page.waitForTimeout(2000);
 
     const version = page.locator('[data-testid="app-version"]');
-    if (await version.count() === 0) {
-      // BuildProperties not available (dev mode) — skip gracefully
-      base.skip();
-      return;
-    }
-    await expect(version).toBeVisible();
+    await expect(version).toBeVisible({ timeout: 10000 });
     const text = await version.textContent();
     expect(text).toMatch(/v\d+\.\d+/);
   });
@@ -32,14 +26,9 @@ base.describe('Version on Login Page', () => {
 authTest.describe('Version in Authenticated Layout', () => {
   authTest('version is visible in admin panel footer', async ({ adminPage }) => {
     await adminPage.goto('/admin');
-    await adminPage.waitForTimeout(2000);
 
     const version = adminPage.locator('[data-testid="app-version"]');
-    if (await version.count() === 0) {
-      authTest.skip();
-      return;
-    }
-    await expect(version).toBeVisible();
+    await expect(version).toBeVisible({ timeout: 10000 });
     const text = await version.textContent();
     expect(text).toMatch(/Finding A Bed Tonight v\d+\.\d+/);
   });


### PR DESCRIPTION
## Summary

Two CI reliability fixes — test helpers that NPE on cold start + app-version test that always skips.

### #50 — Response validation in test helpers (5 files)
Test helpers extract `id` from API responses without checking HTTP status. On cold start (401/403/500), `extractField()` returns null → NPE. Fixed with assert-then-extract pattern in all 5 affected files.

### #49 — app-version test always skips
**Root cause:** The `waitForTimeout(2000)` + `count === 0` skip pattern is a Playwright anti-pattern. The admin page has more competing data fetches than the login page, so the version element doesn't render within 2 seconds — causing the test to skip instead of waiting.

**Fix:** Replace `waitForTimeout` + skip with `toBeVisible({ timeout: 10000 })`. Playwright's web-first assertions internally poll (re-check repeatedly) and return immediately when the condition is met. The test now FAILS on missing elements instead of silently skipping.

**Also:** Added explicit `spring-boot:build-info` to E2E and DV canary CI workflow compile steps (belt-and-suspenders — the POM binding already runs it during `generate-resources`, but making it explicit matches `dev-start.sh` and documents the dependency).

## Test plan
- [x] Backend: 388 tests pass with new assertions
- [ ] CI: app-version test should now PASS (not skip)
- [ ] CI: DV canary job build-info goal added

Closes #49, closes #50

🤖 Generated with [Claude Code](https://claude.com/claude-code)