### PR TITLE
multi-tenant-production-readiness Phase A5: V74 re-encrypt migration (task 2.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,34 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased] — multi-tenant-production-readiness Phases 0 + A (Issue #126)
+## [Unreleased] — multi-tenant-production-readiness Phases 0 + A + A5 (Issue #126)
+
+### ⚠️ v0.41 → v0.42 is effectively ONE-WAY
+
+V74 re-encrypts every existing TOTP / webhook / OAuth2 / HMIS ciphertext from the single-platform-key v0 envelope to per-tenant-DEK v1 envelopes. **v0.41 container images do NOT understand v1 envelopes** — deploying v0.41 against a post-V74 database breaks TOTP login, webhook signing, OAuth2 SSO, and HMIS outbound calls silently at request time. Rollback requires restoring the pre-deploy pg_dump backup (runbook 2.16).
+
+**Release gate:** v0.42 MUST ship Phase 0 + Phase A + Phase A5 (V74) together. No valid Phase-0-only v0.41.x release line exists. Per C-A5-N8, the V74 migration itself refuses to run without V60 + V61 applied — release-process belt-and-suspenders.
+
+### Phase A5 — V74 re-encrypt migration + callsite refactor (task 2.13)
+
+**Completes Phase A** — sweeps every existing v0 ciphertext (single-platform-key) to a v1 per-tenant-DEK envelope; refactors all encrypt/decrypt callsites to the typed `encryptForTenant` / `decryptForTenant` API.
+
+#### Added — Phase A5
+- **`V74__reencrypt_secrets_under_per_tenant_deks.java`** — idempotent Java Flyway migration sweeping four columns: `app_user.totp_secret_encrypted`, `subscription.callback_secret_hash`, `tenant_oauth2_provider.client_secret_encrypted`, and `tenant.config → hmis_vendors[].api_key_encrypted`. Preflights Phase A presence (fails loudly without V60+V61), bounds `lock_timeout`+`statement_timeout`, filters `WHERE tenant_id IS NOT NULL`, takes `FOR UPDATE` row locks, round-trip-verifies each re-encrypted row before commit, hardens the JSONB parser with explicit `StreamReadConstraints`, and emits a `SYSTEM_MIGRATION_V74_REENCRYPT` audit row with expanded JSONB (`duration_ms`, master-KEK fingerprint, Flyway session role, per-column reencrypted/skipped-v1/skipped-null-tenant counts).
+- **`SecretEncryptionService` v0-fallback observability (C-A5-N4)** — every v0 decrypt post-V74 increments `fabt.security.v0_decrypt_fallback.count` (tagged by purpose + tenant_id) and emits a throttled `CIPHERTEXT_V0_DECRYPT` audit event (≤ 1 per tenant+purpose per 60s). Catches both stuck-row repair cases AND hostile v0-forgery downgrade attacks.
+- **Service-layer per-tenant refactor (D38 + D39).** `TotpService.encryptSecret/decryptSecret`, `SubscriptionService.decryptCallbackSecret`, and `HmisConfigService.encryptApiKey/decryptApiKey` now take `UUID tenantId` explicitly. `SubscriptionService.create` + `TenantOAuth2ProviderService.create`/`update` + `DynamicClientRegistrationSource.decryptClientSecret` internally call `encryptForTenant` / `decryptForTenant` with the appropriate `KeyPurpose`. All four controllers/delivery paths (`TotpController` x2, `AuthController` MFA verify, `WebhookDeliveryService` x2) pass the tenantId from the `User` / `Subscription` in hand.
+- **`design-a5-v74-reencrypt.md`** — 42 decisions (D30–D42) + 10 warroom-resolved questions + 12-row risk register + 10 critical + 7 strong-warning items from the Marcus + Jordan + Sam warroom.
+
+#### Hardened — Phase A5
+- **`SecretEncryptionService.encrypt/decrypt` legacy methods** marked `@Deprecated(since = "v0.42", forRemoval = true)` targeting Phase L. Retained only for V74 migration internal use; ArchUnit Family F will block application-code use post-Phase-L.
+- **`CiphertextV0Decoder`** class-level Javadoc carries an explicit "DO NOT REMOVE — defense-in-depth contract per design-a5-v74 D42" statement with pointer to the design doc, protecting the permanent v0 fallback path from future YAGNI-deletion.
+
+#### Test coverage — Phase A5
+- **`V74ReencryptIntegrationTest`** (6 cases) — T1 happy-path round-trip, T2 idempotency on re-run, T3 cross-tenant DEK separation, T5 empty-state no-op, T9 audit row shape, T11 `KeyPurpose.values()` round-trip.
+- **Existing service ITs (`HmisEncryptionRoundTripIntegrationTest`, `OAuth2EncryptionRoundTripIntegrationTest`, `TotpAndAccessCodeIntegrationTest`, `TenantGuardUnitTest`, `PerTenantEncryptionIntegrationTest`, `V59ReencryptPlaintextCredentialsTest`)** updated to assert v1 envelope production post-refactor — 49/49 green.
+
+#### Migrations — Phase A5
+- **V74** — single Java migration. One transaction. Commit semantics: Flyway atomic rollback on mid-migration failure; no reverse migration. See runbook 2.16 for pre-deploy pg_dump procedure.
 
 ### Phase A — Per-tenant JWT signing keys + DEK derivation (PR forthcoming)
 

--- a/backend/src/main/java/db/migration/V74__reencrypt_secrets_under_per_tenant_deks.java
+++ b/backend/src/main/java/db/migration/V74__reencrypt_secrets_under_per_tenant_deks.java
@@ -1,0 +1,847 @@
+package db.migration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * V74 — Re-encrypt existing v0 ciphertexts under per-tenant HKDF-derived DEKs
+ * (Phase A task 2.13, design-a5-v74-reencrypt). Covers the four per-tenant
+ * encrypted columns per A3 D22:
+ *
+ * <ol>
+ *   <li>{@code app_user.totp_secret_encrypted} — TOTP shared secrets</li>
+ *   <li>{@code subscription.callback_secret_hash} — webhook HMAC secrets</li>
+ *   <li>{@code tenant_oauth2_provider.client_secret_encrypted} — OAuth2 client secrets</li>
+ *   <li>{@code tenant.config → hmis_vendors[].api_key_encrypted} — HMIS API keys (JSONB)</li>
+ * </ol>
+ *
+ * <h2>Idempotency (D31)</h2>
+ * Each candidate value is Base64-decoded and checked for the v1 envelope magic
+ * ({@code "FABT\x01"}). Already-v1 rows are counted as {@code skipped_already_v1}
+ * and left untouched. Only v0 rows (no FABT magic) are decrypted under the
+ * platform key and re-encrypted under the tenant DEK. Re-run safe.
+ *
+ * <h2>Transaction scope (D32)</h2>
+ * Single Flyway transaction. At pilot scale (≤10 users × 1 TOTP + ≤5 subscriptions
+ * per tenant + handful of OAuth2 providers + handful of HMIS vendors ≈ tens of KB
+ * in-flight) this is trivially small. Row-exclusive locks taken on every modified
+ * row are held for migration duration; at pilot scale this is under a second.
+ *
+ * <p><b>Memory footprint:</b> all candidate ciphertexts are loaded into JVM heap
+ * for round-trip decrypt+encrypt. At pilot scale this is negligible. If the
+ * target schema has &gt; 10k re-encryptable rows per column, re-evaluate this
+ * migration in favor of batched per-row transactions with an outer retry loop.
+ * (W-A5-7)
+ *
+ * <h2>Per-row round-trip verify (C-A5-N3)</h2>
+ * After every v0→v1 conversion, the new v1 bytes are immediately decrypted under
+ * the same per-tenant DEK and compared to the original plaintext. Catches
+ * tenant_id drift, GCM key misalignment, HKDF salt misconfiguration. Mismatch
+ * fails the whole Flyway transaction.
+ *
+ * <h2>Observability (D35 / C-A5-N10)</h2>
+ * Writes a single {@code SYSTEM_MIGRATION_V74_REENCRYPT} audit row at the end
+ * of the migration with expanded JSONB: counts per column (re-encrypted /
+ * skipped-already-v1 / skipped-null-tenant), timing, master-KEK fingerprint,
+ * and the Flyway session role. JSONB is produced via {@link JsonMapper} to
+ * avoid SQL-injection-adjacent {@code String.format} patterns (W-A5-1).
+ *
+ * <h2>Dev-skip (C-A5-N9)</h2>
+ * If {@code FABT_ENCRYPTION_KEY} is unset, logs WARN and returns cleanly. No
+ * audit row. Flyway still marks V74 as APPLIED — if an operator later sets the
+ * env var in dev, V74 will NOT re-run automatically. Recovery: {@code DELETE
+ * FROM flyway_schema_history WHERE version = '74'} and restart the stack. In
+ * prod, the Phase 0 C2 + Phase A W-A4-3 startup guards fail-fast before Flyway
+ * even runs without a key, so this branch is unreachable in prod.
+ *
+ * <h2>Rollback (D37)</h2>
+ * Flyway atomic transaction → partial failure = full rollback = DB unchanged.
+ * Post-commit, V74 is effectively one-way: there is no reverse migration.
+ * Operator rollback requires restoring from the pre-deploy {@code pg_dump}
+ * (runbook 2.16 mandates this as a deploy precondition).
+ *
+ * <h2>Flyway role (C-A5-N6)</h2>
+ * Writes to {@code audit_events}, {@code kid_to_tenant_key}, {@code tenant_key_material},
+ * {@code app_user}, {@code subscription}, {@code tenant_oauth2_provider}, {@code tenant}.
+ * Must run as the table owner role (typically {@code fabt}) or a role with
+ * BYPASSRLS. V74RestrictedRoleTest exercises the failure mode — a restricted
+ * role receives a loud SQL error, not silent RLS-filtered writes.
+ *
+ * <h2>Phase A preflight (C-A5-N7)</h2>
+ * Throws if {@code flyway_schema_history} does not contain successful V60 and
+ * V61 rows. Protects against a release accidentally shipping V74 without the
+ * Phase A schema that it depends on.
+ */
+public class V74__reencrypt_secrets_under_per_tenant_deks extends BaseJavaMigration {
+
+    private static final Logger log = LoggerFactory.getLogger(
+            V74__reencrypt_secrets_under_per_tenant_deks.class);
+
+    // ------------------------------------------------------------------
+    // Constants mirror SecretEncryptionService + EncryptionEnvelope +
+    // KeyDerivationService. Changes in runtime code MUST be reflected
+    // here — the V74 migration replays the runtime encrypt path inline
+    // because Flyway runs pre-Spring-context.
+    // ------------------------------------------------------------------
+
+    private static final String ALGORITHM = "AES/GCM/NoPadding";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+
+    /** v1 envelope magic bytes — must match {@code EncryptionEnvelope.MAGIC}. */
+    private static final byte[] V1_MAGIC = { 0x46, 0x41, 0x42, 0x54 };
+    private static final byte V1_VERSION = 0x01;
+
+    /** HKDF derivation context version — must match {@code KeyDerivationService}. */
+    private static final String HKDF_CONTEXT_VERSION = "v1";
+
+    private static final String PURPOSE_TOTP = "totp";
+    private static final String PURPOSE_WEBHOOK = "webhook-secret";
+    private static final String PURPOSE_OAUTH2 = "oauth2-client-secret";
+    private static final String PURPOSE_HMIS = "hmis-api-key";
+
+    /**
+     * C-A5-N5 hardened ObjectMapper: bounds nesting depth + string length so
+     * a malicious {@code tenant.config} JSONB cannot blow Jackson's defaults
+     * and crash the migration mid-flight. In Jackson 3 the constraints live
+     * on the {@link JsonFactory}, not the {@link JsonMapper.Builder}.
+     */
+    private final ObjectMapper objectMapper = JsonMapper.builder(
+            JsonFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(64)
+                            .maxStringLength(1_048_576)     // 1 MB
+                            .maxNumberLength(1_000)
+                            .build())
+                    .build())
+            .build();
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Instant started = Instant.now();
+        Connection conn = context.getConnection();
+
+        // D36 / C-A5-N9: dev-skip path. Prod boot already fails-fast without
+        // the key, so this branch is only reachable in dev/CI.
+        String base64Key = System.getenv("FABT_ENCRYPTION_KEY");
+        if (base64Key == null || base64Key.isBlank()) {
+            base64Key = System.getenv("FABT_TOTP_ENCRYPTION_KEY");
+        }
+        if (base64Key == null || base64Key.isBlank()) {
+            log.warn("V74: FABT_ENCRYPTION_KEY not set — skipping re-encryption. "
+                    + "Flyway will mark V74 as APPLIED; set the key + DELETE FROM "
+                    + "flyway_schema_history WHERE version = '74' to retry.");
+            return;
+        }
+
+        byte[] masterKekBytes = Base64.getDecoder().decode(base64Key);
+        if (masterKekBytes.length != 32) {
+            throw new IllegalStateException(
+                    "FABT_ENCRYPTION_KEY must be 32 bytes (256 bits). Got: " + masterKekBytes.length);
+        }
+        SecretKey platformKey = new SecretKeySpec(masterKekBytes, "AES");
+
+        // C-A5-N1: bound migration lock time + statement time so a stray
+        // background lock cannot pin the deploy indefinitely.
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute("SET LOCAL lock_timeout = '30s'");
+            stmt.execute("SET LOCAL statement_timeout = '5min'");
+        }
+
+        // C-A5-N7 Phase A preflight — both V60 and V61 must be applied + successful.
+        try (PreparedStatement check = conn.prepareStatement(
+                "SELECT version, success FROM flyway_schema_history "
+                + "WHERE version IN ('60', '61')")) {
+            ResultSet rs = check.executeQuery();
+            int seen = 0;
+            while (rs.next()) {
+                if (!rs.getBoolean("success")) {
+                    throw new IllegalStateException(
+                            "V74 preflight failed: Phase A migration "
+                            + rs.getString("version") + " was not successful. "
+                            + "V74 cannot run without V60 + V61.");
+                }
+                seen++;
+            }
+            if (seen < 2) {
+                throw new IllegalStateException(
+                        "V74 preflight failed: Phase A migrations V60 + V61 must both be applied "
+                        + "before V74 can run (found " + seen + " of 2). "
+                        + "This usually indicates a release bundling error — v0.42 MUST include "
+                        + "Phase A. See design-a5-v74-reencrypt §C-A5-N7 / §C-A5-N8.");
+            }
+        }
+
+        // Diagnostic: surface the session role so operators can cross-check against
+        // the required role grants (must be BYPASSRLS or table owner — C-A5-N6).
+        String sessionRole = fetchSessionRole(conn);
+        log.info("V74 migrating as DB role: {}", sessionRole);
+
+        Counts totp = reencryptTotpSecrets(conn, masterKekBytes, platformKey);
+        Counts webhook = reencryptWebhookSecrets(conn, masterKekBytes, platformKey);
+        Counts oauth2 = reencryptOAuth2Secrets(conn, masterKekBytes, platformKey);
+        Counts hmis = reencryptHmisSecrets(conn, masterKekBytes, platformKey);
+
+        Instant completed = Instant.now();
+        long durationMs = completed.toEpochMilli() - started.toEpochMilli();
+        String kekFingerprint = fingerprintMasterKek(masterKekBytes);
+
+        writeAuditRow(conn, sessionRole, started, completed, durationMs, kekFingerprint,
+                totp, webhook, oauth2, hmis);
+
+        // W-A5-6: distinctive structured log line so an operator grepping
+        // journalctl can determine whether V74 committed independent of
+        // Spring startup logs.
+        log.info(
+                "V74 COMMITTED — re-encrypted {} TOTP / {} webhook / {} OAuth2 / {} HMIS rows in {}ms",
+                totp.reencrypted, webhook.reencrypted, oauth2.reencrypted, hmis.reencrypted, durationMs);
+    }
+
+    // ------------------------------------------------------------------
+    // Column-specific migration paths
+    // ------------------------------------------------------------------
+
+    private Counts reencryptTotpSecrets(Connection conn, byte[] masterKekBytes,
+                                         SecretKey platformKey) throws Exception {
+        Counts counts = new Counts();
+
+        // C-A5-N2: WHERE tenant_id IS NOT NULL + preflight count of NULL-tenant rows.
+        counts.skippedNullTenant = countSkippedNullTenant(conn,
+                "SELECT COUNT(*) FROM app_user "
+                + "WHERE totp_secret_encrypted IS NOT NULL AND tenant_id IS NULL");
+        if (counts.skippedNullTenant > 0) {
+            log.warn("V74: {} app_user rows skipped due to NULL tenant_id "
+                    + "(cannot derive per-tenant DEK without tenantId)", counts.skippedNullTenant);
+        }
+
+        // W-A5-4: SELECT ... FOR UPDATE to take explicit row-exclusive locks.
+        List<UUID> ids = new ArrayList<>();
+        List<UUID> tenantIds = new ArrayList<>();
+        List<String> newCiphertexts = new ArrayList<>();
+        List<String> plaintexts = new ArrayList<>();
+
+        try (PreparedStatement select = conn.prepareStatement(
+                "SELECT id, tenant_id, totp_secret_encrypted FROM app_user "
+                + "WHERE totp_secret_encrypted IS NOT NULL AND tenant_id IS NOT NULL "
+                + "FOR UPDATE")) {
+            try (ResultSet rs = select.executeQuery()) {
+                while (rs.next()) {
+                    String stored = rs.getString("totp_secret_encrypted");
+                    if (stored == null || stored.isBlank()) continue;
+                    if (isV1(stored)) {
+                        counts.skippedAlreadyV1++;
+                        continue;
+                    }
+                    UUID userId = (UUID) rs.getObject("id");
+                    UUID tenantId = (UUID) rs.getObject("tenant_id");
+                    String plaintext = decryptV0(platformKey, stored);
+                    UUID kid = findOrCreateActiveKid(conn, tenantId);
+                    SecretKey dek = deriveKey(masterKekBytes, tenantId, PURPOSE_TOTP);
+                    String reencrypted = encryptV1(dek, kid, plaintext);
+
+                    // C-A5-N3 round-trip verify
+                    String verify = decryptV1(dek, reencrypted);
+                    if (!plaintext.equals(verify)) {
+                        throw new IllegalStateException(
+                                "V74 TOTP round-trip mismatch for app_user.id=" + userId);
+                    }
+
+                    ids.add(userId);
+                    tenantIds.add(tenantId);
+                    newCiphertexts.add(reencrypted);
+                    plaintexts.add(plaintext);
+                }
+            }
+        }
+
+        if (ids.isEmpty()) return counts;
+
+        try (PreparedStatement update = conn.prepareStatement(
+                "UPDATE app_user SET totp_secret_encrypted = ? WHERE id = ?")) {
+            for (int i = 0; i < ids.size(); i++) {
+                update.setString(1, newCiphertexts.get(i));
+                update.setObject(2, ids.get(i));
+                update.addBatch();
+                counts.reencrypted++;
+            }
+            update.executeBatch();
+        }
+        // Clear plaintext refs promptly; minor memory-hygiene gesture.
+        plaintexts.clear();
+        return counts;
+    }
+
+    private Counts reencryptWebhookSecrets(Connection conn, byte[] masterKekBytes,
+                                            SecretKey platformKey) throws Exception {
+        Counts counts = new Counts();
+
+        counts.skippedNullTenant = countSkippedNullTenant(conn,
+                "SELECT COUNT(*) FROM subscription "
+                + "WHERE callback_secret_hash IS NOT NULL AND tenant_id IS NULL");
+        if (counts.skippedNullTenant > 0) {
+            log.warn("V74: {} subscription rows skipped due to NULL tenant_id",
+                    counts.skippedNullTenant);
+        }
+
+        List<UUID> ids = new ArrayList<>();
+        List<String> newCiphertexts = new ArrayList<>();
+
+        try (PreparedStatement select = conn.prepareStatement(
+                "SELECT id, tenant_id, callback_secret_hash FROM subscription "
+                + "WHERE callback_secret_hash IS NOT NULL AND tenant_id IS NOT NULL "
+                + "FOR UPDATE")) {
+            try (ResultSet rs = select.executeQuery()) {
+                while (rs.next()) {
+                    String stored = rs.getString("callback_secret_hash");
+                    if (stored == null || stored.isBlank()) continue;
+                    if (isV1(stored)) {
+                        counts.skippedAlreadyV1++;
+                        continue;
+                    }
+                    UUID subId = (UUID) rs.getObject("id");
+                    UUID tenantId = (UUID) rs.getObject("tenant_id");
+                    String plaintext = decryptV0(platformKey, stored);
+                    UUID kid = findOrCreateActiveKid(conn, tenantId);
+                    SecretKey dek = deriveKey(masterKekBytes, tenantId, PURPOSE_WEBHOOK);
+                    String reencrypted = encryptV1(dek, kid, plaintext);
+
+                    String verify = decryptV1(dek, reencrypted);
+                    if (!plaintext.equals(verify)) {
+                        throw new IllegalStateException(
+                                "V74 webhook round-trip mismatch for subscription.id=" + subId);
+                    }
+
+                    ids.add(subId);
+                    newCiphertexts.add(reencrypted);
+                }
+            }
+        }
+
+        if (ids.isEmpty()) return counts;
+
+        try (PreparedStatement update = conn.prepareStatement(
+                "UPDATE subscription SET callback_secret_hash = ? WHERE id = ?")) {
+            for (int i = 0; i < ids.size(); i++) {
+                update.setString(1, newCiphertexts.get(i));
+                update.setObject(2, ids.get(i));
+                update.addBatch();
+                counts.reencrypted++;
+            }
+            update.executeBatch();
+        }
+        return counts;
+    }
+
+    private Counts reencryptOAuth2Secrets(Connection conn, byte[] masterKekBytes,
+                                           SecretKey platformKey) throws Exception {
+        Counts counts = new Counts();
+
+        counts.skippedNullTenant = countSkippedNullTenant(conn,
+                "SELECT COUNT(*) FROM tenant_oauth2_provider "
+                + "WHERE client_secret_encrypted IS NOT NULL AND tenant_id IS NULL");
+        if (counts.skippedNullTenant > 0) {
+            log.warn("V74: {} tenant_oauth2_provider rows skipped due to NULL tenant_id",
+                    counts.skippedNullTenant);
+        }
+
+        List<UUID> ids = new ArrayList<>();
+        List<String> newCiphertexts = new ArrayList<>();
+
+        try (PreparedStatement select = conn.prepareStatement(
+                "SELECT id, tenant_id, client_secret_encrypted FROM tenant_oauth2_provider "
+                + "WHERE client_secret_encrypted IS NOT NULL AND tenant_id IS NOT NULL "
+                + "FOR UPDATE")) {
+            try (ResultSet rs = select.executeQuery()) {
+                while (rs.next()) {
+                    String stored = rs.getString("client_secret_encrypted");
+                    if (stored == null || stored.isBlank()) continue;
+                    if (isV1(stored)) {
+                        counts.skippedAlreadyV1++;
+                        continue;
+                    }
+                    UUID providerId = (UUID) rs.getObject("id");
+                    UUID tenantId = (UUID) rs.getObject("tenant_id");
+                    String plaintext;
+                    try {
+                        plaintext = decryptV0(platformKey, stored);
+                    } catch (RuntimeException legacyPlaintext) {
+                        // OAuth2 + HMIS have a plaintext-tolerance fallback in the
+                        // runtime read path. If V74 encounters a row that doesn't
+                        // decrypt under the platform key, assume it was stored as
+                        // plaintext (legacy, pre-V59) and pass it through the
+                        // encrypt-v1 path. Matches the decryptClientSecret
+                        // try/catch contract in DynamicClientRegistrationSource.
+                        log.warn("V74: tenant_oauth2_provider.id={} not valid v0 ciphertext — "
+                                + "treating as plaintext and encrypting-v1", providerId);
+                        plaintext = stored;
+                    }
+                    UUID kid = findOrCreateActiveKid(conn, tenantId);
+                    SecretKey dek = deriveKey(masterKekBytes, tenantId, PURPOSE_OAUTH2);
+                    String reencrypted = encryptV1(dek, kid, plaintext);
+
+                    String verify = decryptV1(dek, reencrypted);
+                    if (!plaintext.equals(verify)) {
+                        throw new IllegalStateException(
+                                "V74 OAuth2 round-trip mismatch for tenant_oauth2_provider.id="
+                                + providerId);
+                    }
+
+                    ids.add(providerId);
+                    newCiphertexts.add(reencrypted);
+                }
+            }
+        }
+
+        if (ids.isEmpty()) return counts;
+
+        try (PreparedStatement update = conn.prepareStatement(
+                "UPDATE tenant_oauth2_provider SET client_secret_encrypted = ? WHERE id = ?")) {
+            for (int i = 0; i < ids.size(); i++) {
+                update.setString(1, newCiphertexts.get(i));
+                update.setObject(2, ids.get(i));
+                update.addBatch();
+                counts.reencrypted++;
+            }
+            update.executeBatch();
+        }
+        return counts;
+    }
+
+    private Counts reencryptHmisSecrets(Connection conn, byte[] masterKekBytes,
+                                         SecretKey platformKey) throws Exception {
+        Counts counts = new Counts();
+
+        // HMIS is JSONB-embedded; no separate tenant_id column to NULL-check.
+        // Iterate tenant rows directly.
+        List<UUID> tenantIds = new ArrayList<>();
+        List<String> newConfigs = new ArrayList<>();
+
+        try (PreparedStatement select = conn.prepareStatement(
+                "SELECT id, config FROM tenant "
+                + "WHERE id IS NOT NULL AND config IS NOT NULL "
+                + "FOR UPDATE")) {
+            try (ResultSet rs = select.executeQuery()) {
+                while (rs.next()) {
+                    String configJson = rs.getString("config");
+                    if (configJson == null || configJson.isBlank()) continue;
+                    UUID tenantId = (UUID) rs.getObject("id");
+
+                    JsonNode root;
+                    try {
+                        root = objectMapper.readTree(configJson);
+                    } catch (Exception parseErr) {
+                        log.debug("V74: tenant {} has unparseable config — skipping",
+                                tenantId);
+                        continue;
+                    }
+                    if (!root.has("hmis_vendors") || !root.get("hmis_vendors").isArray()) {
+                        continue;
+                    }
+                    JsonNode vendorsNode = root.get("hmis_vendors");
+                    if (vendorsNode.isEmpty()) continue;
+
+                    boolean mutated = false;
+                    for (JsonNode vendor : vendorsNode) {
+                        if (!(vendor instanceof ObjectNode vendorObj)) continue;
+                        if (!vendor.has("api_key_encrypted")) continue;
+                        String stored = vendor.get("api_key_encrypted").asText();
+                        if (stored == null || stored.isBlank()) continue;
+                        if (isV1(stored)) {
+                            counts.skippedAlreadyV1++;
+                            continue;
+                        }
+                        String plaintext;
+                        try {
+                            plaintext = decryptV0(platformKey, stored);
+                        } catch (RuntimeException legacyPlaintext) {
+                            // Plaintext-tolerance fallback; see OAuth2 case above.
+                            log.warn("V74: tenant {} api_key_encrypted not valid v0 — "
+                                    + "treating as plaintext and encrypting-v1", tenantId);
+                            plaintext = stored;
+                        }
+                        UUID kid = findOrCreateActiveKid(conn, tenantId);
+                        SecretKey dek = deriveKey(masterKekBytes, tenantId, PURPOSE_HMIS);
+                        String reencrypted = encryptV1(dek, kid, plaintext);
+
+                        String verify = decryptV1(dek, reencrypted);
+                        if (!plaintext.equals(verify)) {
+                            throw new IllegalStateException(
+                                    "V74 HMIS round-trip mismatch for tenant.id=" + tenantId);
+                        }
+
+                        vendorObj.put("api_key_encrypted", reencrypted);
+                        mutated = true;
+                        counts.reencrypted++;
+                    }
+
+                    if (mutated) {
+                        tenantIds.add(tenantId);
+                        newConfigs.add(objectMapper.writeValueAsString(root));
+                    }
+                }
+            }
+        }
+
+        if (tenantIds.isEmpty()) return counts;
+
+        try (PreparedStatement update = conn.prepareStatement(
+                "UPDATE tenant SET config = ?::jsonb WHERE id = ?")) {
+            for (int i = 0; i < tenantIds.size(); i++) {
+                update.setString(1, newConfigs.get(i));
+                update.setObject(2, tenantIds.get(i));
+                update.addBatch();
+            }
+            update.executeBatch();
+        }
+        return counts;
+    }
+
+    // ------------------------------------------------------------------
+    // Audit row (D35 + C-A5-N10)
+    // ------------------------------------------------------------------
+
+    private void writeAuditRow(Connection conn, String sessionRole,
+                                Instant started, Instant completed, long durationMs,
+                                String kekFingerprint,
+                                Counts totp, Counts webhook, Counts oauth2, Counts hmis)
+            throws SQLException {
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("migration", "V74");
+        details.put("started_at", started.toString());
+        details.put("completed_at", completed.toString());
+        details.put("duration_ms", durationMs);
+        details.put("master_kek_fingerprint", kekFingerprint);
+        details.put("flyway_role", sessionRole);
+        details.put("totp_reencrypted", totp.reencrypted);
+        details.put("totp_skipped_already_v1", totp.skippedAlreadyV1);
+        details.put("totp_skipped_null_tenant", totp.skippedNullTenant);
+        details.put("webhook_reencrypted", webhook.reencrypted);
+        details.put("webhook_skipped_already_v1", webhook.skippedAlreadyV1);
+        details.put("webhook_skipped_null_tenant", webhook.skippedNullTenant);
+        details.put("oauth2_reencrypted", oauth2.reencrypted);
+        details.put("oauth2_skipped_already_v1", oauth2.skippedAlreadyV1);
+        details.put("oauth2_skipped_null_tenant", oauth2.skippedNullTenant);
+        details.put("hmis_reencrypted", hmis.reencrypted);
+        details.put("hmis_skipped_already_v1", hmis.skippedAlreadyV1);
+
+        String detailsJson;
+        try {
+            detailsJson = objectMapper.writeValueAsString(details);
+        } catch (Exception serializeErr) {
+            // Should be impossible — Map<String, Object> with primitives.
+            throw new IllegalStateException("V74 audit JSONB serialization failed", serializeErr);
+        }
+
+        try (PreparedStatement insert = conn.prepareStatement(
+                "INSERT INTO audit_events (action, details) VALUES (?, ?::jsonb)")) {
+            insert.setString(1, "SYSTEM_MIGRATION_V74_REENCRYPT");
+            insert.setString(2, detailsJson);
+            insert.executeUpdate();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Kid registry inline path (Q3 + Marcus W-A5 enhancement)
+    //
+    // Mirrors KidRegistryService.findOrCreateActiveKid's INSERT-ON-CONFLICT-
+    // DO-NOTHING + re-SELECT pattern. Race-free by construction because Flyway
+    // runs pre-application-boot — no concurrent first-encrypts exist yet.
+    // ------------------------------------------------------------------
+
+    private UUID findOrCreateActiveKid(Connection conn, UUID tenantId) throws SQLException {
+        ensureActiveGeneration(conn, tenantId);
+        int activeGeneration = getActiveGeneration(conn, tenantId);
+        return findOrCreateKid(conn, tenantId, activeGeneration);
+    }
+
+    private void ensureActiveGeneration(Connection conn, UUID tenantId) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO tenant_key_material (tenant_id, generation, active) "
+                + "VALUES (?, 1, TRUE) "
+                + "ON CONFLICT DO NOTHING")) {
+            ps.setObject(1, tenantId);
+            ps.executeUpdate();
+        }
+    }
+
+    private int getActiveGeneration(Connection conn, UUID tenantId) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT generation FROM tenant_key_material "
+                + "WHERE tenant_id = ? AND active = TRUE")) {
+            ps.setObject(1, tenantId);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException(
+                            "tenant_key_material has no active generation for tenant "
+                            + tenantId + " — ensureActiveGeneration should have created one");
+                }
+                return rs.getInt("generation");
+            }
+        }
+    }
+
+    private UUID findOrCreateKid(Connection conn, UUID tenantId, int generation) throws SQLException {
+        try (PreparedStatement lookup = conn.prepareStatement(
+                "SELECT kid FROM kid_to_tenant_key WHERE tenant_id = ? AND generation = ?")) {
+            lookup.setObject(1, tenantId);
+            lookup.setInt(2, generation);
+            try (ResultSet rs = lookup.executeQuery()) {
+                if (rs.next()) {
+                    return (UUID) rs.getObject("kid");
+                }
+            }
+        }
+        UUID newKid = UUID.randomUUID();
+        try (PreparedStatement insert = conn.prepareStatement(
+                "INSERT INTO kid_to_tenant_key (kid, tenant_id, generation) "
+                + "VALUES (?, ?, ?) "
+                + "ON CONFLICT (tenant_id, generation) DO NOTHING")) {
+            insert.setObject(1, newKid);
+            insert.setObject(2, tenantId);
+            insert.setInt(3, generation);
+            insert.executeUpdate();
+        }
+        try (PreparedStatement reSelect = conn.prepareStatement(
+                "SELECT kid FROM kid_to_tenant_key WHERE tenant_id = ? AND generation = ?")) {
+            reSelect.setObject(1, tenantId);
+            reSelect.setInt(2, generation);
+            try (ResultSet rs = reSelect.executeQuery()) {
+                if (rs.next()) {
+                    return (UUID) rs.getObject("kid");
+                }
+                throw new IllegalStateException(
+                        "kid_to_tenant_key re-select returned empty after INSERT — "
+                        + "tenant " + tenantId + " generation " + generation);
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Envelope + crypto helpers
+    //
+    // Mirror runtime EncryptionEnvelope + KeyDerivationService inline. Any
+    // change in the runtime wire format MUST be reflected here — V74 is
+    // versioned, immutable, and cannot be amended post-deploy.
+    // ------------------------------------------------------------------
+
+    private static boolean isV1(String stored) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            if (decoded.length < V1_MAGIC.length + 1) return false;
+            for (int i = 0; i < V1_MAGIC.length; i++) {
+                if (decoded[i] != V1_MAGIC[i]) return false;
+            }
+            return decoded[V1_MAGIC.length] == V1_VERSION;
+        } catch (IllegalArgumentException badBase64) {
+            return false;
+        }
+    }
+
+    private static String decryptV0(SecretKey platformKey, String stored) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            if (decoded.length < GCM_IV_LENGTH + 16) {
+                throw new IllegalArgumentException("v0 too short");
+            }
+            ByteBuffer buf = ByteBuffer.wrap(decoded);
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            buf.get(iv);
+            byte[] ct = new byte[buf.remaining()];
+            buf.get(ct);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, platformKey,
+                    new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            return new String(cipher.doFinal(ct), StandardCharsets.UTF_8);
+        } catch (Exception cryptoErr) {
+            throw new RuntimeException("v0 decrypt failed", cryptoErr);
+        }
+    }
+
+    private String encryptV1(SecretKey dek, UUID kid, String plaintext) {
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            secureRandom.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.ENCRYPT_MODE, dek, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            byte[] ctWithTag = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+
+            ByteBuffer buf = ByteBuffer.allocate(V1_MAGIC.length + 1 + 16 + GCM_IV_LENGTH + ctWithTag.length);
+            buf.put(V1_MAGIC);
+            buf.put(V1_VERSION);
+            buf.putLong(kid.getMostSignificantBits());
+            buf.putLong(kid.getLeastSignificantBits());
+            buf.put(iv);
+            buf.put(ctWithTag);
+            return Base64.getEncoder().encodeToString(buf.array());
+        } catch (Exception cryptoErr) {
+            throw new RuntimeException("v1 encrypt failed", cryptoErr);
+        }
+    }
+
+    /**
+     * Round-trip verify helper (C-A5-N3). Parses the v1 envelope we just
+     * produced and decrypts it under the same DEK — confirms the written
+     * bytes decrypt back to the original plaintext before we commit them.
+     */
+    private static String decryptV1(SecretKey dek, String stored) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            int headerLen = V1_MAGIC.length + 1 + 16; // magic + version + kid
+            ByteBuffer buf = ByteBuffer.wrap(decoded);
+            buf.position(headerLen);
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            buf.get(iv);
+            byte[] ctWithTag = new byte[buf.remaining()];
+            buf.get(ctWithTag);
+
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, dek, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            return new String(cipher.doFinal(ctWithTag), StandardCharsets.UTF_8);
+        } catch (Exception cryptoErr) {
+            throw new RuntimeException("v1 round-trip decrypt failed", cryptoErr);
+        }
+    }
+
+    private static SecretKey deriveKey(byte[] masterKekBytes, UUID tenantId, String purpose) {
+        try {
+            byte[] salt = uuidToBytes(tenantId);
+            String context = "fabt:" + HKDF_CONTEXT_VERSION + ":" + tenantId + ":" + purpose;
+            byte[] info = context.getBytes(StandardCharsets.UTF_8);
+            byte[] derived = hkdfSha256(masterKekBytes, salt, info, 32);
+            return new SecretKeySpec(derived, "AES");
+        } catch (Exception derivationErr) {
+            throw new RuntimeException("HKDF derivation failed", derivationErr);
+        }
+    }
+
+    private static byte[] uuidToBytes(UUID uuid) {
+        ByteBuffer buf = ByteBuffer.allocate(16);
+        buf.putLong(uuid.getMostSignificantBits());
+        buf.putLong(uuid.getLeastSignificantBits());
+        return buf.array();
+    }
+
+    /**
+     * RFC 5869 HKDF-SHA256. Direct port of {@code KeyDerivationService.hkdfSha256}.
+     */
+    private static byte[] hkdfSha256(byte[] ikm, byte[] salt, byte[] info, int outputLength)
+            throws Exception {
+        final int OUT = 32;
+        byte[] effectiveSalt = (salt == null || salt.length == 0) ? new byte[OUT] : salt;
+
+        Mac extract = Mac.getInstance("HmacSHA256");
+        extract.init(new SecretKeySpec(effectiveSalt, "HmacSHA256"));
+        byte[] prk = extract.doFinal(ikm);
+
+        Mac expand = Mac.getInstance("HmacSHA256");
+        expand.init(new SecretKeySpec(prk, "HmacSHA256"));
+        int blocks = (outputLength + OUT - 1) / OUT;
+        byte[] result = new byte[outputLength];
+        byte[] previous = new byte[0];
+        int written = 0;
+        for (int i = 1; i <= blocks; i++) {
+            expand.reset();
+            expand.update(previous);
+            expand.update(info);
+            expand.update((byte) i);
+            previous = expand.doFinal();
+            int copyLen = Math.min(OUT, outputLength - written);
+            System.arraycopy(previous, 0, result, written, copyLen);
+            written += copyLen;
+        }
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Diagnostic helpers
+    // ------------------------------------------------------------------
+
+    private static String fetchSessionRole(Connection conn) {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT current_user, rolbypassrls, rolsuper "
+                + "FROM pg_roles WHERE rolname = current_user");
+                ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                return String.format("%s (bypassrls=%s, superuser=%s)",
+                        rs.getString("current_user"),
+                        rs.getBoolean("rolbypassrls"),
+                        rs.getBoolean("rolsuper"));
+            }
+        } catch (SQLException ignored) {
+            // non-fatal — role diagnostic is nice-to-have
+        }
+        return "unknown";
+    }
+
+    /**
+     * One-way HMAC-SHA256 fingerprint of the master KEK under a fixed label.
+     * Proves V74 ran under the same KEK later reads will use, without leaking
+     * the KEK. Truncated to 16 hex chars (8 bytes = 64 bits of collision
+     * resistance — enough for "did the KEK drift between V74 and first read").
+     */
+    private static String fingerprintMasterKek(byte[] masterKekBytes) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(masterKekBytes, "HmacSHA256"));
+            byte[] fingerprint = mac.doFinal(
+                    "v74-audit-fingerprint".getBytes(StandardCharsets.UTF_8));
+            byte[] truncated = new byte[8];
+            System.arraycopy(fingerprint, 0, truncated, 0, 8);
+            return HexFormat.of().formatHex(truncated);
+        } catch (Exception hashErr) {
+            // Fingerprint is diagnostic only; failure doesn't block migration.
+            return "unknown";
+        }
+    }
+
+    private static int countSkippedNullTenant(Connection conn, String sql) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(sql);
+                ResultSet rs = ps.executeQuery()) {
+            return rs.next() ? rs.getInt(1) : 0;
+        }
+    }
+
+    /** Per-column counters tracked by each re-encrypt path. */
+    private static final class Counts {
+        int reencrypted;
+        int skippedAlreadyV1;
+        int skippedNullTenant;
+    }
+}

--- a/backend/src/main/java/db/migration/V74__reencrypt_secrets_under_per_tenant_deks.java
+++ b/backend/src/main/java/db/migration/V74__reencrypt_secrets_under_per_tenant_deks.java
@@ -98,8 +98,11 @@ import tools.jackson.databind.node.ObjectNode;
  * Writes to {@code audit_events}, {@code kid_to_tenant_key}, {@code tenant_key_material},
  * {@code app_user}, {@code subscription}, {@code tenant_oauth2_provider}, {@code tenant}.
  * Must run as the table owner role (typically {@code fabt}) or a role with
- * BYPASSRLS. V74RestrictedRoleTest exercises the failure mode — a restricted
- * role receives a loud SQL error, not silent RLS-filtered writes.
+ * BYPASSRLS. The current session role + its BYPASSRLS / superuser flags are
+ * logged at {@code migrate()} start and captured in the audit row's
+ * {@code flyway_role} field so operators can verify pre-deploy via
+ * {@code \dp} that grants are correct. Restricted-role fail-loudly coverage
+ * is deferred — runbook 2.16 mandates the operator-side {@code \dp} check.
  *
  * <h2>Phase A preflight (C-A5-N7)</h2>
  * Throws if {@code flyway_schema_history} does not contain successful V60 and

--- a/backend/src/main/java/db/migration/V74__reencrypt_secrets_under_per_tenant_deks.java
+++ b/backend/src/main/java/db/migration/V74__reencrypt_secrets_under_per_tenant_deks.java
@@ -158,10 +158,16 @@ public class V74__reencrypt_secrets_under_per_tenant_deks extends BaseJavaMigrat
         Connection conn = context.getConnection();
 
         // D36 / C-A5-N9: dev-skip path. Prod boot already fails-fast without
-        // the key, so this branch is only reachable in dev/CI.
+        // the key, so this branch is only reachable in dev/CI. The system-
+        // property fallback exists to give integration tests a knob (where
+        // env vars are hard to set) without relaxing prod semantics — the
+        // Phase 0 startup guard already runs in prod before Flyway.
         String base64Key = System.getenv("FABT_ENCRYPTION_KEY");
         if (base64Key == null || base64Key.isBlank()) {
             base64Key = System.getenv("FABT_TOTP_ENCRYPTION_KEY");
+        }
+        if (base64Key == null || base64Key.isBlank()) {
+            base64Key = System.getProperty("fabt.encryption-key");
         }
         if (base64Key == null || base64Key.isBlank()) {
             log.warn("V74: FABT_ENCRYPTION_KEY not set — skipping re-encryption. "

--- a/backend/src/main/java/org/fabt/auth/api/AuthController.java
+++ b/backend/src/main/java/org/fabt/auth/api/AuthController.java
@@ -323,8 +323,10 @@ public class AuthController {
                     .body(new ErrorBody("Invalid verification token."));
         }
 
-        // Try TOTP code first
-        String secret = totpService.decryptSecret(user.getTotpSecretEncrypted());
+        // Try TOTP code first (Phase A5: tenant-scoped per D38 — MFA verify
+        // runs before SecurityContext binding; tenantId comes from the User
+        // row we just loaded, not from TenantContext)
+        String secret = totpService.decryptSecret(user.getTenantId(), user.getTotpSecretEncrypted());
         boolean codeValid = totpService.verifyCode(secret, code);
 
         // If TOTP failed, try as backup code

--- a/backend/src/main/java/org/fabt/auth/api/TotpController.java
+++ b/backend/src/main/java/org/fabt/auth/api/TotpController.java
@@ -77,7 +77,9 @@ public class TotpController {
 
         // Store pending secret (encrypted) — will be activated on confirmation
         // This allows only one pending enrollment at a time (concurrent enrollment replaces previous)
-        user.setTotpSecretEncrypted(totpService.encryptSecret(secret));
+        // Phase A5 D38: tenantId threaded through so the secret is encrypted
+        // under the owning tenant's per-tenant DEK, not the shared platform key.
+        user.setTotpSecretEncrypted(totpService.encryptSecret(user.getTenantId(), secret));
         user.setUpdatedAt(java.time.Instant.now());
         userRepository.save(user);
 
@@ -114,8 +116,8 @@ public class TotpController {
                     "message", "No enrollment in progress. Start with POST /api/v1/auth/enroll-totp."));
         }
 
-        // Decrypt and verify
-        String secret = totpService.decryptSecret(user.getTotpSecretEncrypted());
+        // Decrypt and verify (Phase A5: tenant-scoped per D38)
+        String secret = totpService.decryptSecret(user.getTenantId(), user.getTotpSecretEncrypted());
         if (!totpService.verifyCode(secret, code)) {
             return ResponseEntity.status(401).body(Map.of(
                     "error", "invalid_code",

--- a/backend/src/main/java/org/fabt/auth/service/DynamicClientRegistrationSource.java
+++ b/backend/src/main/java/org/fabt/auth/service/DynamicClientRegistrationSource.java
@@ -5,7 +5,10 @@ import java.util.concurrent.TimeUnit;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
+import java.util.UUID;
+
 import org.fabt.auth.domain.TenantOAuth2Provider;
+import org.fabt.shared.security.KeyPurpose;
 import org.fabt.shared.security.SecretEncryptionService;
 import org.fabt.tenant.service.TenantService;
 import org.slf4j.Logger;
@@ -72,7 +75,7 @@ public class DynamicClientRegistrationSource implements ClientRegistrationReposi
 
         ClientRegistration registration = ClientRegistration.withRegistrationId(registrationId)
                 .clientId(p.getClientId())
-                .clientSecret(decryptClientSecret(p.getClientSecretEncrypted()))
+                .clientSecret(decryptClientSecret(p.getTenantId(), p.getClientSecretEncrypted()))
                 .clientAuthenticationMethod(ClientAuthenticationMethod.CLIENT_SECRET_BASIC)
                 .authorizationGrantType(AuthorizationGrantType.AUTHORIZATION_CODE)
                 .redirectUri("{baseUrl}/oauth2/callback/" + registrationId)
@@ -90,19 +93,23 @@ public class DynamicClientRegistrationSource implements ClientRegistrationReposi
     }
 
     /**
-     * Decrypts a stored OAuth2 client secret. Falls back to the stored value
-     * on decrypt failure so legacy plaintext providers remain functional until
-     * Flyway V74 re-encrypts them. Mirrors the same tolerance pattern used by
-     * {@code HmisConfigService.decryptApiKey}. Without this fallback, the
-     * window between Phase 0 deploy and V74 completion would hard-fail every
-     * OAuth2 login.
+     * Decrypts a stored OAuth2 client secret under the owning tenant's DEK.
+     * Phase A5 D38: per-tenant-scoped. The v0 fallback path inside
+     * {@link SecretEncryptionService#decryptForTenant} handles legacy
+     * pre-V74 ciphertexts without a caller-side try/catch being required.
+     *
+     * <p>Plaintext-tolerance fallback preserved for direct-DB-edit cases:
+     * if an admin/operator set {@code client_secret_encrypted} to raw
+     * plaintext post-V74 (not encrypted, not v0, not v1), decrypt throws
+     * and we pass the value through. Consistent with
+     * {@code HmisConfigService.decryptApiKey}'s tolerance.
      */
-    private String decryptClientSecret(String stored) {
+    private String decryptClientSecret(UUID tenantId, String stored) {
         if (stored == null || stored.isBlank()) {
             return stored;
         }
         try {
-            return encryptionService.decrypt(stored);
+            return encryptionService.decryptForTenant(tenantId, KeyPurpose.OAUTH2_CLIENT_SECRET, stored);
         } catch (RuntimeException e) {
             log.debug("client_secret_encrypted is not valid ciphertext; returning plaintext fallback");
             return stored;

--- a/backend/src/main/java/org/fabt/auth/service/TenantOAuth2ProviderService.java
+++ b/backend/src/main/java/org/fabt/auth/service/TenantOAuth2ProviderService.java
@@ -8,6 +8,7 @@ import java.util.UUID;
 
 import org.fabt.auth.domain.TenantOAuth2Provider;
 import org.fabt.auth.repository.TenantOAuth2ProviderRepository;
+import org.fabt.shared.security.KeyPurpose;
 import org.fabt.shared.security.SafeOutboundUrlValidator;
 import org.fabt.shared.security.SecretEncryptionService;
 import org.fabt.shared.web.TenantContext;
@@ -72,7 +73,10 @@ public class TenantOAuth2ProviderService {
         provider.setProviderName(providerName);
         provider.setClientId(clientId);
         if (clientSecret != null) {
-            provider.setClientSecretEncrypted(encryptionService.encrypt(clientSecret));
+            // Phase A5 D38: per-tenant DEK under KeyPurpose.OAUTH2_CLIENT_SECRET.
+            provider.setClientSecretEncrypted(
+                    encryptionService.encryptForTenant(
+                            tenantId, KeyPurpose.OAUTH2_CLIENT_SECRET, clientSecret));
         }
         provider.setIssuerUri(issuerUri);
         provider.setEnabled(true);
@@ -100,7 +104,11 @@ public class TenantOAuth2ProviderService {
             provider.setClientId(clientId);
         }
         if (clientSecret != null) {
-            provider.setClientSecretEncrypted(encryptionService.encrypt(clientSecret));
+            // Phase A5 D38: re-use the provider's existing tenantId (the
+            // update path is already tenant-scoped via findByIdOrThrow).
+            provider.setClientSecretEncrypted(
+                    encryptionService.encryptForTenant(
+                            provider.getTenantId(), KeyPurpose.OAUTH2_CLIENT_SECRET, clientSecret));
         }
         if (issuerUri != null && !issuerUri.isBlank()) {
             // D12: same SSRF validation on update — an attacker admin

--- a/backend/src/main/java/org/fabt/auth/service/TotpService.java
+++ b/backend/src/main/java/org/fabt/auth/service/TotpService.java
@@ -3,6 +3,7 @@ package org.fabt.auth.service;
 import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.UUID;
 
 import dev.samstevens.totp.code.CodeGenerator;
 import dev.samstevens.totp.code.CodeVerifier;
@@ -14,6 +15,7 @@ import dev.samstevens.totp.secret.DefaultSecretGenerator;
 import dev.samstevens.totp.secret.SecretGenerator;
 import dev.samstevens.totp.time.SystemTimeProvider;
 
+import org.fabt.shared.security.KeyPurpose;
 import org.springframework.stereotype.Service;
 
 /**
@@ -121,17 +123,28 @@ public class TotpService {
     }
 
     /**
-     * Decrypt a stored TOTP secret for verification.
+     * Decrypt a stored TOTP secret for verification, scoped to the owning
+     * tenant's DEK. Phase A5 D38: the controller must pass {@code tenantId}
+     * explicitly because the MFA-verify flow runs before a SecurityContext
+     * is bound — there is no {@code TenantContext} to implicit-scope against.
+     * The controller has {@code user.getTenantId()} in hand; passing it here
+     * is the right plumbing.
+     *
+     * <p>v0 ciphertexts (pre-V74) continue to decrypt via the defense-in-depth
+     * v0 fallback path in {@code SecretEncryptionService.decryptForTenant} —
+     * no caller-side fallback logic needed here.
      */
-    public String decryptSecret(String encrypted) {
-        return encryptionService.decrypt(encrypted);
+    public String decryptSecret(UUID tenantId, String encrypted) {
+        return encryptionService.decryptForTenant(tenantId, KeyPurpose.TOTP, encrypted);
     }
 
     /**
-     * Encrypt a TOTP secret for storage.
+     * Encrypt a TOTP secret for storage under the owning tenant's DEK.
+     * Phase A5 D38: {@code tenantId} explicit for the same reason as
+     * {@link #decryptSecret}.
      */
-    public String encryptSecret(String plaintext) {
-        return encryptionService.encrypt(plaintext);
+    public String encryptSecret(UUID tenantId, String plaintext) {
+        return encryptionService.encryptForTenant(tenantId, KeyPurpose.TOTP, plaintext);
     }
 
     public boolean isEncryptionConfigured() {

--- a/backend/src/main/java/org/fabt/hmis/service/HmisConfigService.java
+++ b/backend/src/main/java/org/fabt/hmis/service/HmisConfigService.java
@@ -13,6 +13,7 @@ import org.slf4j.LoggerFactory;
 
 import org.fabt.hmis.domain.HmisVendorConfig;
 import org.fabt.hmis.domain.HmisVendorType;
+import org.fabt.shared.security.KeyPurpose;
 import org.fabt.shared.security.SecretEncryptionService;
 import org.fabt.tenant.service.TenantService;
 import org.springframework.stereotype.Service;
@@ -21,12 +22,12 @@ import org.springframework.stereotype.Service;
  * Reads HMIS vendor configuration from tenant config JSONB.
  * Cached via the tenant service's existing cache refresh pattern.
  *
- * <p>API keys are decrypted at read time so adapters receive plaintext. Writes
- * flow through {@link #encryptApiKey(String)} at the typed vendor-CRUD boundary
- * (stubbed today; implemented by platform-hardening). Existing plaintext values
- * are tolerated — {@link #decryptApiKey(String)} falls back to passthrough when
- * the stored value is not valid ciphertext, so a tenant with legacy plaintext
- * config continues to function until V74 re-encrypts on upgrade.
+ * <p>API keys are decrypted at read time so adapters receive plaintext.
+ * Phase A5 D38: writes flow through {@link #encryptApiKey(UUID, String)} under
+ * the owning tenant's per-tenant DEK; reads flow through
+ * {@link #decryptApiKey(UUID, String)} which tolerates direct-DB-edit plaintext
+ * values + relies on the v0 fallback path in
+ * {@link SecretEncryptionService#decryptForTenant} for pre-V74 ciphertexts.
  */
 @Service
 public class HmisConfigService {
@@ -64,7 +65,7 @@ public class HmisConfigService {
                                         v.has("id") ? v.get("id").asText() : UUID.randomUUID().toString(),
                                         HmisVendorType.valueOf(v.get("type").asText()),
                                         v.has("base_url") ? v.get("base_url").asText() : null,
-                                        v.has("api_key_encrypted") ? decryptApiKey(v.get("api_key_encrypted").asText()) : null,
+                                        v.has("api_key_encrypted") ? decryptApiKey(tenantId, v.get("api_key_encrypted").asText()) : null,
                                         !v.has("enabled") || v.get("enabled").asBoolean(true),
                                         v.has("push_interval_hours") ? v.get("push_interval_hours").asInt(6) : 6
                                 ));
@@ -95,28 +96,31 @@ public class HmisConfigService {
     }
 
     /**
-     * Encrypts a plaintext API key for JSONB storage. Typed vendor-CRUD
-     * endpoints (platform-hardening) call this before serializing the vendor
-     * config into the tenant config Map. Safe to call with null (returns null).
+     * Encrypts a plaintext API key for JSONB storage under the owning
+     * tenant's per-tenant DEK (Phase A5 D38). Typed vendor-CRUD endpoints
+     * (platform-hardening) call this before serializing the vendor config
+     * into the tenant config Map. Safe to call with null (returns null).
      */
-    public String encryptApiKey(String plaintext) {
+    public String encryptApiKey(UUID tenantId, String plaintext) {
         if (plaintext == null || plaintext.isBlank()) {
             return plaintext;
         }
-        return encryptionService.encrypt(plaintext);
+        return encryptionService.encryptForTenant(tenantId, KeyPurpose.HMIS_API_KEY, plaintext);
     }
 
     /**
      * Decrypts a stored API key. Falls back to passthrough on decrypt failure
-     * so legacy plaintext values remain usable until the V74 re-encryption
-     * migration runs on upgrade. Safe to call with null (returns null).
+     * so legacy plaintext values remain usable (e.g., direct-DB edits post-V74).
+     * The v0 fallback path inside {@link SecretEncryptionService#decryptForTenant}
+     * transparently decrypts pre-V74 v0 ciphertexts without a caller try/catch
+     * being required. Safe to call with null (returns null).
      */
-    private String decryptApiKey(String stored) {
+    private String decryptApiKey(UUID tenantId, String stored) {
         if (stored == null || stored.isBlank()) {
             return stored;
         }
         try {
-            return encryptionService.decrypt(stored);
+            return encryptionService.decryptForTenant(tenantId, KeyPurpose.HMIS_API_KEY, stored);
         } catch (RuntimeException e) {
             log.debug("api_key_encrypted is not valid ciphertext; returning plaintext fallback");
             return stored;

--- a/backend/src/main/java/org/fabt/shared/security/CiphertextV0Decoder.java
+++ b/backend/src/main/java/org/fabt/shared/security/CiphertextV0Decoder.java
@@ -23,6 +23,24 @@ import javax.crypto.spec.GCMParameterSpec;
  * The platform key arrives as an explicit {@link SecretKey} parameter
  * sourced from {@link MasterKekProvider#getPlatformKey()} on the call
  * site.
+ *
+ * <h2>DO NOT REMOVE — defense-in-depth contract per design-a5-v74 D42 + W-A5-5</h2>
+ *
+ * This class MUST NOT be deleted, even if a future grep shows it unused.
+ * The caller ({@link SecretEncryptionService#decryptForTenant}) selects
+ * this path via a magic-byte check on the stored ciphertext, NOT via
+ * exception-catch fallback. Removing this class would eliminate the
+ * defense-in-depth guarantee that a V74-skipped row (transient lock,
+ * operator DB edit, disaster-recovery partial restore) still decrypts
+ * cleanly. See {@code openspec/changes/multi-tenant-production-readiness/
+ * design-a5-v74-reencrypt.md} §D42 for the full rationale.
+ *
+ * <p>Observability on every v0-fallback call is wired in
+ * {@link SecretEncryptionService#recordV0DecryptFallback} —
+ * {@code fabt.security.v0_decrypt_fallback.count} counter + throttled
+ * {@code CIPHERTEXT_V0_DECRYPT} audit event. Post-V74 a non-zero rate
+ * is either a stuck-row repair indicator or a downgrade-attack signal;
+ * either way, it is surveilled.
  */
 final class CiphertextV0Decoder {
 

--- a/backend/src/main/java/org/fabt/shared/security/SecretEncryptionService.java
+++ b/backend/src/main/java/org/fabt/shared/security/SecretEncryptionService.java
@@ -3,14 +3,22 @@ package org.fabt.shared.security;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.security.SecureRandom;
+import java.time.Duration;
 import java.util.Base64;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 import javax.crypto.Cipher;
 import javax.crypto.SecretKey;
 import javax.crypto.spec.GCMParameterSpec;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.fabt.shared.audit.AuditEventRecord;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 /**
@@ -42,29 +50,57 @@ public class SecretEncryptionService {
     static final java.util.UUID UNKNOWN_KID_SENTINEL_TENANT =
             java.util.UUID.fromString("00000000-0000-0000-0000-000000000000");
 
+    /**
+     * C-A5-N4 (Marcus warroom): throttle for {@code CIPHERTEXT_V0_DECRYPT} audit
+     * events — ≤ once per (tenant, purpose) per 60s window. Post-V74 a spike of
+     * v0 fallbacks is either a stuck-row repair case (1 or 2 rows) or an attack
+     * (adversary replacing v1 ciphertexts with v0 forgeries). Either way, we
+     * want the signal, not a flood.
+     */
+    private static final Duration V0_DECRYPT_AUDIT_THROTTLE = Duration.ofSeconds(60);
+
     private final SecretKey secretKey;
     private final SecureRandom secureRandom = new SecureRandom();
     private final boolean configured;
     private final MasterKekProvider masterKekProvider;
     private final KeyDerivationService keyDerivationService;
     private final KidRegistryService kidRegistryService;
+    private final MeterRegistry meterRegistry;
+    private final ApplicationEventPublisher eventPublisher;
+
+    /**
+     * Last-emit timestamps (epoch ms) keyed by {@code tenantId + ":" + purpose}.
+     * Concurrent map because v0-fallback can fire on any request thread. Entries
+     * are never evicted (bounded by tenant count × purpose count — tiny at
+     * pilot scale; the max-size cap on a real Caffeine cache would be premature
+     * optimization here).
+     */
+    private final Map<String, Long> v0DecryptLastAuditMs = new ConcurrentHashMap<>();
 
     /**
      * Phase A3 D17: validation + key bytes now owned by {@link MasterKekProvider}.
      * Phase A3 D18+D21: per-tenant typed encrypt/decrypt added; legacy v0 path
-     * preserved via {@link CiphertextV0Decoder}. The provider, derivation
-     * service, and kid registry are injected together because the v1 encrypt
-     * path needs all three.
+     * preserved via {@link CiphertextV0Decoder}. Phase A5 C-A5-N4: v0-fallback
+     * observability — every v0 decrypt post-V74 increments a counter + emits a
+     * throttled audit event.
+     *
+     * <p>{@link ObjectProvider} wrappers keep the service usable by unit tests
+     * that instantiate without a full Spring context (no MeterRegistry, no
+     * event publisher). In a Spring context both beans are injected normally.
      */
     public SecretEncryptionService(
             MasterKekProvider masterKekProvider,
             KeyDerivationService keyDerivationService,
-            KidRegistryService kidRegistryService) {
+            KidRegistryService kidRegistryService,
+            ObjectProvider<MeterRegistry> meterRegistryProvider,
+            ObjectProvider<ApplicationEventPublisher> eventPublisherProvider) {
         this.masterKekProvider = masterKekProvider;
         this.keyDerivationService = keyDerivationService;
         this.kidRegistryService = kidRegistryService;
         this.secretKey = masterKekProvider.getPlatformKey();
         this.configured = true;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
+        this.eventPublisher = eventPublisherProvider.getIfAvailable();
     }
 
     // ------------------------------------------------------------------
@@ -107,7 +143,13 @@ public class SecretEncryptionService {
     public String decryptForTenant(java.util.UUID tenantId, KeyPurpose purpose, String stored) {
         byte[] decoded = java.util.Base64.getDecoder().decode(stored);
         if (!EncryptionEnvelope.isV1Envelope(decoded)) {
-            // v0 fallback — Phase 0 single-platform-key envelope
+            // v0 fallback — Phase 0 single-platform-key envelope. Design D42
+            // keeps this path alive indefinitely as defense-in-depth. Phase A5
+            // C-A5-N4: emit a counter + throttled audit event so any v0
+            // decrypt that fires post-V74 is visible (catches both the
+            // V74-skipped-row repair case and a hostile v0-forgery downgrade
+            // attack).
+            recordV0DecryptFallback(tenantId, purpose);
             return CiphertextV0Decoder.decrypt(masterKekProvider.getPlatformKey(), stored);
         }
         EncryptionEnvelope envelope = EncryptionEnvelope.decode(stored);
@@ -138,10 +180,22 @@ public class SecretEncryptionService {
         }
     }
 
+    // ------------------------------------------------------------------
+     // Legacy v0 API (deprecated)
+     // ------------------------------------------------------------------
+
     /**
      * Encrypt a plaintext secret for database storage.
      * Returns base64-encoded ciphertext (IV + encrypted data + GCM auth tag).
+     *
+     * @deprecated since v0.42 — use {@link #encryptForTenant} with a
+     * {@link KeyPurpose}. This un-typed path writes v0-envelope ciphertexts
+     * that are NOT bound to a tenant. Retained only for V74 migration
+     * internal use (via {@code db.migration.V74}) and the deprecated
+     * test-fixtures path. Scheduled for removal in Phase L under
+     * ArchUnit Family F.
      */
+    @Deprecated(since = "v0.42", forRemoval = true)
     public String encrypt(String plaintext) {
         requireKey();
         try {
@@ -166,7 +220,14 @@ public class SecretEncryptionService {
     /**
      * Decrypt a secret from database storage.
      * Input is base64-encoded (IV + encrypted data + GCM auth tag).
+     *
+     * @deprecated since v0.42 — use {@link #decryptForTenant}. This path
+     * decrypts v0 ciphertext under the platform key with no tenant binding
+     * and is retained only for V74 migration use + the deprecated
+     * test-fixtures path. Scheduled for removal in Phase L. Application
+     * code reaching this method bypasses per-tenant DEK isolation.
      */
+    @Deprecated(since = "v0.42", forRemoval = true)
     public String decrypt(String encrypted) {
         requireKey();
         try {
@@ -209,5 +270,50 @@ public class SecretEncryptionService {
                     "Encryption key not configured. Set FABT_ENCRYPTION_KEY environment variable. "
                     + "Generate with: openssl rand -base64 32");
         }
+    }
+
+    /**
+     * C-A5-N4: increments the v0-fallback counter and emits a throttled
+     * audit event whenever a legacy v0 ciphertext is decrypted on the
+     * runtime path. Post-V74 sweep, any v0 read is either a stuck-row
+     * repair case or a downgrade-attack indicator; either way, we want
+     * the signal.
+     *
+     * <p>Throttle is per-(tenant, purpose) at {@link #V0_DECRYPT_AUDIT_THROTTLE}.
+     * Counter is always incremented regardless of throttle (so dashboards
+     * see the true rate).
+     */
+    private void recordV0DecryptFallback(java.util.UUID tenantId, KeyPurpose purpose) {
+        if (meterRegistry != null) {
+            Counter.builder("fabt.security.v0_decrypt_fallback.count")
+                    .tag("purpose", purpose.name())
+                    .tag("tenant_id", tenantId == null ? "unknown" : tenantId.toString())
+                    .register(meterRegistry)
+                    .increment();
+        }
+        if (eventPublisher != null && shouldEmitV0DecryptAudit(tenantId, purpose)) {
+            java.util.Map<String, Object> details = new java.util.HashMap<>();
+            details.put("tenantId", tenantId == null ? "unknown" : tenantId.toString());
+            details.put("purpose", purpose.name());
+            details.put("note", "v0 fallback decrypt — expected only for stuck V74 rows or attack indicator");
+            eventPublisher.publishEvent(
+                    new AuditEventRecord(null, null, "CIPHERTEXT_V0_DECRYPT", details, null));
+        }
+    }
+
+    /**
+     * Returns true if the per-(tenant, purpose) throttle permits an audit
+     * emission now. Updates the last-emit timestamp as a side effect.
+     */
+    private boolean shouldEmitV0DecryptAudit(java.util.UUID tenantId, KeyPurpose purpose) {
+        String key = (tenantId == null ? "null" : tenantId.toString()) + ":" + purpose.name();
+        long now = System.currentTimeMillis();
+        long windowMs = V0_DECRYPT_AUDIT_THROTTLE.toMillis();
+        Long last = v0DecryptLastAuditMs.get(key);
+        if (last != null && (now - last) < windowMs) {
+            return false;
+        }
+        v0DecryptLastAuditMs.put(key, now);
+        return true;
     }
 }

--- a/backend/src/main/java/org/fabt/subscription/service/SubscriptionService.java
+++ b/backend/src/main/java/org/fabt/subscription/service/SubscriptionService.java
@@ -12,6 +12,7 @@ import java.util.UUID;
 import tools.jackson.core.JacksonException;
 import tools.jackson.databind.ObjectMapper;
 import org.fabt.shared.config.JsonString;
+import org.fabt.shared.security.KeyPurpose;
 import org.fabt.shared.security.SafeOutboundUrlValidator;
 import org.fabt.shared.security.TenantUnscoped;
 import org.fabt.shared.web.TenantContext;
@@ -71,7 +72,11 @@ public class SubscriptionService {
         // Encrypt the callback secret with AES-256-GCM for storage at rest.
         // Decrypted on delivery to compute HMAC-SHA256 signatures.
         // Field name is still callbackSecretHash (pre-existing column) — stores encrypted value.
-        subscription.setCallbackSecretHash(encryptionService.encrypt(callbackSecret));
+        // Phase A5 D38: encrypted under the per-tenant DEK, not the shared
+        // platform key. The column name rename to callback_secret_encrypted
+        // is a separate housekeeping migration.
+        subscription.setCallbackSecretHash(
+                encryptionService.encryptForTenant(tenantId, KeyPurpose.WEBHOOK_SECRET, callbackSecret));
         subscription.setStatus("ACTIVE");
         subscription.setExpiresAt(Instant.now().plus(365, ChronoUnit.DAYS));
         subscription.setCreatedAt(Instant.now());
@@ -277,10 +282,15 @@ public class SubscriptionService {
 
     /**
      * Decrypt a stored webhook callback secret for HMAC computation.
-     * Public so WebhookDeliveryService can call it.
+     * Public so {@link WebhookDeliveryService} can call it.
+     *
+     * <p>Phase A5 D38: tenant-scoped. The delivery path always has the
+     * {@code Subscription} object in hand, so {@code subscription.getTenantId()}
+     * is the right source. v0 ciphertexts (pre-V74) continue to decrypt via
+     * the defense-in-depth v0 fallback in {@code SecretEncryptionService}.
      */
-    public String decryptCallbackSecret(String encryptedSecret) {
-        return encryptionService.decrypt(encryptedSecret);
+    public String decryptCallbackSecret(UUID tenantId, String encryptedSecret) {
+        return encryptionService.decryptForTenant(tenantId, KeyPurpose.WEBHOOK_SECRET, encryptedSecret);
     }
 
     private JsonString toJsonString(Map<String, Object> filter) {

--- a/backend/src/main/java/org/fabt/subscription/service/WebhookDeliveryService.java
+++ b/backend/src/main/java/org/fabt/subscription/service/WebhookDeliveryService.java
@@ -126,7 +126,8 @@ public class WebhookDeliveryService {
             ));
 
             // Decrypt the stored secret for HMAC computation (AES-256-GCM at rest)
-            String hmacKey = subscriptionService.decryptCallbackSecret(subscription.getCallbackSecretHash());
+            String hmacKey = subscriptionService.decryptCallbackSecret(
+                    subscription.getTenantId(), subscription.getCallbackSecretHash());
             String signature = "sha256=" + computeHmacSha256(hmacKey, jsonBody);
 
             // D12 (cross-tenant-isolation-audit Phase 2.14): dial-time SSRF
@@ -280,7 +281,8 @@ public class WebhookDeliveryService {
         }
 
         // Decrypt the stored secret for HMAC computation (AES-256-GCM at rest)
-        String hmacKey = subscriptionService.decryptCallbackSecret(subscription.getCallbackSecretHash());
+        String hmacKey = subscriptionService.decryptCallbackSecret(
+                subscription.getTenantId(), subscription.getCallbackSecretHash());
         String signature = "sha256=" + computeHmacSha256(hmacKey, jsonBody);
 
         log.debug("Delivering event {} to {} for subscription {}",

--- a/backend/src/test/java/db/migration/V74ReencryptIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V74ReencryptIntegrationTest.java
@@ -1,0 +1,323 @@
+package db.migration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.sql.Connection;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.sql.DataSource;
+
+import org.flywaydb.core.api.migration.Context;
+import org.fabt.Application;
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.shared.security.KeyPurpose;
+import org.fabt.shared.security.SecretEncryptionService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * V74 re-encrypt migration integration test (task 2.13.12 — design-a5-v74 §6).
+ *
+ * <p>Exercises the migration end-to-end against a Testcontainers Postgres:
+ * seeds v0 ciphertext directly via JDBC, invokes {@code migrate(Context)},
+ * asserts the migration produced v1 envelopes that round-trip through the
+ * runtime {@link SecretEncryptionService#decryptForTenant} path. Cross-tenant
+ * DEK separation, idempotency, and the audit row contract are all verified
+ * against real Postgres state, not mocks.
+ *
+ * <p>Why the env-var-property fallback: V74 reads {@code FABT_ENCRYPTION_KEY}
+ * from the process environment. Tests cannot set env vars via
+ * {@code @DynamicPropertySource}, so V74 additionally falls back to
+ * {@code fabt.encryption-key} system property — unreachable in prod (Phase 0
+ * startup guard runs first) but lets the test drive the migration directly.
+ *
+ * <p>Setup dance: Flyway has already run V74 on the shared Testcontainers
+ * schema before this test class starts. Each test seeds fresh v0 data via
+ * JDBC + directly invokes {@code migrate()} again — V74's idempotency
+ * (magic-byte skip) makes this safe. No need to DELETE FROM
+ * flyway_schema_history.
+ */
+@DisplayName("V74 re-encrypt migration (task 2.13 — design-a5)")
+@SpringBootTest(classes = Application.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class V74ReencryptIntegrationTest extends BaseIntegrationTest {
+
+    private static final String PLATFORM_KEY_B64 = "dGVzdC1vbmx5LXRvdHAtZW5jcnlwdGlvbi1rZXktMzI=";
+
+    @Autowired private DataSource dataSource;
+    @Autowired private SecretEncryptionService encryptionService;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private TestAuthHelper authHelper;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    private UUID tenantA;
+    private UUID tenantB;
+
+    @BeforeEach
+    void setUp() {
+        authHelper.setupTestTenant();
+        tenantA = authHelper.getTestTenantId();
+        tenantB = authHelper.setupSecondaryTenant("v74-tenant-b-"
+                + UUID.randomUUID().toString().substring(0, 8)).getId();
+
+        // Ensure V74 can find the key when we invoke it manually.
+        System.setProperty("fabt.encryption-key", PLATFORM_KEY_B64);
+    }
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty("fabt.encryption-key");
+    }
+
+    // ------------------------------------------------------------------
+    // T1 — happy-path round-trip
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T1: v0 TOTP → v1 round-trip decrypts to original plaintext")
+    void t1_happyPath_totpRoundTrip() throws Exception {
+        String plaintextSecret = "HIYA-RFC6238-BASE32-ABCDEFGHIJKL";
+        UUID userId = seedUserWithV0Totp(tenantA, plaintextSecret);
+
+        invokeV74();
+
+        String stored = jdbc.queryForObject(
+                "SELECT totp_secret_encrypted FROM app_user WHERE id = ?",
+                String.class, userId);
+        assertTrue(isV1(stored), "post-V74 stored value must be v1 envelope");
+        assertEquals(plaintextSecret,
+                encryptionService.decryptForTenant(tenantA, KeyPurpose.TOTP, stored),
+                "v1 ciphertext must decrypt to original plaintext under tenant DEK");
+    }
+
+    // ------------------------------------------------------------------
+    // T2 — idempotency on re-run
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T2: re-running V74 on v1 rows skips them (idempotent)")
+    void t2_idempotentReRun() throws Exception {
+        String plaintextSecret = "IDEMPOTENT-TOTP-SECRET-DO-NOT-CRY";
+        UUID userId = seedUserWithV0Totp(tenantA, plaintextSecret);
+
+        invokeV74();
+        String firstPassStored = jdbc.queryForObject(
+                "SELECT totp_secret_encrypted FROM app_user WHERE id = ?",
+                String.class, userId);
+
+        invokeV74();
+        String secondPassStored = jdbc.queryForObject(
+                "SELECT totp_secret_encrypted FROM app_user WHERE id = ?",
+                String.class, userId);
+
+        assertEquals(firstPassStored, secondPassStored,
+                "v1 row must not be re-encrypted on a second V74 pass (idempotency via magic-byte skip)");
+    }
+
+    // ------------------------------------------------------------------
+    // T3 — cross-tenant DEK separation
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T3: v1 TOTP for tenantA cannot be decrypted under tenantB DEK")
+    void t3_crossTenantDekSeparation() throws Exception {
+        String plaintextSecret = "CROSS-TENANT-SEPARATION-TEST-ABCD";
+        UUID userId = seedUserWithV0Totp(tenantA, plaintextSecret);
+
+        invokeV74();
+
+        String stored = jdbc.queryForObject(
+                "SELECT totp_secret_encrypted FROM app_user WHERE id = ?",
+                String.class, userId);
+
+        // Attempt cross-tenant decrypt — SecretEncryptionService throws
+        // CrossTenantCiphertextException because the kid resolves to tenantA,
+        // not tenantB.
+        assertThrows(org.fabt.shared.security.CrossTenantCiphertextException.class,
+                () -> encryptionService.decryptForTenant(tenantB, KeyPurpose.TOTP, stored),
+                "cross-tenant decrypt must reject via kid tenant mismatch");
+    }
+
+    // ------------------------------------------------------------------
+    // T5 — empty table no-op (variant: tenants with no encryptable columns)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T5: no candidate rows → V74 completes cleanly + audit row fires with zero counts")
+    void t5_emptyStateNoOp() throws Exception {
+        // Clear any stray TOTP + webhook rows for the test tenants to simulate
+        // the no-candidate case. Don't touch other tenants — shared container.
+        jdbc.update("UPDATE app_user SET totp_secret_encrypted = NULL "
+                + "WHERE tenant_id IN (?, ?)", tenantA, tenantB);
+        jdbc.update("DELETE FROM subscription WHERE tenant_id IN (?, ?)", tenantA, tenantB);
+
+        long auditRowsBefore = countV74AuditRows();
+        invokeV74();
+        long auditRowsAfter = countV74AuditRows();
+
+        assertEquals(auditRowsBefore + 1, auditRowsAfter,
+                "V74 must write exactly one audit row even on no-op runs");
+    }
+
+    // ------------------------------------------------------------------
+    // T9 — audit row contract
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T9: audit row carries expanded JSONB (duration_ms, KEK fingerprint, per-column counts)")
+    void t9_auditRowShape() throws Exception {
+        String plaintextSecret = "AUDIT-ROW-SHAPE-TOTP-SECRET-GOGO";
+        seedUserWithV0Totp(tenantA, plaintextSecret);
+
+        invokeV74();
+
+        String detailsJson = jdbc.queryForObject(
+                "SELECT details::text FROM audit_events "
+                + "WHERE action = 'SYSTEM_MIGRATION_V74_REENCRYPT' "
+                + "ORDER BY timestamp DESC LIMIT 1",
+                String.class);
+
+        // Postgres JSONB::text serializes with a space after each colon, so
+        // match on the key name only.
+        assertNotNull(detailsJson, "V74 must write an audit row");
+        assertTrue(detailsJson.contains("\"migration\""), detailsJson);
+        assertTrue(detailsJson.contains("\"V74\""), detailsJson);
+        assertTrue(detailsJson.contains("\"duration_ms\""), detailsJson);
+        assertTrue(detailsJson.contains("\"master_kek_fingerprint\""), detailsJson);
+        assertTrue(detailsJson.contains("\"flyway_role\""), detailsJson);
+        assertTrue(detailsJson.contains("\"totp_reencrypted\""), detailsJson);
+        assertTrue(detailsJson.contains("\"webhook_reencrypted\""), detailsJson);
+        assertTrue(detailsJson.contains("\"oauth2_reencrypted\""), detailsJson);
+        assertTrue(detailsJson.contains("\"hmis_reencrypted\""), detailsJson);
+        assertTrue(detailsJson.contains("\"totp_skipped_already_v1\""), detailsJson);
+        assertTrue(detailsJson.contains("\"totp_skipped_null_tenant\""), detailsJson);
+    }
+
+    // ------------------------------------------------------------------
+    // T11 — KeyPurpose.values() round-trip (catches future enum additions)
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T11: every KeyPurpose round-trips through encryptForTenant/decryptForTenant")
+    void t11_keyPurposeEnumCoverage() {
+        String plaintext = "round-trip-" + UUID.randomUUID();
+        for (KeyPurpose purpose : KeyPurpose.values()) {
+            String ciphertext = encryptionService.encryptForTenant(tenantA, purpose, plaintext);
+            assertTrue(isV1(ciphertext),
+                    purpose + " encrypt must produce v1 envelope");
+            String decrypted = encryptionService.decryptForTenant(tenantA, purpose, ciphertext);
+            assertEquals(plaintext, decrypted,
+                    purpose + " round-trip must preserve plaintext");
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Helpers
+    // ------------------------------------------------------------------
+
+    /**
+     * Seeds a pre-existing user with a v0-shape {@code totp_secret_encrypted}.
+     * Uses the V59 envelope format: {@code [iv: 12][ct+tag: N+16]} Base64.
+     * Returns the user id.
+     */
+    private UUID seedUserWithV0Totp(UUID tenantId, String plaintext) throws Exception {
+        var user = authHelper.createUserInTenant(tenantId,
+                "v74-test-" + UUID.randomUUID() + "@test.fabt.org",
+                "V74 Test User", new String[]{"OUTREACH_WORKER"}, false);
+
+        String v0Ciphertext = encryptV0(plaintext);
+        jdbc.update("UPDATE app_user SET totp_secret_encrypted = ? WHERE id = ?",
+                v0Ciphertext, user.getId());
+        return user.getId();
+    }
+
+    private String encryptV0(String plaintext) throws Exception {
+        byte[] keyBytes = Base64.getDecoder().decode(PLATFORM_KEY_B64);
+        SecretKey key = new SecretKeySpec(keyBytes, "AES");
+        byte[] iv = new byte[12];
+        secureRandom.nextBytes(iv);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, key, new GCMParameterSpec(128, iv));
+        byte[] ct = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+        ByteBuffer buf = ByteBuffer.allocate(iv.length + ct.length);
+        buf.put(iv);
+        buf.put(ct);
+        return Base64.getEncoder().encodeToString(buf.array());
+    }
+
+    private boolean isV1(String stored) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            return decoded.length >= 5
+                    && decoded[0] == 0x46 && decoded[1] == 0x41
+                    && decoded[2] == 0x42 && decoded[3] == 0x54
+                    && decoded[4] == 0x01;
+        } catch (IllegalArgumentException badBase64) {
+            return false;
+        }
+    }
+
+    private long countV74AuditRows() {
+        Long count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM audit_events WHERE action = 'SYSTEM_MIGRATION_V74_REENCRYPT'",
+                Long.class);
+        return count == null ? 0L : count;
+    }
+
+    /**
+     * Invokes V74's {@code migrate} method against a minimal Flyway Context
+     * stub. We only need {@code getConnection()} — V74 doesn't touch
+     * configuration. Using a live Connection borrowed from the Spring-managed
+     * DataSource is intentional: V74 runs its UPDATEs in the same session and
+     * Flyway's own transaction boundary logic is not replayed here (each test
+     * sees V74's effects immediately; the @AfterEach tenant cleanup handles
+     * isolation).
+     */
+    private void invokeV74() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(true);
+            var migration = new V74__reencrypt_secrets_under_per_tenant_deks();
+            migration.migrate(new StubContext(conn));
+        }
+    }
+
+    /** Minimal Flyway Context — just enough for {@code getConnection()}. */
+    private static final class StubContext implements Context {
+        private final Connection conn;
+
+        StubContext(Connection conn) {
+            this.conn = conn;
+        }
+
+        @Override
+        public org.flywaydb.core.api.configuration.Configuration getConfiguration() {
+            return null;
+        }
+
+        @Override
+        public Connection getConnection() {
+            return conn;
+        }
+    }
+}

--- a/backend/src/test/java/db/migration/V74ReencryptIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V74ReencryptIntegrationTest.java
@@ -293,6 +293,15 @@ class V74ReencryptIntegrationTest extends BaseIntegrationTest {
      * Flyway's own transaction boundary logic is not replayed here (each test
      * sees V74's effects immediately; the @AfterEach tenant cleanup handles
      * isolation).
+     *
+     * <p><b>Test-realism caveat:</b> we set {@code autoCommit = true} so
+     * individual UPDATEs are visible to subsequent assertions without an
+     * explicit commit. This means V74's {@code SET LOCAL lock_timeout} +
+     * {@code statement_timeout} (C-A5-N1) emit a Postgres NOTICE and become
+     * no-ops — they require a transaction block to take effect. Real Flyway
+     * wraps {@code migrate()} in a transaction, so prod behavior is correct.
+     * Not a regression, just a test-stub limitation worth flagging so a
+     * future reader doesn't chase a phantom bug.
      */
     private void invokeV74() throws Exception {
         try (Connection conn = dataSource.getConnection()) {

--- a/backend/src/test/java/org/fabt/architecture/TenantGuardUnitTest.java
+++ b/backend/src/test/java/org/fabt/architecture/TenantGuardUnitTest.java
@@ -96,14 +96,23 @@ class TenantGuardUnitTest {
         when(providerRepo.findByTenantIdAndProviderName(TENANT_ID, "okta"))
                 .thenReturn(Optional.empty());
         when(providerRepo.save(any())).thenAnswer(inv -> inv.getArgument(0));
-        when(encryptionService.encrypt("plain-secret")).thenReturn("CIPHERTEXT");
+        // Phase A5 D38: encrypt flow now goes through encryptForTenant with
+        // KeyPurpose.OAUTH2_CLIENT_SECRET. Stub the new typed API and verify
+        // the same method is invoked.
+        when(encryptionService.encryptForTenant(
+                TENANT_ID,
+                org.fabt.shared.security.KeyPurpose.OAUTH2_CLIENT_SECRET,
+                "plain-secret")).thenReturn("CIPHERTEXT");
 
         var service = new TenantOAuth2ProviderService(providerRepo, urlValidator, encryptionService);
         TenantContext.runWithContext(TENANT_ID, false, () ->
                 service.create("okta", "client-x", "plain-secret",
                         "https://login.microsoftonline.com/common/v2.0"));
 
-        verify(encryptionService).encrypt("plain-secret");
+        verify(encryptionService).encryptForTenant(
+                TENANT_ID,
+                org.fabt.shared.security.KeyPurpose.OAUTH2_CLIENT_SECRET,
+                "plain-secret");
     }
 
     @Test

--- a/backend/src/test/java/org/fabt/auth/OAuth2EncryptionRoundTripIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/auth/OAuth2EncryptionRoundTripIntegrationTest.java
@@ -10,6 +10,7 @@ import org.fabt.auth.domain.TenantOAuth2Provider;
 import org.fabt.auth.repository.TenantOAuth2ProviderRepository;
 import org.fabt.auth.service.DynamicClientRegistrationSource;
 import org.fabt.auth.service.TenantOAuth2ProviderService;
+import org.fabt.shared.security.KeyPurpose;
 import org.fabt.shared.security.SecretEncryptionService;
 import org.fabt.shared.web.TenantContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,7 +72,9 @@ class OAuth2EncryptionRoundTripIntegrationTest extends BaseIntegrationTest {
         assertNotNull(stored, "stored secret must be non-null");
         assertNotEquals(plaintextSecret, stored,
                 "stored secret must be ciphertext, not plaintext");
-        assertEquals(plaintextSecret, encryptionService.decrypt(stored),
+        // Phase A5 D38: v1 envelope — use decryptForTenant with OAUTH2_CLIENT_SECRET.
+        assertEquals(plaintextSecret,
+                encryptionService.decryptForTenant(tenantId, KeyPurpose.OAUTH2_CLIENT_SECRET, stored),
                 "ciphertext must decrypt to the original plaintext");
     }
 
@@ -110,7 +113,8 @@ class OAuth2EncryptionRoundTripIntegrationTest extends BaseIntegrationTest {
                 .getClientSecretEncrypted();
 
         assertNotEquals(firstStored, secondStored, "stored ciphertext must change on update");
-        assertEquals(secondSecret, encryptionService.decrypt(secondStored));
+        assertEquals(secondSecret,
+                encryptionService.decryptForTenant(tenantId, KeyPurpose.OAUTH2_CLIENT_SECRET, secondStored));
     }
 
     @Test

--- a/backend/src/test/java/org/fabt/auth/TotpAndAccessCodeIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/auth/TotpAndAccessCodeIntegrationTest.java
@@ -409,7 +409,7 @@ class TotpAndAccessCodeIntegrationTest extends BaseIntegrationTest {
         if (!totpService.isEncryptionConfigured()) return null;
 
         String secret = totpService.generateSecret();
-        user.setTotpSecretEncrypted(totpService.encryptSecret(secret));
+        user.setTotpSecretEncrypted(totpService.encryptSecret(user.getTenantId(), secret));
         user.setTotpEnabled(true);
 
         TotpService.BackupCodes codes = totpService.generateBackupCodes();
@@ -583,7 +583,7 @@ class TotpAndAccessCodeIntegrationTest extends BaseIntegrationTest {
         // the self-enrollment flow — same shape as line 49 test setup).
         String testSecret = totpService.generateSecret();
         tenantBUser.setTotpEnabled(true);
-        tenantBUser.setTotpSecretEncrypted(totpService.encryptSecret(testSecret));
+        tenantBUser.setTotpSecretEncrypted(totpService.encryptSecret(tenantBUser.getTenantId(), testSecret));
         tenantBUser.setRecoveryCodes("[\"hash1\",\"hash2\"]");
         tenantBUser.setUpdatedAt(java.time.Instant.now());
         authHelper.getUserRepository().save(tenantBUser);
@@ -636,7 +636,7 @@ class TotpAndAccessCodeIntegrationTest extends BaseIntegrationTest {
         String originalCodesJson = "[\"original-hash-1\",\"original-hash-2\"]";
         String testSecret = totpService.generateSecret();
         tenantBUser.setTotpEnabled(true);
-        tenantBUser.setTotpSecretEncrypted(totpService.encryptSecret(testSecret));
+        tenantBUser.setTotpSecretEncrypted(totpService.encryptSecret(tenantBUser.getTenantId(), testSecret));
         tenantBUser.setRecoveryCodes(originalCodesJson);
         tenantBUser.setUpdatedAt(java.time.Instant.now());
         authHelper.getUserRepository().save(tenantBUser);

--- a/backend/src/test/java/org/fabt/hmis/HmisEncryptionRoundTripIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/hmis/HmisEncryptionRoundTripIntegrationTest.java
@@ -9,6 +9,7 @@ import org.fabt.TestAuthHelper;
 import org.fabt.hmis.domain.HmisVendorConfig;
 import org.fabt.hmis.domain.HmisVendorType;
 import org.fabt.hmis.service.HmisConfigService;
+import org.fabt.shared.security.KeyPurpose;
 import org.fabt.shared.security.SecretEncryptionService;
 import org.fabt.tenant.service.TenantService;
 import org.junit.jupiter.api.AfterEach;
@@ -77,28 +78,31 @@ class HmisEncryptionRoundTripIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("encryptApiKey produces ciphertext that round-trips through SecretEncryptionService")
+    @DisplayName("encryptApiKey produces v1 ciphertext that round-trips through decryptForTenant")
     void encryptApiKeyRoundTripsThroughSharedService() {
         String plaintext = "hmis-api-key-" + UUID.randomUUID();
-        String ciphertext = hmisConfigService.encryptApiKey(plaintext);
+        String ciphertext = hmisConfigService.encryptApiKey(tenantId, plaintext);
 
         assertNotEquals(plaintext, ciphertext);
-        assertEquals(plaintext, encryptionService.decrypt(ciphertext));
+        // Phase A5 D38: encryptApiKey now writes v1 envelope bytes under the
+        // tenant's HMIS DEK. Round-trip must go through the typed API.
+        assertEquals(plaintext,
+                encryptionService.decryptForTenant(tenantId, KeyPurpose.HMIS_API_KEY, ciphertext));
     }
 
     @Test
     @DisplayName("encryptApiKey returns null/blank inputs unchanged (safe-by-default)")
     void encryptApiKeyHandlesNullAndBlank() {
-        assertEquals(null, hmisConfigService.encryptApiKey(null));
-        assertEquals("", hmisConfigService.encryptApiKey(""));
-        assertEquals("   ", hmisConfigService.encryptApiKey("   "));
+        assertEquals(null, hmisConfigService.encryptApiKey(tenantId, null));
+        assertEquals("", hmisConfigService.encryptApiKey(tenantId, ""));
+        assertEquals("   ", hmisConfigService.encryptApiKey(tenantId, "   "));
     }
 
     @Test
     @DisplayName("getVendors decrypts hmis_vendors[].api_key_encrypted ciphertext back to plaintext")
     void getVendorsDecryptsCiphertextOnRead() {
         String plaintext = "round-trip-key-" + UUID.randomUUID();
-        String ciphertext = hmisConfigService.encryptApiKey(plaintext);
+        String ciphertext = hmisConfigService.encryptApiKey(tenantId, plaintext);
 
         tenantService.updateConfig(tenantId, Map.of(
                 "hmis_vendors", List.of(Map.of(
@@ -159,7 +163,7 @@ class HmisEncryptionRoundTripIntegrationTest extends BaseIntegrationTest {
                                 "id", UUID.randomUUID().toString(),
                                 "type", HmisVendorType.CLARITY.name(),
                                 "base_url", "https://on.test",
-                                "api_key_encrypted", hmisConfigService.encryptApiKey(enabledPlain),
+                                "api_key_encrypted", hmisConfigService.encryptApiKey(tenantId, enabledPlain),
                                 "enabled", true,
                                 "push_interval_hours", 6
                         ),
@@ -167,7 +171,7 @@ class HmisEncryptionRoundTripIntegrationTest extends BaseIntegrationTest {
                                 "id", UUID.randomUUID().toString(),
                                 "type", HmisVendorType.CLIENTTRACK.name(),
                                 "base_url", "https://off.test",
-                                "api_key_encrypted", hmisConfigService.encryptApiKey(disabledPlain),
+                                "api_key_encrypted", hmisConfigService.encryptApiKey(tenantId, disabledPlain),
                                 "enabled", false,
                                 "push_interval_hours", 6
                         )


### PR DESCRIPTION
## Summary

Completes Phase A of **multi-tenant-production-readiness** (#126 task 2.13) — the V74 re-encrypt migration sweeping every existing v0 ciphertext (single-platform-key) to v1 per-tenant-DEK envelopes, plus the companion service-layer refactor that threads `tenantId` through every encrypt/decrypt callsite via the typed `encryptForTenant` / `decryptForTenant` API.

Scope per A3 D22 + design-a5: **all four** per-tenant encrypted columns — `app_user.totp_secret_encrypted`, `subscription.callback_secret_hash`, `tenant_oauth2_provider.client_secret_encrypted`, `tenant.config → hmis_vendors[].api_key_encrypted`.

Ships with Phase 0 + Phase A as **v0.42**. Phase A5 is the final piece.

## Warroom audits

**Pre-implementation warroom** (Marcus Webb / security, Jordan / DBA, Sam / SRE): 3 APPROVE-WITH-MUST-FIX verdicts → 10 critical + 7 strong-warning items captured as C-A5-N1..10 and W-A5-1..7 in `openspec/changes/multi-tenant-production-readiness/design-a5-v74-reencrypt.md` §11. All 10 must-fix items implemented + 6 of 7 strong warnings in this PR (W-A5-2 expanded T4 variants deferred with design-doc note).

**Final implementation warroom**: APPROVE FOR PR. Verified every C-A5-N item is present at the named line; HKDF + envelope constants match runtime byte-for-byte; CHANGELOG release-gate wording accurate. Applied 2 docs-only cleanup items before opening this PR.

## What ships

### V74 migration (`db.migration.V74__reencrypt_secrets_under_per_tenant_deks`)
- **C-A5-N1** — `SET LOCAL lock_timeout=30s + statement_timeout=5min` at `migrate()` start
- **C-A5-N2** — `WHERE tenant_id IS NOT NULL` filter on every candidate SELECT; NULL-tenant preflight count reported in audit JSONB
- **C-A5-N3** — per-row round-trip verify (decrypt fresh v1 → assertEquals plaintext) catches tenant_id drift + HKDF salt misalignment
- **C-A5-N5** — hardened `StreamReadConstraints` ObjectMapper (max nesting 64, max string 1 MB, max number 1k) for the JSONB vendor-walker
- **C-A5-N6** — session role logged at start + recorded in audit `flyway_role` field (must be BYPASSRLS or owner, per runbook 2.16)
- **C-A5-N7** — Phase A preflight (fails if V60+V61 absent from `flyway_schema_history`)
- **C-A5-N9** — dev-skip recovery procedure documented in migration Javadoc
- **C-A5-N10** — expanded audit JSONB: `duration_ms`, `master_kek_fingerprint` (HMAC-SHA256 under fixed label), `flyway_role`, per-column reencrypted / skipped-v1 / skipped-null counts — serialized via `ObjectMapper.writeValueAsString(Map.of(...))` (not `String.format` — W-A5-1)
- **W-A5-4** — `SELECT ... FOR UPDATE` on candidate rows
- **W-A5-6** — structured `V74 COMMITTED` final log
- **W-A5-7** — memory-footprint Javadoc with 10k-row scale threshold

### Observability (C-A5-N4)
`SecretEncryptionService.decryptForTenant`'s v0-fallback path now:
- Increments `fabt.security.v0_decrypt_fallback.count` counter (tagged by purpose + tenant_id)
- Emits throttled `CIPHERTEXT_V0_DECRYPT` audit event (≤ 1 per (tenant, purpose) per 60s)

Catches both stuck-row repair cases AND hostile v0-forgery downgrade-attack indicators post-V74.

### Service-layer refactor (D38 + D39)
- `TotpService.encryptSecret` / `decryptSecret` now take `UUID tenantId` (passed from `user.getTenantId()` in `TotpController` + `AuthController` MFA verify)
- `SubscriptionService.create` internally calls `encryptForTenant(tenantId, WEBHOOK_SECRET, ...)`; `decryptCallbackSecret` takes `UUID tenantId` (passed from `subscription.getTenantId()` in `WebhookDeliveryService` both delivery paths)
- `TenantOAuth2ProviderService.create` / `update` internally call `encryptForTenant(tenantId, OAUTH2_CLIENT_SECRET, ...)`
- `HmisConfigService.encryptApiKey` / `decryptApiKey` take `UUID tenantId`
- `DynamicClientRegistrationSource.decryptClientSecret` takes `UUID tenantId`
- `SecretEncryptionService.encrypt` / `decrypt` marked `@Deprecated(since="v0.42", forRemoval=true)` — retained only for V74 migration internal use
- `CiphertextV0Decoder` class-level Javadoc carries explicit DO-NOT-REMOVE contract (W-A5-5)

### Release gate (C-A5-N8)
`CHANGELOG.md` [Unreleased] LEADS with bold `⚠️ v0.41 → v0.42 is ONE-WAY` banner enumerating the full outage surface: TOTP login + webhook signing + OAuth2 SSO + HMIS outbound all break on v0.41-against-v1 DB. Release gate forbids any Phase-0-only v0.41.x line.

## Test plan

- [x] Run `V74ReencryptIntegrationTest` locally — 6/6 green (T1 happy-path, T2 idempotency, T3 cross-tenant DEK separation, T5 empty-state no-op, T9 audit JSONB shape, T11 `KeyPurpose.values()` enum coverage)
- [x] Run targeted regression suite — 156/156 green: `*Encryption*`, `*Totp*`, `*Subscription*`, `*Jwt*`, `*HMIS*`, `*Webhook*`, `TenantKeyRotation*`, `KidRegistry*`, `GlobalExceptionHandler*Test`, `SecurityStartup*`
- [x] Full `mvn test-compile` clean
- [ ] CI: wait for full suite green before merging
- [ ] Pre-deploy (gated by v0.42 runbook): `pg_dump` + verify `\dp` grants on affected tables as the Flyway role

## Follow-ups (post-merge, same issue #126)

- Task 2.16 key-rotation runbook (`docs/security/key-rotation-runbook.md`) with mandatory pre-deploy `pg_dump` procedure
- `v0.42` oracle-update-notes covering the combined Phase 0 + A + A5 deploy
- 7-day post-deploy tracker issue for legacy-JWT path removal
- W-A5-2 expanded T4 test variants (truncated / forged-kid / unregistered-kid v1 envelopes) — documented as deferred in design §11
- Column rename `subscription.callback_secret_hash` → `callback_secret_encrypted` (housekeeping migration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
