### PR TITLE
fix: 2 missing i18n keys + coverage test (Spanish "Security" regression)

### DIFF
--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -591,6 +591,7 @@
   "login.forgotPassword": "Forgot password?",
   "login.organizationPlaceholder": "my-organization",
   "login.emailPlaceholder": "you@example.com",
+  "totp.settingsButton": "Security",
   "forgotPassword.title": "Reset Your Password",
   "forgotPassword.instructions": "Enter your organization and email address. If an account exists, we'll send a reset link.",
   "forgotPassword.submit": "Send Reset Link",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -591,6 +591,7 @@
   "login.forgotPassword": "¿Olvidó su contraseña?",
   "login.organizationPlaceholder": "mi-organización",
   "login.emailPlaceholder": "usted@ejemplo.com",
+  "totp.settingsButton": "Seguridad",
   "forgotPassword.title": "Restablecer Contraseña",
   "forgotPassword.instructions": "Ingrese su organización y correo electrónico. Si existe una cuenta, enviaremos un enlace de restablecimiento.",
   "forgotPassword.submit": "Enviar Enlace",

--- a/frontend/src/i18n/i18n-coverage.test.ts
+++ b/frontend/src/i18n/i18n-coverage.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+import enMessages from './en.json';
+import esMessages from './es.json';
+
+/**
+ * i18n coverage lint — every `<FormattedMessage id="...">` and
+ * `intl.formatMessage({ id: '...' })` reference in the source tree must
+ * have a matching key in BOTH en.json and es.json. Missing keys fall
+ * back to the `defaultMessage=` value (always English) regardless of
+ * locale, which produces silent English-in-Spanish bugs that Sam and
+ * Tomás would consider an a11y violation.
+ *
+ * Pre-existing bugs caught by the manual audit that led to this test:
+ * - `login.organization` / `login.organizationPlaceholder` /
+ *   `login.emailPlaceholder` — rendered literal key text on
+ *   `/login/forgot-password` since v0.29. Fixed in v0.44.2.
+ * - `totp.settingsButton` — Layout.tsx defaultMessage="Security" fell
+ *   through to English for Spanish users. Fixed in v0.44.3.
+ * - `referral.requestTitle` — aria-label on DV referral modal. Fixed
+ *   in v0.44.3 by reusing existing `referral.title` key.
+ *
+ * If this test fails, either (a) add the missing key to both en.json
+ * and es.json, or (b) change the code to use an existing key.
+ */
+
+const FRONTEND_SRC = join(__dirname, '..', '..', 'src');
+const SKIP_DIRS = new Set(['node_modules', 'dist', 'dist-v0.32.1-backup']);
+
+function walkSourceFiles(root: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(root)) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const full = join(root, entry);
+    const s = statSync(full);
+    if (s.isDirectory()) out.push(...walkSourceFiles(full));
+    else if (s.isFile() && (entry.endsWith('.tsx') || entry.endsWith('.ts')) && !entry.endsWith('.test.ts') && !entry.endsWith('.test.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+function extractReferencedIds(): Set<string> {
+  const ids = new Set<string>();
+  const fmPattern = /<FormattedMessage\s+id="([^"]+)"/g;
+  const imPattern = /formatMessage\(\{\s*id:\s*['"]([^'"]+)['"]/g;
+  for (const file of walkSourceFiles(FRONTEND_SRC)) {
+    const text = readFileSync(file, 'utf8');
+    for (const m of text.matchAll(fmPattern)) ids.add(m[1]);
+    for (const m of text.matchAll(imPattern)) ids.add(m[1]);
+  }
+  return ids;
+}
+
+describe('i18n coverage', () => {
+  const referenced = extractReferencedIds();
+  const en = enMessages as Record<string, string>;
+  const es = esMessages as Record<string, string>;
+
+  it('every referenced id is present in en.json', () => {
+    const missing = [...referenced].filter((k) => !(k in en)).sort();
+    expect(missing, `keys referenced in source but missing in en.json:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+
+  it('every referenced id is present in es.json', () => {
+    const missing = [...referenced].filter((k) => !(k in es)).sort();
+    expect(missing, `keys referenced in source but missing in es.json:\n  ${missing.join('\n  ')}`).toEqual([]);
+  });
+
+  it('en.json and es.json have matching key sets (no locale drift)', () => {
+    const enKeys = new Set(Object.keys(en));
+    const esKeys = new Set(Object.keys(es));
+    const enOnly = [...enKeys].filter((k) => !esKeys.has(k)).sort();
+    const esOnly = [...esKeys].filter((k) => !enKeys.has(k)).sort();
+    expect(enOnly, `keys in en.json but not es.json:\n  ${enOnly.join('\n  ')}`).toEqual([]);
+    expect(esOnly, `keys in es.json but not en.json:\n  ${esOnly.join('\n  ')}`).toEqual([]);
+  });
+});

--- a/frontend/src/pages/OutreachSearch.tsx
+++ b/frontend/src/pages/OutreachSearch.tsx
@@ -1071,7 +1071,7 @@ export function OutreachSearch() {
             ref={referralModalRef}
             role="dialog"
             aria-modal="true"
-            aria-label={intl.formatMessage({ id: 'referral.requestTitle' })}
+            aria-label={intl.formatMessage({ id: 'referral.title' })}
             tabIndex={-1}
             onKeyDown={(e) => { if (e.key === 'Escape') setReferralModal(null); }}
             data-testid="referral-modal"


### PR DESCRIPTION
## Summary

User-reported 2026-04-18 post-v0.44.2 deploy: the "Security" menu item in `Layout.tsx` stays in English when switching to Spanish. Root cause: `<FormattedMessage id="totp.settingsButton" defaultMessage="Security" />` references a key that doesn't exist in either locale → react-intl falls back to `defaultMessage` for ALL locales.

Same class of bug as the `login.organization`/`login.organizationPlaceholder`/`login.emailPlaceholder` gaps fixed in v0.44.2.

## Audit scope

- **513 unique i18n IDs** referenced across `frontend/src`
- **41 of them** use `defaultMessage=` as fallback
- en.json + es.json: **662 keys each** (matched count pre-fix)
- **Only 2 keys missing** across both locales:
  - `totp.settingsButton` — user-visible (Layout.tsx × 2)
  - `referral.requestTitle` — aria-label on DV referral modal

## Fixes

- **`totp.settingsButton`**: added to en.json ("Security") + es.json ("Seguridad").
- **`referral.requestTitle`**: changed OutreachSearch.tsx aria-label to reuse existing `referral.title` key. Aligns the aria-label with the modal's visible `<h3>` (already uses `referral.title`), avoids creating a redundant new key.

## Prevention (the real fix)

New `frontend/src/i18n/i18n-coverage.test.ts` with 3 Vitest assertions:
1. Every `<FormattedMessage id="...">` + `formatMessage({ id: '...' })` reference exists in en.json
2. Same for es.json
3. en.json + es.json have matching key sets (no locale drift)

Runs in the existing Vitest suite on every frontend CI gate. No new CI job. Fails fast with the missing key names in the assertion output.

## Test plan

- [x] `npx vitest run` → 139/139 (3 new i18n-coverage tests pass)
- [x] `npm run build` green
- [ ] CI green (backend, frontend, legal-scan, etc.)
- [ ] After merge + deploy: manual check that Spanish toggle shows "Seguridad" in Layout menu

## Next steps (deferred)

- Ship as v0.44.3 (frontend-only, same pattern as v0.44.2; ~5-min deploy)

Refs #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)