### PR TITLE
Fix webhook delivery read timeout, add WireMock test coverage (#51)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,33 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased] — Platform Hardening Phase 1 Follow-up
+
+### Fixed
+- **Webhook delivery read timeout** — `WebhookDeliveryService` documented a 30s read timeout in design D3 but only the connect timeout (10s) was actually wired into `JdkClientHttpRequestFactory`. JDK `HttpClient` has no per-client read timeout, so a hanging webhook subscriber would block a virtual thread until the JVM died. Marcus Webb's lens: documented timeouts that don't exist are a security gap. Discovered while writing `WebhookTimeoutTest` — exactly what the test was for.
+
+### Added
+- **Configurable webhook timeouts** — both timeouts are now constructor-injected and configurable:
+  - `fabt.webhook.connect-timeout-seconds` (env: `FABT_WEBHOOK_CONNECT_TIMEOUT_SECONDS`, default `10`)
+  - `fabt.webhook.read-timeout-seconds` (env: `FABT_WEBHOOK_READ_TIMEOUT_SECONDS`, default `30`)
+  - Defaults preserve the original D3 contract. Slow legacy partners can be granted extended timeouts via env var without code changes.
+- **`WebhookTestEventDeliveryTest`** (T-25) — 4 integration tests covering the `POST /api/v1/subscriptions/{id}/test` endpoint: HMAC signing format, X-Test-Event header, JSON body shape, success/failure recording, 404 on missing subscription. Uses WireMock to verify the full transport path.
+- **`WebhookTimeoutTest`** (T-25a) — 2 integration tests verifying the read timeout fires (1s configured timeout vs 3s WireMock delay → completes in ~1.1s, failure recorded, never reports the upstream's would-be 200) and that fast endpoints under the timeout still succeed.
+- **WireMock 3.13.2** test dependency (`org.wiremock:wiremock-standalone`, test scope). Spring Framework explicitly recommends mock web servers over `MockRestServiceServer` for RestClient testing because they exercise the real transport layer and can simulate timeouts. Validated against Java 25 / Spring Boot 4. Matches portfolio standard `PLATFORM-STANDARDS.md §10`.
+
+### Changed
+- `WebhookDeliveryService` constructor signature: added `@Value("${fabt.webhook.connect-timeout-seconds:10}")` and `@Value("${fabt.webhook.read-timeout-seconds:30}")` parameters. Spring DI handles defaults — existing test contexts continue to work without overrides.
+
+### Test Results
+- Backend: **502 passed**, 0 failures, 0 errors (up from 425 at v0.30.0)
+- ArchUnit: **22 passed** — modular monolith boundaries intact
+- Webhook test classes: 20 (existing) + 4 (T-25) + 2 (T-25a) + 6 (resilience) = 32, all green
+
+### Spec
+- `openspec/changes/platform-hardening/`: tasks T-25, T-25a, T-43, T-PD-2, T-9a, T-24g marked done with evidence; T-24b and T-64l marked REJECTED with rationale (the implementation pattern eliminated the cases the tests would have covered); design D3a documents the timeout configurability decision.
+
+---
+
 ## [v0.32.1] — 2026-04-09 — Bed Search Performance Optimization
 
 ### Changed

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -207,6 +207,16 @@
             <version>2.1.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- WireMock — mock HTTP server for webhook delivery integration tests (T-25, T-25a).
+             Spring Framework recommends mock web servers over MockRestServiceServer for
+             RestClient testing because they exercise the real transport layer and can
+             simulate timeouts. Standard per portfolio PLATFORM-STANDARDS.md §10. -->
+        <dependency>
+            <groupId>org.wiremock</groupId>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.13.2</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-csv</artifactId>

--- a/backend/src/main/java/org/fabt/subscription/service/WebhookDeliveryService.java
+++ b/backend/src/main/java/org/fabt/subscription/service/WebhookDeliveryService.java
@@ -27,9 +27,11 @@ import io.github.resilience4j.circuitbreaker.CircuitBreaker;
 import io.github.resilience4j.circuitbreaker.CircuitBreakerRegistry;
 import io.github.resilience4j.retry.Retry;
 import io.github.resilience4j.retry.RetryRegistry;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.event.EventListener;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.JdkClientHttpRequestFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestClient;
 import org.springframework.web.client.RestClientResponseException;
@@ -60,15 +62,23 @@ public class WebhookDeliveryService {
                                   RestClient.Builder restClientBuilder,
                                   ObservabilityMetrics metrics,
                                   CircuitBreakerRegistry circuitBreakerRegistry,
-                                  RetryRegistry retryRegistry) {
+                                  RetryRegistry retryRegistry,
+                                  @Value("${fabt.webhook.connect-timeout-seconds:10}") int connectTimeoutSeconds,
+                                  @Value("${fabt.webhook.read-timeout-seconds:30}") int readTimeoutSeconds) {
         this.subscriptionService = subscriptionService;
         this.objectMapper = objectMapper;
-        // Timeouts: 10s connect, 30s read per design D3
+        // Timeouts per design D3: connect (default 10s) protects against unreachable
+        // endpoints, read (default 30s) protects against hanging endpoints. The read
+        // timeout MUST be set on the request factory — JDK HttpClient has no per-client
+        // read timeout, so without setReadTimeout() a slow endpoint blocks the virtual
+        // thread indefinitely (Marcus Webb finding, 2026-04-09).
+        JdkClientHttpRequestFactory requestFactory = new JdkClientHttpRequestFactory(
+                HttpClient.newBuilder()
+                        .connectTimeout(Duration.ofSeconds(connectTimeoutSeconds))
+                        .build());
+        requestFactory.setReadTimeout(Duration.ofSeconds(readTimeoutSeconds));
         this.restClient = restClientBuilder
-                .requestFactory(new org.springframework.http.client.JdkClientHttpRequestFactory(
-                        HttpClient.newBuilder()
-                                .connectTimeout(Duration.ofSeconds(10))
-                                .build()))
+                .requestFactory(requestFactory)
                 .build();
         this.metrics = metrics;
         this.deliveryExecutor = Executors.newVirtualThreadPerTaskExecutor();

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -150,6 +150,13 @@ fabt:
     noaa:
       coordinates: ${FABT_NOAA_LAT:35.8776},${FABT_NOAA_LON:-78.7875}
       station-id: ${FABT_NOAA_STATION:KRDU}
+  webhook:
+    # Webhook delivery timeouts (design D3). The read timeout protects virtual
+    # threads against hanging callback endpoints — without it, a misbehaving
+    # subscriber can pin a delivery thread until the JVM dies. Override per
+    # tenant via FABT_WEBHOOK_*_SECONDS env vars only if a partner needs longer.
+    connect-timeout-seconds: ${FABT_WEBHOOK_CONNECT_TIMEOUT_SECONDS:10}
+    read-timeout-seconds: ${FABT_WEBHOOK_READ_TIMEOUT_SECONDS:30}
 
 # Rate limiting — brute force protection on auth endpoints
 # Uses JCache (JSR-107) backed by Caffeine for bucket4j

--- a/backend/src/test/java/org/fabt/subscription/WebhookTestEventDeliveryTest.java
+++ b/backend/src/test/java/org/fabt/subscription/WebhookTestEventDeliveryTest.java
@@ -1,0 +1,218 @@
+package org.fabt.subscription;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+import com.github.tomakehurst.wiremock.matching.RequestPatternBuilder;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.subscription.service.SubscriptionService;
+import org.fabt.subscription.service.WebhookDeliveryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.matchingJsonPath;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * T-25: Integration test for the webhook test-event endpoint
+ * (POST /api/v1/subscriptions/{id}/test).
+ *
+ * <p>Uses WireMock as a mock subscriber endpoint to verify the full transport
+ * path: HMAC signing, headers, JSON body, and delivery logging. Spring Framework
+ * recommends mock web servers over MockRestServiceServer for RestClient testing
+ * because they exercise the real HTTP layer.</p>
+ *
+ * <p><b>Persona drivers:</b></p>
+ * <ul>
+ *   <li>Marcus Okafor (CoC admin): "Send Test" is the button he clicks during
+ *       partner onboarding. If it silently fails, he wastes a partner call.</li>
+ *   <li>Marcus Webb (pen tester): every untested authorization/transport path
+ *       is a finding waiting to happen.</li>
+ * </ul>
+ */
+@DisplayName("Webhook Test Event Delivery (T-25)")
+class WebhookTestEventDeliveryTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private SubscriptionService subscriptionService;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private WireMockServer wireMock;
+    private UUID subscriptionId;
+
+    @BeforeEach
+    void setUp() {
+        // Random port — multiple test classes can run in parallel without collisions
+        wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        WireMock.configureFor("localhost", wireMock.port());
+
+        authHelper.setupTestTenant();
+        authHelper.setupAdminUser();
+
+        // Create a subscription pointing at the WireMock server
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = """
+                {"eventType":"availability.updated","filter":{},
+                 "callbackUrl":"http://localhost:%d/webhook",
+                 "callbackSecret":"test-secret-T25-abcdef"}
+                """.formatted(wireMock.port());
+        ResponseEntity<Map<String, Object>> resp = restTemplate.exchange(
+                "/api/v1/subscriptions", HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                new ParameterizedTypeReference<>() {});
+        subscriptionId = UUID.fromString((String) resp.getBody().get("id"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (wireMock != null) {
+            wireMock.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("POST /test delivers synthetic event to subscriber and returns delivery result")
+    void sendTestEvent_succeeds_andRecordsDelivery() {
+        // Arrange — subscriber returns 200 OK with a small body
+        wireMock.stubFor(post(urlEqualTo("/webhook"))
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("{\"received\":true}")));
+
+        // Act
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<WebhookDeliveryService.TestDeliveryResult> resp = restTemplate.exchange(
+                "/api/v1/subscriptions/" + subscriptionId + "/test", HttpMethod.POST,
+                new HttpEntity<>("{\"eventType\":\"availability.updated\"}", headers),
+                WebhookDeliveryService.TestDeliveryResult.class);
+
+        // Assert — endpoint contract
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody()).isNotNull();
+        assertThat(resp.getBody().statusCode()).isEqualTo(200);
+        assertThat(resp.getBody().responseTimeMs()).isGreaterThanOrEqualTo(0);
+        assertThat(resp.getBody().responseBody()).contains("received");
+
+        // Assert — WireMock saw a well-formed delivery
+        RequestPatternBuilder expected = postRequestedFor(urlEqualTo("/webhook"))
+                .withHeader("Content-Type", WireMock.containing("application/json"))
+                .withHeader("X-Signature", WireMock.matching("sha256=[0-9a-f]+"))
+                .withHeader("X-Test-Event", WireMock.equalTo("true"))
+                .withRequestBody(matchingJsonPath("$.type", WireMock.equalTo("availability.updated")))
+                .withRequestBody(matchingJsonPath("$.test", WireMock.equalTo("true")))
+                .withRequestBody(matchingJsonPath("$.id"))
+                .withRequestBody(matchingJsonPath("$.timestamp"));
+        wireMock.verify(1, expected);
+
+        // Assert — delivery was logged
+        Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM webhook_delivery_log WHERE subscription_id = ? AND status_code = 200",
+                Integer.class, subscriptionId);
+        assertThat(rows).as("Successful test delivery should be recorded with status 200")
+                .isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("POST /test on subscriber returning 500 records failure but does NOT auto-disable")
+    void sendTestEvent_5xxResponse_recordsFailureWithoutAutoDisable() {
+        // Arrange — subscriber returns 500
+        wireMock.stubFor(post(urlEqualTo("/webhook"))
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withBody("Internal Server Error")));
+
+        // Act — capture as String so we can diagnose the actual envelope
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> raw = restTemplate.exchange(
+                "/api/v1/subscriptions/" + subscriptionId + "/test", HttpMethod.POST,
+                new HttpEntity<>("{\"eventType\":\"availability.updated\"}", headers),
+                String.class);
+
+        // The endpoint always returns 200 with the result envelope; the subscriber's
+        // status code lives inside the body.
+        assertThat(raw.getStatusCode())
+                .as("Test endpoint must return 200 even when delivery fails")
+                .isEqualTo(HttpStatus.OK);
+        assertThat(raw.getBody()).isNotNull();
+        // sendTestEvent's catch branch records null statusCode for non-2xx (RestClient throws)
+        // — assert we did not silently report success.
+        assertThat(raw.getBody())
+                .as("Body must not claim upstream returned 200")
+                .doesNotContain("\"statusCode\":200");
+
+        // Failure was logged
+        Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM webhook_delivery_log WHERE subscription_id = ?",
+                Integer.class, subscriptionId);
+        assertThat(rows).as("Failed test delivery should still be recorded").isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("POST /test on missing subscription returns 404")
+    void sendTestEvent_unknownSubscription_returns404() {
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> resp = restTemplate.exchange(
+                "/api/v1/subscriptions/" + UUID.randomUUID() + "/test", HttpMethod.POST,
+                new HttpEntity<>("{\"eventType\":\"availability.updated\"}", headers),
+                String.class);
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("POST /test signature is reproducible — same body → same HMAC")
+    void sendTestEvent_signatureIsHmacSha256() {
+        wireMock.stubFor(post(urlEqualTo("/webhook"))
+                .willReturn(aResponse().withStatus(200).withBody("ok")));
+
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        restTemplate.exchange(
+                "/api/v1/subscriptions/" + subscriptionId + "/test", HttpMethod.POST,
+                new HttpEntity<>("{\"eventType\":\"availability.updated\"}", headers),
+                WebhookDeliveryService.TestDeliveryResult.class);
+
+        // Marcus Webb's lens: every signed request must have a verifiable signature.
+        // We don't recompute the HMAC here (we'd need the encryption key), but we
+        // verify the format is correct: sha256=<64 hex chars>.
+        wireMock.verify(1, postRequestedFor(urlEqualTo("/webhook"))
+                .withHeader("X-Signature", WireMock.matching("sha256=[0-9a-f]{64}")));
+
+        // Sanity: there is exactly one delivery log entry, regardless of which
+        // record path was taken (success vs. caught exception).
+        @SuppressWarnings("unused")
+        List<Map<String, Object>> logs = jdbcTemplate.queryForList(
+                "SELECT * FROM webhook_delivery_log WHERE subscription_id = ?",
+                subscriptionId);
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM webhook_delivery_log WHERE subscription_id = ?",
+                Integer.class, subscriptionId);
+        assertThat(count).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/org/fabt/subscription/WebhookTimeoutTest.java
+++ b/backend/src/test/java/org/fabt/subscription/WebhookTimeoutTest.java
@@ -1,0 +1,164 @@
+package org.fabt.subscription;
+
+import java.util.Map;
+import java.util.UUID;
+
+import com.github.tomakehurst.wiremock.WireMockServer;
+import com.github.tomakehurst.wiremock.client.WireMock;
+import com.github.tomakehurst.wiremock.core.WireMockConfiguration;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.subscription.service.WebhookDeliveryService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.aResponse;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * T-25a: Integration test for webhook delivery read timeout.
+ *
+ * <p>Design D3 specifies a 30s read timeout. Investigation 2026-04-09 found that
+ * only the connect timeout was actually wired into the JDK HttpClient — there was
+ * no read timeout, so a slow endpoint would block a virtual thread indefinitely.
+ * Marcus Webb's lens: documented timeouts that don't exist are a security gap.</p>
+ *
+ * <p>This test uses a tiny configured timeout (1s) and a WireMock fixed delay
+ * (3s) so the test runs quickly. It verifies the timeout fires, the failure is
+ * recorded, and the delivery result envelope reports an error rather than a
+ * silent success.</p>
+ */
+@DisplayName("Webhook Delivery Timeout (T-25a)")
+@TestPropertySource(properties = {
+        "fabt.webhook.connect-timeout-seconds=10",
+        "fabt.webhook.read-timeout-seconds=1"
+})
+class WebhookTimeoutTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private WireMockServer wireMock;
+    private UUID subscriptionId;
+
+    @BeforeEach
+    void setUp() {
+        wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        WireMock.configureFor("localhost", wireMock.port());
+
+        authHelper.setupTestTenant();
+        authHelper.setupAdminUser();
+
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = """
+                {"eventType":"availability.updated","filter":{},
+                 "callbackUrl":"http://localhost:%d/webhook",
+                 "callbackSecret":"test-secret-T25a-abcdef"}
+                """.formatted(wireMock.port());
+        ResponseEntity<Map<String, Object>> resp = restTemplate.exchange(
+                "/api/v1/subscriptions", HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                new ParameterizedTypeReference<>() {});
+        subscriptionId = UUID.fromString((String) resp.getBody().get("id"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (wireMock != null) {
+            wireMock.stop();
+        }
+    }
+
+    @Test
+    @DisplayName("Slow endpoint exceeding read timeout fails the test delivery")
+    void slowEndpoint_exceedsReadTimeout_recordedAsFailure() {
+        // Subscriber sleeps 3s before responding; configured read timeout is 1s
+        wireMock.stubFor(post(urlEqualTo("/webhook"))
+                .willReturn(aResponse()
+                        .withFixedDelay(3000)
+                        .withStatus(200)
+                        .withBody("would have been ok")));
+
+        long start = System.currentTimeMillis();
+
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<String> raw = restTemplate.exchange(
+                "/api/v1/subscriptions/" + subscriptionId + "/test", HttpMethod.POST,
+                new HttpEntity<>("{\"eventType\":\"availability.updated\"}", headers),
+                String.class);
+
+        long elapsedMs = System.currentTimeMillis() - start;
+
+        // The endpoint must return 200 with the result envelope (not propagate the
+        // delivery failure as a server error — the test endpoint reports the result
+        // in the body, not via HTTP status)
+        assertThat(raw.getStatusCode())
+                .as("Test endpoint must return 200 even when delivery fails — failure lives in the body")
+                .isEqualTo(HttpStatus.OK);
+        assertThat(raw.getBody()).isNotNull();
+
+        // The body must indicate failure (statusCode is null when the RestClient
+        // threw on timeout) — never the upstream's would-be 200.
+        assertThat(raw.getBody())
+                .as("Body must not report upstream's would-be 200")
+                .doesNotContain("\"statusCode\":200");
+
+        // Most important: we did not wait for the upstream to finish.
+        // 3s upstream delay > 1s read timeout — total elapsed should be well under 3s.
+        // Allow generous slack for CI overhead but still prove the timeout fired.
+        assertThat(elapsedMs)
+                .as("Read timeout must fire well before the upstream's 3s delay completes")
+                .isLessThan(2500);
+
+        // The failure was logged
+        Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM webhook_delivery_log WHERE subscription_id = ?",
+                Integer.class, subscriptionId);
+        assertThat(rows).as("Timed-out delivery must still be recorded").isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("Fast endpoint within timeout still succeeds")
+    void fastEndpoint_underTimeout_succeeds() {
+        // Subscriber responds well within the 1s read timeout
+        wireMock.stubFor(post(urlEqualTo("/webhook"))
+                .willReturn(aResponse()
+                        .withFixedDelay(100)
+                        .withStatus(200)
+                        .withBody("ok")));
+
+        HttpHeaders headers = authHelper.adminHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<WebhookDeliveryService.TestDeliveryResult> resp = restTemplate.exchange(
+                "/api/v1/subscriptions/" + subscriptionId + "/test", HttpMethod.POST,
+                new HttpEntity<>("{\"eventType\":\"availability.updated\"}", headers),
+                WebhookDeliveryService.TestDeliveryResult.class);
+
+        assertThat(resp.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(resp.getBody()).isNotNull();
+        assertThat(resp.getBody().statusCode()).isEqualTo(200);
+
+        Integer rows = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM webhook_delivery_log WHERE subscription_id = ? AND status_code = 200",
+                Integer.class, subscriptionId);
+        assertThat(rows).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
## Summary

- **Read timeout bug fix:** `WebhookDeliveryService` documented a 30s read timeout (design D3), but only the connect timeout was actually wired into `JdkClientHttpRequestFactory`. JDK `HttpClient` has no per-client read timeout — a hanging webhook subscriber would block a virtual thread until the JVM died. Marcus Webb's lens: documented timeouts that don't exist are a security gap.
- **Configurable timeouts:** both timeouts are now constructor-injected via `fabt.webhook.connect-timeout-seconds` (default 10) and `fabt.webhook.read-timeout-seconds` (default 30). Defaults preserve the original D3 contract; partners with slow legacy endpoints can be granted extended windows via env var without code changes.
- **Two new test classes** using WireMock 3.13.2 (Spring Framework's recommended approach for `RestClient` transport-layer testing):
  - `WebhookTestEventDeliveryTest` (T-25, 4 tests) — verifies the `POST /api/v1/subscriptions/{id}/test` full transport path: HMAC signing format, headers, JSON body shape, success/failure recording, 404 on missing subscription
  - `WebhookTimeoutTest` (T-25a, 2 tests) — verifies the read timeout fires correctly (1s configured timeout vs 3s WireMock fixed delay → completes in ~1.1s, failure recorded, never reports the upstream's would-be 200) and that fast endpoints under the timeout still succeed
- **WireMock 3.13.2** added as test-scope dependency. Spring Framework explicitly recommends mock web servers over `MockRestServiceServer` for `RestClient` testing because they exercise the real transport layer and can simulate timeouts. Matches portfolio standard `PLATFORM-STANDARDS.md §10`. Validated against Java 25 / Spring Boot 4.

## Context

Discovered while verifying issue #51 (platform-hardening) against the post-v0.30.0 codebase. The bug T-25a was meant to test was real — the test caught it. Spec updates landed in the docs repo at `findABed@b8facb8`.

## Test plan

- [x] `mvn test -Dtest='WebhookTestEventDeliveryTest,WebhookTimeoutTest'` → 6/6 green
- [x] `mvn clean test` → **502 passed, 0 failures, 0 errors** (up from 425 at v0.30.0)
- [x] ArchUnit → 22/22 (modular monolith boundaries intact)
- [x] No regressions in Webhook Management (20/20), Subscription Integration (5/5), Webhook Resilience (6/6)
- [ ] CI pipeline green (CodeQL, OWASP dependency-check, etc.)
- [ ] Manual smoke: ensure existing webhook subscribers still work with the new constructor signature (Spring DI handles defaults)

## Persona-aligned outcomes

- **Marcus Webb (pen tester):** the documented timeout now exists and is verified. No more silent doc/code drift in transport-layer security claims.
- **Marcus Okafor (CoC admin):** the "Send Test" button is now load-bearing — won't silently fail during partner onboarding.
- **Alex Chen (principal):** WireMock matches the portfolio standard. Configurable timeout is a cleaner boundary than a hardcoded constant.
- **Riley Cho (QA):** "What happens to the person in crisis if this test is missing?" — Now it's not missing.
- **Jordan Reyes (SRE):** WireMock's diagnostic output is best-in-class for 3am CI debugging.

## Related

- Issue #51 (platform hardening — Marcus Webb's 6 pen test findings)
- Spec: `openspec/changes/platform-hardening` (T-25, T-25a, T-9a, T-FU-1..5)

🤖 Generated with [Claude Code](https://claude.com/claude-code)