### PR TITLE
Phase B close-out: PG floor + pgaudit tenant tag + Flyway HWM guard + residual ITs (v0.45.0)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -29,13 +29,14 @@
 # Phase B source-side invariants — FORCE RLS policy migrations + the
 # runtime RLS wiring. A change here without a matching spec/test update
 # is the exact regression class Phase B was built to prevent.
-/backend/src/main/resources/db/migration/V67__*  @ccradle
-/backend/src/main/resources/db/migration/V68__*  @ccradle
-/backend/src/main/resources/db/migration/V69__*  @ccradle
-/backend/src/main/resources/db/migration/V70__*  @ccradle
-/backend/src/main/resources/db/migration/V71__*  @ccradle
-/backend/src/main/resources/db/migration/V72__*  @ccradle
-/backend/src/main/resources/db/migration/V73__*  @ccradle
+#
+# The catch-all below covers both the existing V67-V73 Phase B files AND
+# any future migration that might touch RLS policies (e.g., a rogue
+# `V99__drop_force_rls.sql` would otherwise slip past file-specific
+# patterns). Warroom recommendation — coverage gap Marcus identified in
+# the v0.45.0 pre-PR review.
+/backend/src/main/resources/db/migration/  @ccradle
+/backend/src/main/java/db/migration/  @ccradle
 /backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java  @ccradle
 /backend/src/main/java/org/fabt/shared/security/ForceRlsHealthGauge.java  @ccradle
 /backend/src/main/java/org/fabt/shared/security/PgVersionGate.java  @ccradle
@@ -50,6 +51,13 @@
 # Flyway posture — prod-state.json is the CI HWM guard's source of truth.
 /deploy/prod-state.json  @ccradle
 /scripts/ci/check-flyway-migration-versions.sh  @ccradle
+
+# Release-gate SHA-256 pins — changes here move the compliance-grade
+# attestation for what shipped. Must be reviewed even if the diff looks
+# trivial (a character-transposition on a hash would silently pass
+# deploy verification on the wrong file).
+/deploy/release-gate-pins.txt  @ccradle
+/scripts/ci/verify-release-gate-pins.sh  @ccradle
 
 # The release-gate file itself — ownership must not be self-editable
 # without a second-pair review in a larger team. Solo for now.

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,56 @@
+# CODEOWNERS — FABT named security reviewers
+#
+# Every path listed below requires the named owner's explicit review on any
+# PR that modifies it. GitHub will auto-request their review; merges are
+# blocked until the named owner approves (branch protection required — see
+# docs/runbook.md).
+#
+# The file doubles as the source of the "named signer" references cited in
+# each release's CHANGELOG entry (warroom W-CHANGELOG-3). When a CHANGELOG
+# entry says "signed off by @ccradle", that's the human this file maps the
+# handle to; the release-gate verification script can look up the mapping
+# here rather than chase Git author-email history.
+#
+# Format: <path-pattern>  <@owner> [<@owner> ...]
+
+# Phase B invariants — the pg_policies snapshot and the tenant-RLS design
+# carry the compliance-grade owner-bypass contract. Changes here must be
+# reviewed + signed by the named security owner even when edits are
+# typos, because any drift against the committed snapshot breaks the
+# release-gate SHA-256 pin (W-CHANGELOG-1).
+/docs/security/pg-policies-snapshot.md  @ccradle
+/docs/security/logical-replication-posture.md  @ccradle
+/docs/security/phase-b-audited-write-sites.md  @ccradle
+/docs/security/phase-b-silent-audit-write-failures-runbook.md  @ccradle
+/docs/security/rls-coverage.md  @ccradle
+/docs/security/safe-tenant-bypass-sites.md  @ccradle
+/docs/security/compliance-posture-matrix.md  @ccradle
+
+# Phase B source-side invariants — FORCE RLS policy migrations + the
+# runtime RLS wiring. A change here without a matching spec/test update
+# is the exact regression class Phase B was built to prevent.
+/backend/src/main/resources/db/migration/V67__*  @ccradle
+/backend/src/main/resources/db/migration/V68__*  @ccradle
+/backend/src/main/resources/db/migration/V69__*  @ccradle
+/backend/src/main/resources/db/migration/V70__*  @ccradle
+/backend/src/main/resources/db/migration/V71__*  @ccradle
+/backend/src/main/resources/db/migration/V72__*  @ccradle
+/backend/src/main/resources/db/migration/V73__*  @ccradle
+/backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java  @ccradle
+/backend/src/main/java/org/fabt/shared/security/ForceRlsHealthGauge.java  @ccradle
+/backend/src/main/java/org/fabt/shared/security/PgVersionGate.java  @ccradle
+
+# pgaudit image + alert pipeline — if these drift, the detection-of-last-
+# resort breaks silently.
+/deploy/pgaudit.Dockerfile  @ccradle
+/deploy/pgaudit.conf  @ccradle
+/infra/scripts/pgaudit-enable.sh  @ccradle
+/infra/scripts/pgaudit-alert-tail.sh  @ccradle
+
+# Flyway posture — prod-state.json is the CI HWM guard's source of truth.
+/deploy/prod-state.json  @ccradle
+/scripts/ci/check-flyway-migration-versions.sh  @ccradle
+
+# The release-gate file itself — ownership must not be self-editable
+# without a second-pair review in a larger team. Solo for now.
+/.github/CODEOWNERS  @ccradle

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,24 @@ permissions:
   contents: read
 
 jobs:
+  flyway-hwm-guard:
+    name: Flyway HWM guard (v0.45 renumber-forward)
+    runs-on: ubuntu-latest
+    # v0.45 task #151 — enforces the renumber-forward Flyway posture
+    # chosen in the Phase B close-out warroom: new migrations must have
+    # version > deploy/prod-state.json.appliedMigrationsHighWaterMark.
+    # Removes the need for SPRING_FLYWAY_OUT_OF_ORDER=true bridge
+    # compose on the VM going forward. See the script docstring +
+    # docs/runbook.md -> 'Flyway Out-of-Order Posture' for rationale.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # need full history to diff PR against base
+      - name: Check new migrations against HWM
+        env:
+          BASE_REF: ${{ github.base_ref && format('origin/{0}', github.base_ref) || 'origin/main' }}
+        run: bash scripts/ci/check-flyway-migration-versions.sh
+
   backend:
     name: Backend (Java 25 + Maven)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,19 @@ permissions:
   contents: read
 
 jobs:
+  release-gate-pin-verify:
+    name: Release-gate SHA-256 pin verify (v0.45 W-CHANGELOG-1)
+    runs-on: ubuntu-latest
+    # Enforces that every SHA-256 in deploy/release-gate-pins.txt matches
+    # the current file content. Makes the pin load-bearing instead of
+    # decorative — an operator editing pg-policies-snapshot.md without
+    # updating the pin (and without CODEOWNERS re-review) will fail CI
+    # before the drift ever reaches prod.
+    steps:
+      - uses: actions/checkout@v4
+      - name: Verify release-gate pins
+        run: bash scripts/ci/verify-release-gate-pins.sh
+
   flyway-hwm-guard:
     name: Flyway HWM guard (v0.45 renumber-forward)
     runs-on: ubuntu-latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,6 +64,43 @@ unchanged.
 - `docs/FOR-DEVELOPERS.md` Tech Stack row updates PostgreSQL floor from
   "16.6+" (stale) to "16.5+ (enforced by `PgVersionGate` at boot)".
 
+### Release Gate
+
+Phase B release-gate artifacts pinned for this tag so operator-side
+rollback can verify the deploy bit-for-bit (W-CHANGELOG-1 and
+W-CHANGELOG-3):
+
+- **`pg_policies` snapshot hash** — `docs/security/pg-policies-snapshot.md`
+  SHA-256: `abca0e94b7626bf855b200a677a1cdd54d3522610417ad3f76c383240e004207`
+  (PostgreSQL 16-line file, 7 regulated tables × USING + WITH CHECK clauses).
+  Recompute during deploy verification with
+  `sha256sum docs/security/pg-policies-snapshot.md`; a mismatch means the
+  snapshot was edited without a corresponding policy-diff review.
+- **Named signer** — `@ccradle`, per `.github/CODEOWNERS` lines 18-26
+  (new in this release). The named-signer + SHA-256 pair satisfies the
+  release-gate #4 acceptance criterion from the Phase B warroom.
+- **Supporting artifacts** — `deploy/prod-state.json` captures the prod
+  Flyway HWM (74) + schemaVersion:1. `PgVersionGate` + its test assert
+  the runtime PG floor (16.5) is above the CVE-2024-10977 gate.
+
+### Added (test infrastructure)
+
+These are test-only additions that ship with v0.45.0 but don't change
+production behavior. All referenced above; listed here for
+release-gate counting.
+
+- `PgVersionGateTest` (2 ITs) + `PgVersionGateUnitTest` (4 unit tests).
+- `PgauditApplicationNameDriftTest` (4 ITs — sequential + null +
+  concurrent + transaction-scoped drift documentation).
+- `PhaseBRlsEnforcementTest` (4 ITs covering task 3.19 + 3.21 + 3.22).
+- `RlsAwareDataSourceFailureTest` (3 unit tests for task 3.18 B12).
+- `ForceRlsHealthGaugeTest` (1 IT validating the W-GAUGE-3
+  `java.sql.Array` fix + gauge publication).
+- `TenantKeyRotationSetConfigReuseTest` (2 ITs — W-B-FIXA-1 pinning no
+  pool-reuse leak from is_local=true override).
+- `MigrationLintTest` (1 lint test — task 3.14 SECURITY DEFINER ban
+  with empty allowlist).
+
 ---
 
 ## [v0.44.3] — 2026-04-19 — i18n hygiene: missing keys + coverage test (#173)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,67 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [v0.45.0] — Phase B close-out: PG floor + pgaudit tenant tag + Flyway HWM guard
+
+Three multi-tenant-production-readiness close-out items agreed in the
+v0.45.0 warroom. All three tighten existing Phase B invariants rather
+than adding new surface; the release keeps prod's FORCE RLS 1.0 posture
+unchanged.
+
+### Added
+
+- **`PgVersionGate`** (`@Component`/`@PostConstruct` in `org.fabt.shared.security`)
+  halts JVM boot when the live PostgreSQL server reports
+  `server_version_num < 160005` (PostgreSQL 16.5). Catches prod image
+  drift on every deploy. Paired `PgVersionGateTest` asserts the CI image
+  sits above the same floor — dual-layer because an IT alone
+  tautologically passes whatever image CI tells it to run. Floor doubles
+  as a CVE gate: 16.5 is the first release containing the fix for
+  CVE-2024-10977. Runbook entry "PostgreSQL Minor-Version Bump Checklist"
+  tracks the revisit-on-every-minor responsibility. Unit test covers the
+  fail-fast path (mocked low version → `IllegalStateException`). (#167)
+
+- **`application_name = 'fabt:tenant:<uuid>'`** now set alongside
+  `app.tenant_id` in `RlsDataSourceConfig.applyRlsContext`, co-located in
+  the same prepared statement so the two values cannot drift. pgaudit
+  log lines now carry the tenant UUID via a new `%a` in
+  `deploy/pgaudit.conf` `log_line_prefix`. `PgauditApplicationNameDriftTest`
+  guards the invariant with three `@Test` cases — sequential alternating
+  tenants, null-tenant transition, and a concurrent virtual-thread load
+  (50 threads/tenant × 2 tenants × 20 iterations) asserting drift-count
+  is zero. Null-tenant case resets to `'fabt:tenant:none'` so the tag
+  never carries a stale prior tenant. Known skew documented for the
+  seven service-layer `set_config('app.tenant_id', ?, is_local=true)`
+  callers (all run from SYSTEM_TENANT_ID context; pgaudit will tag their
+  rows with `fabt:tenant:none` while RLS sees the real tenant —
+  misleading but not wrong). (#168)
+
+- **`deploy/prod-state.json`** — committed snapshot (with explicit
+  `"schemaVersion": 1`) of prod's applied Flyway HWM (74 at v0.44.3).
+  Updated post-deploy per the new runbook section "Flyway Out-of-Order
+  Posture". `scripts/ci/check-flyway-migration-versions.sh` + new
+  `flyway-hwm-guard` job in `.github/workflows/ci.yml` reject PRs whose
+  new migration files are at or below the HWM. Enforces the
+  renumber-forward posture chosen in the v0.45 warroom — avoids the
+  permanent `spring.flyway.out-of-order=true` relaxation while still
+  leaving the v0.43 bridge compose on the VM for v0.45 belt-and-suspenders.
+  Manually verified pass (no new migrations in this diff) + fail (adding
+  a below-HWM `V68_5__*.sql` triggers exit 1). (#151)
+
+### Changed
+
+- `docs/runbook.md` gains two new sections: "Flyway Out-of-Order Posture"
+  explains why prod's `installed_rank` is permanently out-of-order until
+  the ~v0.60 B-baseline, documents the renumber-forward rule, and gives
+  the post-deploy HWM-snapshot update procedure; "PostgreSQL
+  Minor-Version Bump Checklist" lists the six-step revisit protocol for
+  CVE-gate bumps when the PG image advances.
+
+- `docs/FOR-DEVELOPERS.md` Tech Stack row updates PostgreSQL floor from
+  "16.6+" (stale) to "16.5+ (enforced by `PgVersionGate` at boot)".
+
+---
+
 ## [v0.44.3] — 2026-04-19 — i18n hygiene: missing keys + coverage test (#173)
 
 User-reported 2026-04-18 post-v0.44.2 deploy: the "Security" menu item in

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,12 +70,12 @@ Phase B release-gate artifacts pinned for this tag so operator-side
 rollback can verify the deploy bit-for-bit (W-CHANGELOG-1 and
 W-CHANGELOG-3):
 
-- **`pg_policies` snapshot hash** — `docs/security/pg-policies-snapshot.md`
-  SHA-256: `abca0e94b7626bf855b200a677a1cdd54d3522610417ad3f76c383240e004207`
-  (PostgreSQL 16-line file, 7 regulated tables × USING + WITH CHECK clauses).
-  Recompute during deploy verification with
-  `sha256sum docs/security/pg-policies-snapshot.md`; a mismatch means the
-  snapshot was edited without a corresponding policy-diff review.
+- **`pg_policies` snapshot SHA-256 pinned** in `deploy/release-gate-pins.txt`
+  (7 regulated tables × USING + WITH CHECK clauses). CI job
+  `release-gate-pin-verify` reruns `scripts/ci/verify-release-gate-pins.sh`
+  on every PR, which recomputes `sha256sum docs/security/pg-policies-snapshot.md`
+  and fails the build on any drift. Pin format + update rules are
+  documented in the header of the pins file.
 - **Named signer** — `@ccradle`, per `.github/CODEOWNERS` lines 18-26
   (new in this release). The named-signer + SHA-256 pair satisfies the
   release-gate #4 acceptance criterion from the Phase B warroom.

--- a/backend/src/main/java/org/fabt/shared/security/ForceRlsHealthGauge.java
+++ b/backend/src/main/java/org/fabt/shared/security/ForceRlsHealthGauge.java
@@ -1,5 +1,6 @@
 package org.fabt.shared.security;
 
+import java.sql.Array;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -80,14 +81,47 @@ public class ForceRlsHealthGauge {
      */
     @Scheduled(fixedDelay = 60_000L, initialDelay = 15_000L)
     public void poll() {
-        List<Map<String, Object>> rows = jdbcTemplate.queryForList(
-                "SELECT c.relname AS table_name, c.relforcerowsecurity AS force_flag "
-                        + "FROM pg_class c "
-                        + "JOIN pg_namespace n ON n.oid = c.relnamespace "
-                        + "WHERE n.nspname = 'public' "
-                        + "AND c.relname = ANY(?::text[])",
-                "{" + String.join(",", REGULATED_TABLES) + "}");
+        // W-GAUGE-3 warroom fix (v0.45.0): build the table-name list as a
+        // java.sql.Array via Connection.createArrayOf("text", ...) rather
+        // than the legacy PostgreSQL array-literal string. The literal form
+        // "{tbl1,tbl2}" breaks for any element containing a comma, brace,
+        // backslash, or double quote — our current table names are safe
+        // but the pattern is a foot-gun for future additions. The typed
+        // Array round-trip also gives us the correct sqltype instead of
+        // an implicit cast to text[].
+        List<Map<String, Object>> rows = jdbcTemplate.execute((java.sql.Connection conn) -> {
+            // java.sql.Array is NOT AutoCloseable in JDBC 4.3, so we free()
+            // it manually in a finally block rather than try-with-resources.
+            Array arr = conn.createArrayOf("text", REGULATED_TABLES.toArray(new String[0]));
+            try (java.sql.PreparedStatement ps = conn.prepareStatement(
+                    "SELECT c.relname AS table_name, c.relforcerowsecurity AS force_flag "
+                            + "FROM pg_class c "
+                            + "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                            + "WHERE n.nspname = 'public' "
+                            + "AND c.relname = ANY(?)")) {
+                ps.setArray(1, arr);
+                try (java.sql.ResultSet rs = ps.executeQuery()) {
+                    List<Map<String, Object>> out = new java.util.ArrayList<>();
+                    while (rs.next()) {
+                        Map<String, Object> row = new LinkedHashMap<>();
+                        row.put("table_name", rs.getString("table_name"));
+                        row.put("force_flag", rs.getBoolean("force_flag"));
+                        out.add(row);
+                    }
+                    return out;
+                }
+            } finally {
+                try {
+                    arr.free();
+                } catch (java.sql.SQLException ignored) {
+                    // free() may no-op on some drivers; we're past the useful point either way.
+                }
+            }
+        });
 
+        if (rows == null) {
+            return;
+        }
         for (Map<String, Object> row : rows) {
             String name = (String) row.get("table_name");
             Boolean forceFlag = (Boolean) row.get("force_flag");

--- a/backend/src/main/java/org/fabt/shared/security/PgVersionGate.java
+++ b/backend/src/main/java/org/fabt/shared/security/PgVersionGate.java
@@ -1,0 +1,61 @@
+package org.fabt.shared.security;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Component;
+
+/**
+ * Startup gate asserting the live PostgreSQL server meets FABT's minimum
+ * supported version. Runs once at bean initialization; throws
+ * {@link IllegalStateException} if the floor is breached, which Spring's
+ * bootstrap converts into a non-zero JVM exit.
+ *
+ * <p><b>Floor:</b> {@code server_version_num >= 160005} (PostgreSQL 16.5).
+ * Task 3.2 of the multi-tenant-production-readiness change set that floor
+ * during Phase B; earlier releases lacked the {@code pg_policies.permissive}
+ * column this codebase relies on for FORCE RLS policy snapshots.
+ *
+ * <h2>Why this is needed alongside {@code PgVersionGateTest}</h2>
+ * <p>The Testcontainers integration test tautologically passes whatever
+ * image CI tells it to run (currently {@code postgres:16-alpine}, which
+ * resolves to 16.13). It catches the class of bug where someone bumps the
+ * CI image backwards but does not catch prod drift — an operator running
+ * an unpatched 16.4 pgaudit image on the VM would sail past CI. This
+ * startup check runs on every boot (CI + prod) against the actual live
+ * server, closing that gap.
+ *
+ * <h2>Bumping the floor</h2>
+ * Per the v0.45.0 warroom, this floor doubles as a CVE gate — revisit on
+ * every PostgreSQL minor release. When bumping, update (a) this constant,
+ * (b) the equivalent assertion in {@code PgVersionGateTest}, and (c) the
+ * "PG version bump" checklist entry in {@code docs/runbook.md}.
+ */
+@Component
+public class PgVersionGate {
+
+    /**
+     * Minimum acceptable {@code server_version_num} — PostgreSQL 16.5.
+     * PostgreSQL encodes versions as {@code major * 10000 + minor} (since
+     * 10.x); 16.5 → 160005, 16.6 → 160006.
+     */
+    static final int MIN_SERVER_VERSION_NUM = 160005;
+
+    private final JdbcTemplate jdbcTemplate;
+
+    public PgVersionGate(JdbcTemplate jdbcTemplate) {
+        this.jdbcTemplate = jdbcTemplate;
+    }
+
+    @PostConstruct
+    void assertMinimumVersion() {
+        Integer actual = jdbcTemplate.queryForObject(
+                "SELECT current_setting('server_version_num')::int", Integer.class);
+        if (actual == null || actual < MIN_SERVER_VERSION_NUM) {
+            throw new IllegalStateException(
+                    "PostgreSQL server_version_num=" + actual
+                            + " is below FABT's supported floor "
+                            + MIN_SERVER_VERSION_NUM
+                            + " (PostgreSQL 16.5). Upgrade the server or the CI image.");
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java
+++ b/backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java
@@ -163,7 +163,13 @@ public class RlsDataSourceConfig {
                 }
             } catch (SQLException e) {
                 log.error("Failed to apply RLS context on connection; closing to prevent data leak", e);
-                conn.close();
+                try {
+                    conn.close();
+                } catch (SQLException closeFailure) {
+                    // Preserve the original cause; a secondary failure during
+                    // close() must not mask the real diagnostic.
+                    e.addSuppressed(closeFailure);
+                }
                 throw e;
             }
         }

--- a/backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java
+++ b/backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java
@@ -132,6 +132,20 @@ public class RlsDataSourceConfig {
                 //   drift — a divergence between them would mean pgaudit logs the wrong
                 //   tenant while RLS enforces the right one, which is worse than no tag.
                 //   Drift-safety is covered by PgauditApplicationNameDriftTest.
+                //   KNOWN LIMITATION: seven service-layer call sites (AccessCodeService,
+                //   AuditEventPersister, HmisPushService, KidRegistryService,
+                //   PasswordResetTokenPersister, TenantKeyRotationService, V74 migration)
+                //   override app.tenant_id transaction-scoped with is_local=true to do
+                //   system-scoped work under a specific tenant's RLS. Because
+                //   application_name is session-scoped here, it retains the borrow-time
+                //   value and pgaudit tags those statements with the SESSION tenant
+                //   (typically 'fabt:tenant:none' since system callers run outside any
+                //   TenantContext). RLS still enforces correctly. See
+                //   PgauditApplicationNameDriftTest.transactionScopedOverride_applicationNameKeepsSessionTenant
+                //   for the pinned contract. If you add a new is_local=true call site
+                //   inside an active TenantContext, the audit log will credibly name the
+                //   wrong tenant — update application_name in the same statement or
+                //   accept the documented skew with a test expressing it.
                 // Callers bind context via TenantContext.runWithContext() BEFORE queries.
                 String userIdStr = userId != null ? userId.toString() : "00000000-0000-0000-0000-000000000000";
                 String tenantIdStr = tenantId != null ? tenantId.toString() : "";

--- a/backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java
+++ b/backend/src/main/java/org/fabt/shared/security/RlsDataSourceConfig.java
@@ -124,16 +124,27 @@ public class RlsDataSourceConfig {
                 //   on regulated tables). No current RLS policy reads it — Elena's
                 //   defense-in-depth insistence (D13). Empty string when null (scheduled-
                 //   task / batch-job case where TenantContext is unset).
+                // set_config('application_name', 'fabt:tenant:<uuid>', ...): tags every
+                //   pgaudit log line + pg_stat_activity row with the bound tenant so an
+                //   operator reading the audit log can correlate a statement to its tenant
+                //   without joining by timestamp+pid (task 3.11 follow-up). Co-located with
+                //   app.tenant_id in the SAME prepared statement so the two values cannot
+                //   drift — a divergence between them would mean pgaudit logs the wrong
+                //   tenant while RLS enforces the right one, which is worse than no tag.
+                //   Drift-safety is covered by PgauditApplicationNameDriftTest.
                 // Callers bind context via TenantContext.runWithContext() BEFORE queries.
                 String userIdStr = userId != null ? userId.toString() : "00000000-0000-0000-0000-000000000000";
                 String tenantIdStr = tenantId != null ? tenantId.toString() : "";
+                String applicationNameStr = "fabt:tenant:" + (tenantId != null ? tenantIdStr : "none");
                 try (java.sql.PreparedStatement pstmt = conn.prepareStatement(
                         "SET ROLE fabt_app; SELECT set_config('app.dv_access', ?, false), "
                                 + "set_config('app.current_user_id', ?, false), "
-                                + "set_config('app.tenant_id', ?, false)")) {
+                                + "set_config('app.tenant_id', ?, false), "
+                                + "set_config('application_name', ?, false)")) {
                     pstmt.setString(1, String.valueOf(dvAccess));
                     pstmt.setString(2, userIdStr);
                     pstmt.setString(3, tenantIdStr);
+                    pstmt.setString(4, applicationNameStr);
                     pstmt.execute();
                 }
             } catch (SQLException e) {

--- a/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
+++ b/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
@@ -1,0 +1,121 @@
+package org.fabt.architecture;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Lint rules over Flyway migration files. Complements the ArchUnit rules
+ * on Java code (see {@code TenantContextTransactionalRuleTest},
+ * {@code TenantPredicateCoverageTest}) with similar enforcement for SQL.
+ *
+ * <p>Task 3.14 (v0.45 task #165): forbid {@code SECURITY DEFINER} on
+ * functions created by Flyway migrations. Rationale:
+ * {@code SECURITY DEFINER} functions execute with the privileges of the
+ * FUNCTION OWNER, not the calling role. In FABT's Phase B regime the
+ * owner is {@code fabt} (superuser-adjacent; BYPASSRLS) and the caller
+ * is {@code fabt_app} (RLS-enforced). A {@code SECURITY DEFINER} function
+ * owned by {@code fabt} would bypass every RLS policy on the seven
+ * regulated tables — exactly the owner-bypass vector Phase B's FORCE RLS
+ * (V69) is designed to block.
+ *
+ * <p>When a future migration legitimately needs {@code SECURITY DEFINER}
+ * (e.g., a superuser-only operation like {@code CREATE EXTENSION}), add
+ * the migration's filename to {@link #SECURITY_DEFINER_ALLOWLIST} with
+ * a comment explaining the justification. The owner-security-model
+ * trade-off must be documented in the warroom / design doc first.
+ *
+ * <p>This is a FABT-specific SQL lint; ArchUnit has no native support
+ * for SQL AST traversal, so a file-scan test is the right tool.
+ */
+@DisplayName("Flyway migration lint — task 3.14 (SECURITY DEFINER ban)")
+class MigrationLintTest {
+
+    private static final Path SQL_MIGRATIONS =
+            Paths.get("src", "main", "resources", "db", "migration");
+    private static final Path JAVA_MIGRATIONS =
+            Paths.get("src", "main", "java", "db", "migration");
+
+    /**
+     * Allowlist of migration filenames that may use {@code SECURITY DEFINER}.
+     * Additions MUST be approved in a warroom review + reference a
+     * design-doc section. Empty today — Phase B's Flyway migrations all
+     * run under {@code fabt} owner for DDL but define functions without
+     * the {@code SECURITY DEFINER} attribute.
+     */
+    private static final List<String> SECURITY_DEFINER_ALLOWLIST = List.of(
+            // No entries as of v0.45.0. Add here with a comment:
+            // "VNN__migration_name.sql  // warroom ref: ..."
+    );
+
+    private static final Pattern SECURITY_DEFINER = Pattern.compile(
+            "\\bSECURITY\\s+DEFINER\\b", Pattern.CASE_INSENSITIVE);
+
+    @Test
+    @DisplayName("No Flyway migration uses SECURITY DEFINER (task 3.14)")
+    void noMigrationUsesSecurityDefiner() throws IOException {
+        List<String> violations = new ArrayList<>();
+        collectViolations(SQL_MIGRATIONS, violations);
+        collectViolations(JAVA_MIGRATIONS, violations);
+
+        assertThat(violations)
+                .as("SECURITY DEFINER functions bypass RLS on the owning role. "
+                        + "Phase B FORCE RLS (V69) depends on every write path running as fabt_app, "
+                        + "not the fabt owner — a SECURITY DEFINER function owned by fabt would "
+                        + "reintroduce owner-bypass. If a new migration genuinely needs SECURITY "
+                        + "DEFINER (e.g. wrapping CREATE EXTENSION), add its filename to "
+                        + "SECURITY_DEFINER_ALLOWLIST with a warroom/design citation.")
+                .isEmpty();
+    }
+
+    private void collectViolations(Path dir, List<String> violations) throws IOException {
+        if (!Files.isDirectory(dir)) {
+            return;
+        }
+        try (Stream<Path> stream = Files.walk(dir)) {
+            stream.filter(Files::isRegularFile)
+                    .filter(p -> {
+                        String name = p.getFileName().toString();
+                        return name.startsWith("V")
+                                && (name.endsWith(".sql") || name.endsWith(".java"));
+                    })
+                    .forEach(p -> scanFile(p, violations));
+        }
+    }
+
+    private void scanFile(Path file, List<String> violations) {
+        String name = file.getFileName().toString();
+        if (SECURITY_DEFINER_ALLOWLIST.contains(name)) {
+            return;
+        }
+        String content;
+        try {
+            content = Files.readString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            violations.add(file + " — could not read: " + e.getMessage());
+            return;
+        }
+        // Strip SQL line comments so a -- "avoid SECURITY DEFINER" comment
+        // doesn't itself trigger the rule.
+        String stripped = content.replaceAll("(?m)--.*$", "");
+        // Strip block comments.
+        stripped = stripped.replaceAll("(?s)/\\*.*?\\*/", "");
+
+        Matcher m = SECURITY_DEFINER.matcher(stripped);
+        while (m.find()) {
+            violations.add(name + " — contains SECURITY DEFINER at offset " + m.start());
+        }
+    }
+}

--- a/backend/src/test/java/org/fabt/security/PgauditApplicationNameDriftTest.java
+++ b/backend/src/test/java/org/fabt/security/PgauditApplicationNameDriftTest.java
@@ -1,0 +1,157 @@
+package org.fabt.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.shared.web.TenantContext;
+import org.fabt.tenant.domain.Tenant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Drift-safety guard for the co-located {@code application_name} +
+ * {@code app.tenant_id} session variables set by
+ * {@link org.fabt.shared.security.RlsDataSourceConfig#applyRlsContext}
+ * (task 3.11 follow-up, v0.45.0).
+ *
+ * <p><b>Why this test is load-bearing.</b> pgaudit tags every logged
+ * statement with {@code application_name}; RLS enforces {@code app.tenant_id}.
+ * If those two values ever disagree, the audit log credibly names tenant-A
+ * while the actual DML ran as tenant-B — a compliance-grade log that lies
+ * about tenant identity, worse than no tag at all. Marcus's v0.45.0
+ * warroom acceptance criterion: without this test the feature ships
+ * un-vouched-for.
+ *
+ * <p>The existing {@link TenantIdPoolBleedTest} covers {@code app.tenant_id}
+ * in isolation; this class specifically targets the invariant that the
+ * two GUCs are set in the same statement block and cannot diverge.
+ */
+@DisplayName("pgaudit application_name + app.tenant_id drift-safety (task 3.11)")
+class PgauditApplicationNameDriftTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private UUID tenantAId;
+    private UUID tenantBId;
+
+    @BeforeEach
+    void setUp() {
+        authHelper.setupTestTenant();
+        tenantAId = authHelper.getTestTenantId();
+
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        Tenant tenantB = authHelper.setupSecondaryTenant("pgaudit-drift-" + suffix);
+        tenantBId = tenantB.getId();
+    }
+
+    @Test
+    @DisplayName("application_name always matches app.tenant_id on every borrow")
+    void sequentialAlternatingTenants_applicationNameMatchesTenantId() {
+        for (int i = 0; i < 100; i++) {
+            final int iteration = i;
+            UUID expectedTenantId = (i % 2 == 0) ? tenantAId : tenantBId;
+
+            TenantContext.runWithContext(expectedTenantId, false, () -> {
+                Map<String, Object> row = jdbcTemplate.queryForMap(
+                        "SELECT current_setting('app.tenant_id', true) AS tenant_id, "
+                                + "current_setting('application_name', true) AS app_name");
+                String tenantId = (String) row.get("tenant_id");
+                String appName = (String) row.get("app_name");
+
+                assertThat(tenantId)
+                        .as("Iteration %d: app.tenant_id bound to expected tenant", iteration)
+                        .isEqualTo(expectedTenantId.toString());
+                assertThat(appName)
+                        .as("Iteration %d: application_name carries same tenant UUID as app.tenant_id", iteration)
+                        .isEqualTo("fabt:tenant:" + expectedTenantId);
+            });
+        }
+    }
+
+    @Test
+    @DisplayName("Null tenant context: application_name = 'fabt:tenant:none'")
+    void nullTenantContext_applicationNameIsNone() {
+        TenantContext.runWithContext(tenantAId, false, () -> {
+            String warmup = jdbcTemplate.queryForObject(
+                    "SELECT current_setting('application_name', true)", String.class);
+            assertThat(warmup).isEqualTo("fabt:tenant:" + tenantAId);
+        });
+
+        String afterNull = jdbcTemplate.queryForObject(
+                "SELECT current_setting('application_name', true)", String.class);
+        assertThat(afterNull)
+                .as("After TenantContext scope exits, application_name must reset to "
+                        + "'fabt:tenant:none' — never carry the previous tenant's UUID")
+                .isEqualTo("fabt:tenant:none");
+    }
+
+    @Test
+    @DisplayName("Concurrent virtual threads: per-checkout pair stays consistent")
+    void concurrentVirtualThreads_noDriftBetweenTenantIdAndApplicationName() throws Exception {
+        int threadsPerTenant = 50;
+        int iterationsPerThread = 20;
+
+        List<UUID> tenants = List.of(tenantAId, tenantBId);
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch done = new CountDownLatch(tenants.size() * threadsPerTenant);
+        AtomicInteger driftCount = new AtomicInteger();
+        AtomicInteger totalChecks = new AtomicInteger();
+
+        try (ExecutorService pool = Executors.newVirtualThreadPerTaskExecutor()) {
+            for (UUID tenantId : tenants) {
+                for (int t = 0; t < threadsPerTenant; t++) {
+                    pool.submit(() -> {
+                        try {
+                            startGate.await();
+                            for (int i = 0; i < iterationsPerThread; i++) {
+                                TenantContext.runWithContext(tenantId, false, () -> {
+                                    Map<String, Object> row = jdbcTemplate.queryForMap(
+                                            "SELECT current_setting('app.tenant_id', true) AS tid, "
+                                                    + "current_setting('application_name', true) AS app");
+                                    String boundTid = (String) row.get("tid");
+                                    String boundApp = (String) row.get("app");
+                                    totalChecks.incrementAndGet();
+                                    String expectedApp = "fabt:tenant:" + tenantId;
+                                    if (!tenantId.toString().equals(boundTid)
+                                            || !expectedApp.equals(boundApp)) {
+                                        driftCount.incrementAndGet();
+                                    }
+                                });
+                            }
+                        } catch (InterruptedException e) {
+                            Thread.currentThread().interrupt();
+                        } finally {
+                            done.countDown();
+                        }
+                    });
+                }
+            }
+            startGate.countDown();
+            assertThat(done.await(60, TimeUnit.SECONDS))
+                    .as("Concurrent virtual-thread barrier completed within 60s")
+                    .isTrue();
+        }
+
+        assertThat(totalChecks.get())
+                .isEqualTo(tenants.size() * threadsPerTenant * iterationsPerThread);
+        assertThat(driftCount.get())
+                .as("Under concurrent load, application_name and app.tenant_id must stay "
+                        + "co-located — any drift means pgaudit would log the wrong tenant "
+                        + "for that query. Drift count MUST be zero.")
+                .isZero();
+    }
+}

--- a/backend/src/test/java/org/fabt/security/PgauditApplicationNameDriftTest.java
+++ b/backend/src/test/java/org/fabt/security/PgauditApplicationNameDriftTest.java
@@ -20,6 +20,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Drift-safety guard for the co-located {@code application_name} +
@@ -44,6 +46,7 @@ class PgauditApplicationNameDriftTest extends BaseIntegrationTest {
 
     @Autowired private TestAuthHelper authHelper;
     @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private PlatformTransactionManager transactionManager;
 
     private UUID tenantAId;
     private UUID tenantBId;
@@ -97,6 +100,52 @@ class PgauditApplicationNameDriftTest extends BaseIntegrationTest {
                 .as("After TenantContext scope exits, application_name must reset to "
                         + "'fabt:tenant:none' — never carry the previous tenant's UUID")
                 .isEqualTo("fabt:tenant:none");
+    }
+
+    @Test
+    @DisplayName("Transaction-scoped app.tenant_id override: application_name keeps session tenant (known skew)")
+    void transactionScopedOverride_applicationNameKeepsSessionTenant() {
+        // Seven service-layer call sites (AccessCodeService, AuditEventPersister,
+        // HmisPushService, KidRegistryService, PasswordResetTokenPersister,
+        // TenantKeyRotationService, V74__reencrypt) override app.tenant_id
+        // transaction-scoped with is_local=true to do system-scoped work under
+        // a specific tenant's RLS. application_name is session-scoped, so it
+        // keeps the borrow-time value. Pgaudit logs the session tenant; RLS
+        // enforces the transaction tenant. For current callers all run from
+        // SYSTEM_TENANT_ID context where session tenant is 'none', so the
+        // divergence is documented-and-safe rather than a correctness bug.
+        // This test pins that contract — if a caller starts overriding
+        // app.tenant_id under a real TenantContext, this test still passes
+        // (correctly documenting the skew) and the caller's own tests should
+        // catch any resulting audit-log lie.
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        TenantContext.runWithContext(tenantAId, false, () ->
+                tx.executeWithoutResult(status -> {
+                    // Inside a real transaction so is_local=true persists to later
+                    // queries on this same connection. Mirrors the @Transactional
+                    // boundary that AccessCodeService et al. operate under.
+                    Map<String, Object> before = jdbcTemplate.queryForMap(
+                            "SELECT current_setting('app.tenant_id', true) AS tid, "
+                                    + "current_setting('application_name', true) AS app");
+                    assertThat(before.get("tid")).isEqualTo(tenantAId.toString());
+                    assertThat(before.get("app")).isEqualTo("fabt:tenant:" + tenantAId);
+
+                    jdbcTemplate.queryForObject(
+                            "SELECT set_config('app.tenant_id', ?, true)",
+                            String.class, tenantBId.toString());
+
+                    Map<String, Object> after = jdbcTemplate.queryForMap(
+                            "SELECT current_setting('app.tenant_id', true) AS tid, "
+                                    + "current_setting('application_name', true) AS app");
+
+                    assertThat(after.get("tid"))
+                            .as("transaction-scoped override: app.tenant_id now reads the is_local=true value")
+                            .isEqualTo(tenantBId.toString());
+                    assertThat(after.get("app"))
+                            .as("application_name is session-scoped — still tagged with the borrow-time (A) tenant. "
+                                    + "This is the documented is_local=true drift; see RlsDataSourceConfig javadoc.")
+                            .isEqualTo("fabt:tenant:" + tenantAId);
+                }));
     }
 
     @Test

--- a/backend/src/test/java/org/fabt/security/PhaseBRlsEnforcementTest.java
+++ b/backend/src/test/java/org/fabt/security/PhaseBRlsEnforcementTest.java
@@ -1,8 +1,9 @@
 package org.fabt.security;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.fail;
 
+import java.sql.SQLException;
 import java.util.UUID;
 
 import org.fabt.BaseIntegrationTest;
@@ -13,7 +14,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 
 /**
@@ -124,25 +124,21 @@ class PhaseBRlsEnforcementTest extends BaseIntegrationTest {
                                 + "VALUES (?, ?, ?, ?)",
                         rowId, actorUserId, "phase-b-3-22-probe", tenantAId));
 
-        // Attempted UPDATE under the same tenant — fails at GRANT level,
-        // not RLS. That's the append-only invariant.
-        assertThatThrownBy(() ->
-                TenantContext.runWithContext(tenantAId, false, () ->
-                        jdbcTemplate.update(
-                                "UPDATE audit_events SET action = 'modified' WHERE id = ?",
-                                rowId)))
-                .as("fabt_app must lack UPDATE grant on audit_events — audit trail is append-only per V70")
-                .isInstanceOf(DataAccessException.class)
-                .hasStackTraceContaining("permission denied for table audit_events");
+        // Attempted UPDATE under the same tenant — fails with SQLSTATE 42501
+        // (insufficient_privilege) because V70 REVOKEs UPDATE from fabt_app.
+        // Assert on SQLSTATE rather than message text so a future PG release
+        // that rewords the English message doesn't break this test.
+        Throwable updateFailure = catchExceptionInRlsContext(tenantAId, () ->
+                jdbcTemplate.update(
+                        "UPDATE audit_events SET action = 'modified' WHERE id = ?", rowId));
+        assertRootCauseSqlState(updateFailure, "42501",
+                "UPDATE on audit_events must fail with 42501 (GRANT revoked by V70)");
 
-        // Attempted DELETE also blocked by GRANT.
-        assertThatThrownBy(() ->
-                TenantContext.runWithContext(tenantAId, false, () ->
-                        jdbcTemplate.update(
-                                "DELETE FROM audit_events WHERE id = ?", rowId)))
-                .as("fabt_app must lack DELETE grant on audit_events — audit trail is append-only per V70")
-                .isInstanceOf(DataAccessException.class)
-                .hasStackTraceContaining("permission denied for table audit_events");
+        // Attempted DELETE also blocked by GRANT — same SQLSTATE.
+        Throwable deleteFailure = catchExceptionInRlsContext(tenantAId, () ->
+                jdbcTemplate.update("DELETE FROM audit_events WHERE id = ?", rowId));
+        assertRootCauseSqlState(deleteFailure, "42501",
+                "DELETE on audit_events must fail with 42501 (GRANT revoked by V70)");
     }
 
     @Test
@@ -152,16 +148,47 @@ class PhaseBRlsEnforcementTest extends BaseIntegrationTest {
 
         // Under tenant A, try to insert a row with tenant_id = B.
         // The RLS policy's WITH CHECK clause (tenant_id = fabt_current_tenant_id())
-        // should reject this as a policy violation — this is the load-bearing
-        // guard against owner-bypass INSERTs claiming foreign tenant identity.
-        assertThatThrownBy(() ->
-                TenantContext.runWithContext(tenantAId, false, () ->
-                        jdbcTemplate.update(
-                                "INSERT INTO audit_events (id, actor_user_id, action, tenant_id) "
-                                        + "VALUES (?, ?, ?, ?)",
-                                rowId, actorUserId, "phase-b-3-22-forged", tenantBId)))
-                .as("RLS WITH CHECK must reject an INSERT claiming a different tenant_id than the session's binding")
-                .isInstanceOf(DataAccessException.class)
-                .hasStackTraceContaining("new row violates row-level security policy");
+        // rejects this as a policy violation (SQLSTATE 42501). Asserting on
+        // SQLSTATE is more durable than matching the English error message.
+        Throwable failure = catchExceptionInRlsContext(tenantAId, () ->
+                jdbcTemplate.update(
+                        "INSERT INTO audit_events (id, actor_user_id, action, tenant_id) "
+                                + "VALUES (?, ?, ?, ?)",
+                        rowId, actorUserId, "phase-b-3-22-forged", tenantBId));
+        assertRootCauseSqlState(failure, "42501",
+                "INSERT with foreign tenant_id must fail with 42501 (RLS WITH CHECK)");
+    }
+
+    /**
+     * Runs {@code action} under {@code TenantContext.runWithContext(tenantId)}
+     * and returns the thrown exception for inspection. Using this helper
+     * instead of AssertJ's {@code assertThatThrownBy} because the lambda
+     * needs to run inside a ScopedValue binding and AssertJ's fluent API
+     * cannot thread an arbitrary context through the call chain cleanly.
+     */
+    private Throwable catchExceptionInRlsContext(UUID tenantId, Runnable action) {
+        try {
+            TenantContext.runWithContext(tenantId, false, action);
+            fail("Expected the action to throw, but it succeeded");
+            return null; // unreachable
+        } catch (RuntimeException e) {
+            return e;
+        }
+    }
+
+    /**
+     * Asserts that {@code throwable}'s cause chain contains a
+     * {@link SQLException} whose {@code SQLState} equals {@code expected}.
+     */
+    private void assertRootCauseSqlState(Throwable throwable, String expected, String message) {
+        Throwable cur = throwable;
+        while (cur != null) {
+            if (cur instanceof SQLException se && expected.equals(se.getSQLState())) {
+                return;
+            }
+            cur = cur.getCause();
+        }
+        fail(message + " — no SQLException with SQLState=" + expected
+                + " found in cause chain of " + throwable);
     }
 }

--- a/backend/src/test/java/org/fabt/security/PhaseBRlsEnforcementTest.java
+++ b/backend/src/test/java/org/fabt/security/PhaseBRlsEnforcementTest.java
@@ -1,0 +1,167 @@
+package org.fabt.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.shared.web.TenantContext;
+import org.fabt.tenant.domain.Tenant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Phase B close-out integration tests — 3.19, 3.21, 3.22.
+ *
+ * <p>Consolidates three RLS-enforcement guards into a single test class so
+ * the Spring context spins up once per CI run rather than three times.
+ * Each test isolates a distinct invariant of the Phase B FORCE-RLS regime.
+ *
+ * <h2>Assertions</h2>
+ * <ul>
+ *   <li><b>3.19</b> — every connection borrow ends up under the
+ *       {@code fabt_app} role (not the owner {@code fabt}), because RLS
+ *       bypass semantics treat superusers + table owners as exempt.</li>
+ *   <li><b>3.21</b> — RLS policy on {@code audit_events} hides rows from
+ *       non-owning tenants. A row inserted under tenant A must be
+ *       invisible when the session binds tenant B.</li>
+ *   <li><b>3.22</b> — running under {@code fabt_app}, tenant B cannot
+ *       UPDATE tenant A's {@code audit_events} row. The FORCE RLS flag
+ *       (V69) blocks owner-bypass attempts at the statement level.</li>
+ * </ul>
+ */
+@DisplayName("Phase B RLS enforcement — 3.19 + 3.21 + 3.22 (task #165)")
+class PhaseBRlsEnforcementTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private JdbcTemplate jdbcTemplate;
+
+    private UUID tenantAId;
+    private UUID tenantBId;
+    private UUID actorUserId;
+
+    @BeforeEach
+    void setUp() {
+        authHelper.setupTestTenant();
+        tenantAId = authHelper.getTestTenantId();
+
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        Tenant tenantB = authHelper.setupSecondaryTenant("phase-b-rls-" + suffix);
+        tenantBId = tenantB.getId();
+
+        actorUserId = UUID.randomUUID();
+    }
+
+    @Test
+    @DisplayName("3.19 — every connection borrow runs as fabt_app (not owner fabt)")
+    void connectionBorrow_runsAsFabtAppRole() {
+        TenantContext.runWithContext(tenantAId, false, () -> {
+            String currentUser = jdbcTemplate.queryForObject(
+                    "SELECT current_user", String.class);
+            assertThat(currentUser)
+                    .as("RlsDataSourceConfig.applyRlsContext must SET ROLE fabt_app on every borrow — "
+                            + "running as the owner role would bypass RLS entirely (PostgreSQL semantics).")
+                    .isEqualTo("fabt_app");
+        });
+
+        // Also assert for the null-tenant case (scheduled job / system work)
+        String currentUserNoContext = jdbcTemplate.queryForObject(
+                "SELECT current_user", String.class);
+        assertThat(currentUserNoContext)
+                .as("Null TenantContext still drops to fabt_app — SET ROLE is unconditional")
+                .isEqualTo("fabt_app");
+    }
+
+    @Test
+    @DisplayName("3.21 — cross-tenant SELECT on audit_events returns zero rows (RLS hides)")
+    void crossTenantSelectOnAuditEvents_rlsHidesOtherTenantRows() {
+        UUID rowIdA = UUID.randomUUID();
+
+        TenantContext.runWithContext(tenantAId, false, () ->
+                jdbcTemplate.update(
+                        "INSERT INTO audit_events (id, actor_user_id, action, tenant_id) "
+                                + "VALUES (?, ?, ?, ?)",
+                        rowIdA, actorUserId, "phase-b-3-21-probe", tenantAId));
+
+        // Under tenant A, the row IS visible.
+        Integer visibleToA = TenantContext.callWithContext(tenantAId, null, false, () ->
+                jdbcTemplate.queryForObject(
+                        "SELECT count(*) FROM audit_events WHERE id = ?",
+                        Integer.class, rowIdA));
+        assertThat(visibleToA)
+                .as("Tenant A must still see its own audit row (sanity)")
+                .isEqualTo(1);
+
+        // Under tenant B, the row is hidden.
+        Integer visibleToB = TenantContext.callWithContext(tenantBId, null, false, () ->
+                jdbcTemplate.queryForObject(
+                        "SELECT count(*) FROM audit_events WHERE id = ?",
+                        Integer.class, rowIdA));
+        assertThat(visibleToB)
+                .as("RLS policy tenant_isolation_audit_events must hide tenant A's row from tenant B — "
+                        + "this is the load-bearing invariant of Phase B V68 + V69.")
+                .isZero();
+    }
+
+    @Test
+    @DisplayName("3.22 — owner-bypass prevention: UPDATE/DELETE on audit_events is revoked for fabt_app (V70)")
+    void auditEvents_updateAndDeleteRevoked_defenseInDepth() {
+        // V70 explicitly REVOKEs UPDATE + DELETE on the audit tables from
+        // fabt_app, making them append-only at the GRANT level. FORCE RLS
+        // on V69 is the secondary guard; for UPDATE+DELETE the primary
+        // guard is the missing GRANT. Assert the primary guard holds.
+        UUID rowId = UUID.randomUUID();
+
+        TenantContext.runWithContext(tenantAId, false, () ->
+                jdbcTemplate.update(
+                        "INSERT INTO audit_events (id, actor_user_id, action, tenant_id) "
+                                + "VALUES (?, ?, ?, ?)",
+                        rowId, actorUserId, "phase-b-3-22-probe", tenantAId));
+
+        // Attempted UPDATE under the same tenant — fails at GRANT level,
+        // not RLS. That's the append-only invariant.
+        assertThatThrownBy(() ->
+                TenantContext.runWithContext(tenantAId, false, () ->
+                        jdbcTemplate.update(
+                                "UPDATE audit_events SET action = 'modified' WHERE id = ?",
+                                rowId)))
+                .as("fabt_app must lack UPDATE grant on audit_events — audit trail is append-only per V70")
+                .isInstanceOf(DataAccessException.class)
+                .hasStackTraceContaining("permission denied for table audit_events");
+
+        // Attempted DELETE also blocked by GRANT.
+        assertThatThrownBy(() ->
+                TenantContext.runWithContext(tenantAId, false, () ->
+                        jdbcTemplate.update(
+                                "DELETE FROM audit_events WHERE id = ?", rowId)))
+                .as("fabt_app must lack DELETE grant on audit_events — audit trail is append-only per V70")
+                .isInstanceOf(DataAccessException.class)
+                .hasStackTraceContaining("permission denied for table audit_events");
+    }
+
+    @Test
+    @DisplayName("3.22 — fabt_app cannot INSERT an audit row claiming a different tenant (WITH CHECK enforcement)")
+    void crossTenantInsertWithForeignTenantId_blockedByWithCheck() {
+        UUID rowId = UUID.randomUUID();
+
+        // Under tenant A, try to insert a row with tenant_id = B.
+        // The RLS policy's WITH CHECK clause (tenant_id = fabt_current_tenant_id())
+        // should reject this as a policy violation — this is the load-bearing
+        // guard against owner-bypass INSERTs claiming foreign tenant identity.
+        assertThatThrownBy(() ->
+                TenantContext.runWithContext(tenantAId, false, () ->
+                        jdbcTemplate.update(
+                                "INSERT INTO audit_events (id, actor_user_id, action, tenant_id) "
+                                        + "VALUES (?, ?, ?, ?)",
+                                rowId, actorUserId, "phase-b-3-22-forged", tenantBId)))
+                .as("RLS WITH CHECK must reject an INSERT claiming a different tenant_id than the session's binding")
+                .isInstanceOf(DataAccessException.class)
+                .hasStackTraceContaining("new row violates row-level security policy");
+    }
+}

--- a/backend/src/test/java/org/fabt/security/TenantKeyRotationSetConfigReuseTest.java
+++ b/backend/src/test/java/org/fabt/security/TenantKeyRotationSetConfigReuseTest.java
@@ -1,0 +1,125 @@
+package org.fabt.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.shared.web.TenantContext;
+import org.fabt.tenant.domain.Tenant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * Warroom W-B-FIXA-1 guard (v0.45 task #166).
+ *
+ * <p>{@link org.fabt.shared.security.TenantKeyRotationService#bumpJwtKeyGeneration}
+ * runs under {@code @Transactional} and sets {@code app.tenant_id} via
+ * {@code set_config(..., is_local=true)} so Phase B FORCE RLS on
+ * {@code audit_events} accepts the audit INSERT done later in the same
+ * transaction. The warroom flagged a theoretical leak: if
+ * {@code is_local=false} were used instead, the session-scoped GUC
+ * would survive the connection's return to the Hikari pool and poison
+ * the next borrow.
+ *
+ * <p>The actual code correctly uses {@code is_local=true}, but the
+ * defense-in-depth question is: even in the {@code is_local=true} case,
+ * does a subsequent pool borrow under a DIFFERENT tenant see the right
+ * tenant binding (not the rotation target)? {@code RlsDataSourceConfig}
+ * re-applies {@code applyRlsContext} on every borrow, so the answer
+ * should be yes — this test pins that.
+ */
+@DisplayName("W-B-FIXA-1 — TenantKeyRotationService is_local=true doesn't leak via pool reuse (task #166)")
+class TenantKeyRotationSetConfigReuseTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private JdbcTemplate jdbcTemplate;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private UUID tenantAId;
+    private UUID tenantBId;
+
+    @BeforeEach
+    void setUp() {
+        authHelper.setupTestTenant();
+        tenantAId = authHelper.getTestTenantId();
+
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        Tenant tenantB = authHelper.setupSecondaryTenant("wb-fixa-1-" + suffix);
+        tenantBId = tenantB.getId();
+    }
+
+    @Test
+    @DisplayName("set_config with is_local=true inside @Transactional does not leak to next pool borrow")
+    void transactionScopedSetConfig_doesNotLeakToNextBorrow() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+
+        // Mimic TenantKeyRotationService.bumpJwtKeyGeneration — under
+        // TenantContext(tenantA), inside @Transactional, set_config
+        // app.tenant_id = tenantB with is_local=true (this is what the
+        // real service does when a platform admin rotates tenant B's key).
+        TenantContext.runWithContext(tenantAId, false, () ->
+                tx.executeWithoutResult(status -> {
+                    String bound = jdbcTemplate.queryForObject(
+                            "SELECT set_config('app.tenant_id', ?, true)",
+                            String.class, tenantBId.toString());
+                    assertThat(bound)
+                            .as("Inside the transaction, is_local=true binds tenantB as the effective tenant")
+                            .isEqualTo(tenantBId.toString());
+                }));
+
+        // Borrow a fresh connection under tenantA. applyRlsContext
+        // re-fires, which must set app.tenant_id to tenantA — NOT
+        // leaving tenantB's rotation-scoped value behind.
+        String afterUnderA = TenantContext.callWithContext(tenantAId, null, false, () ->
+                jdbcTemplate.queryForObject(
+                        "SELECT current_setting('app.tenant_id', true)", String.class));
+        assertThat(afterUnderA)
+                .as("Next borrow under tenantA must see tenantA — the rotation's is_local=true override must "
+                        + "not survive transaction commit (proven by Hikari returning the connection + "
+                        + "applyRlsContext re-applying the session-scoped tenantA binding on the new borrow)")
+                .isEqualTo(tenantAId.toString());
+
+        // And borrow under null context — must reset to empty, not carry
+        // any stale value.
+        String afterUnderNull = jdbcTemplate.queryForObject(
+                "SELECT current_setting('app.tenant_id', true)", String.class);
+        assertThat(afterUnderNull)
+                .as("Next borrow under null context must see empty — no bleed from the rotation transaction")
+                .isEqualTo("");
+    }
+
+    @Test
+    @DisplayName("100 alternating rotation-pattern iterations show zero leak")
+    void alternatingRotationPattern_noLeakOver100Iterations() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+
+        for (int i = 0; i < 100; i++) {
+            UUID sessionTenant = (i % 2 == 0) ? tenantAId : tenantBId;
+            UUID rotationTarget = (i % 2 == 0) ? tenantBId : tenantAId;
+            final int iteration = i;
+
+            // 1. Inside @Transactional, is_local=true override.
+            TenantContext.runWithContext(sessionTenant, false, () ->
+                    tx.executeWithoutResult(status ->
+                            jdbcTemplate.queryForObject(
+                                    "SELECT set_config('app.tenant_id', ?, true)",
+                                    String.class, rotationTarget.toString())));
+
+            // 2. Fresh borrow under session tenant — must NOT see rotation target.
+            String actual = TenantContext.callWithContext(sessionTenant, null, false, () ->
+                    jdbcTemplate.queryForObject(
+                            "SELECT current_setting('app.tenant_id', true)", String.class));
+            assertThat(actual)
+                    .as("Iteration %d: borrow after rotation must see session tenant %s, not rotation target %s",
+                            iteration, sessionTenant, rotationTarget)
+                    .isEqualTo(sessionTenant.toString());
+        }
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/ForceRlsHealthGaugeTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/ForceRlsHealthGaugeTest.java
@@ -1,0 +1,62 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tags;
+import org.fabt.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+/**
+ * Integration test for {@link ForceRlsHealthGauge}. Validates the v0.45
+ * W-GAUGE-3 warroom fix — the poll query now binds the regulated-table
+ * list as a typed {@code java.sql.Array} via {@code createArrayOf("text",
+ * ...)} rather than the legacy PostgreSQL array-literal string.
+ *
+ * <p>Verifies that after {@code poll()} executes:
+ * <ol>
+ *   <li>The query completes without SQL errors (the Array binding works
+ *       against the CI Postgres image).</li>
+ *   <li>Micrometer exposes one gauge per regulated table with the
+ *       expected label set.</li>
+ *   <li>Gauges read {@code 1} on the Testcontainers database where
+ *       V69 has enabled FORCE RLS on all seven tables.</li>
+ * </ol>
+ */
+@DisplayName("ForceRlsHealthGauge — W-GAUGE-3 java.sql.Array binding (task #166)")
+class ForceRlsHealthGaugeTest extends BaseIntegrationTest {
+
+    @Autowired private ForceRlsHealthGauge gauge;
+    @Autowired private MeterRegistry meterRegistry;
+
+    @Test
+    @DisplayName("poll() completes without error and publishes one gauge per regulated table")
+    void pollPublishesGaugesForAllRegulatedTables() {
+        // @PostConstruct already registered the gauges; fire poll() once
+        // more to exercise the Array-binding query path in isolation.
+        gauge.poll();
+
+        String[] expectedTables = {
+                "audit_events",
+                "hmis_audit_log",
+                "hmis_outbox",
+                "kid_to_tenant_key",
+                "one_time_access_code",
+                "password_reset_token",
+                "tenant_key_material"
+        };
+
+        for (String table : expectedTables) {
+            Double value = meterRegistry.find("fabt.rls.force_rls_enabled")
+                    .tags(Tags.of("table", table))
+                    .gauge()
+                    .value();
+            assertThat(value)
+                    .as("fabt.rls.force_rls_enabled{table=%s} gauge is registered and reads 1 "
+                            + "on Testcontainers where V69 has applied FORCE RLS to all regulated tables", table)
+                    .isEqualTo(1.0);
+        }
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/PgVersionGateTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/PgVersionGateTest.java
@@ -1,0 +1,46 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.fabt.BaseIntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Testcontainers-backed assertion that the CI PostgreSQL image meets FABT's
+ * minimum supported version floor (16.5 / {@code server_version_num >= 160005}).
+ *
+ * <p>Paired with {@link PgVersionGate} — the component runs at every JVM
+ * boot and halts startup on floor breach, but only against whatever image
+ * the runtime is pointed at. This test is the CI-time guard catching the
+ * "someone bumped the CI image backwards" case before it reaches prod.
+ */
+class PgVersionGateTest extends BaseIntegrationTest {
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private PgVersionGate pgVersionGate;
+
+    @Test
+    void testImageMeetsMinimumServerVersion() {
+        Integer actual = jdbcTemplate.queryForObject(
+                "SELECT current_setting('server_version_num')::int", Integer.class);
+
+        assertThat(actual)
+                .as("Testcontainers Postgres image exposes server_version_num")
+                .isNotNull();
+        assertThat(actual)
+                .as("CI image at or above FABT's 16.5 floor (bump PgVersionGate.MIN_SERVER_VERSION_NUM when raising)")
+                .isGreaterThanOrEqualTo(PgVersionGate.MIN_SERVER_VERSION_NUM);
+    }
+
+    @Test
+    void startupGateBeanIsRegistered() {
+        assertThat(pgVersionGate)
+                .as("PgVersionGate @Component registered and @PostConstruct completed without halting boot")
+                .isNotNull();
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/PgVersionGateUnitTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/PgVersionGateUnitTest.java
@@ -1,0 +1,76 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Failure-branch unit tests for {@link PgVersionGate}. Covers the paths the
+ * IT (in {@link PgVersionGateTest}) cannot reach: a real Postgres server is
+ * always above the floor, so the {@code IllegalStateException} branches
+ * never fire in an integration context. Without these a regression that
+ * inverts the comparison operator (e.g. {@code <} → {@code >}) would pass
+ * CI silently.
+ */
+@ExtendWith(MockitoExtension.class)
+class PgVersionGateUnitTest {
+
+    @Mock
+    JdbcTemplate jdbcTemplate;
+
+    @Test
+    void belowFloor_throwsIllegalStateExceptionReferencingBothVersions() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class)))
+                .thenReturn(160004);
+
+        PgVersionGate gate = new PgVersionGate(jdbcTemplate);
+
+        assertThatThrownBy(gate::assertMinimumVersion)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("160004")
+                .hasMessageContaining(String.valueOf(PgVersionGate.MIN_SERVER_VERSION_NUM));
+    }
+
+    @Test
+    void nullFromQuery_throwsIllegalStateException() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class)))
+                .thenReturn(null);
+
+        PgVersionGate gate = new PgVersionGate(jdbcTemplate);
+
+        assertThatThrownBy(gate::assertMinimumVersion)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("null");
+    }
+
+    @Test
+    void atFloor_passes() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class)))
+                .thenReturn(PgVersionGate.MIN_SERVER_VERSION_NUM);
+
+        PgVersionGate gate = new PgVersionGate(jdbcTemplate);
+
+        gate.assertMinimumVersion(); // no throw
+        assertThat(gate).isNotNull();
+    }
+
+    @Test
+    void aboveFloor_passes() {
+        when(jdbcTemplate.queryForObject(anyString(), eq(Integer.class)))
+                .thenReturn(PgVersionGate.MIN_SERVER_VERSION_NUM + 100);
+
+        PgVersionGate gate = new PgVersionGate(jdbcTemplate);
+
+        gate.assertMinimumVersion(); // no throw
+        assertThat(gate).isNotNull();
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/RlsAwareDataSourceFailureTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/RlsAwareDataSourceFailureTest.java
@@ -1,0 +1,103 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit test for the v0.43 B12 invariant (task 3.18 hardening): when
+ * {@code RlsAwareDataSource.applyRlsContext} fails mid-setup, the borrowed
+ * connection MUST be closed before the {@link SQLException} escapes — a
+ * half-configured connection returned to Hikari would carry stale
+ * {@code app.tenant_id} / {@code app.dv_access} from a prior tenant and
+ * leak RLS-scoped data on the next borrow.
+ *
+ * <p>Testing this via a real Testcontainers Postgres is awkward because
+ * manufacturing a {@code SET ROLE} failure requires DB-level GRANT
+ * manipulation. Since the decorator's error path is a small 5-line
+ * try/catch (see {@link RlsDataSourceConfig.RlsAwareDataSource#applyRlsContext}),
+ * a targeted unit test of the wrapper with mocked JDBC types is both
+ * sufficient and faster.
+ */
+@DisplayName("RlsAwareDataSource B12 — connection-setup failure closes the connection (task #165)")
+class RlsAwareDataSourceFailureTest {
+
+    @Test
+    @DisplayName("getConnection(): if applyRlsContext fails, the connection is closed before the exception escapes")
+    void applyRlsContextFailure_connectionClosedBeforeExceptionEscapes() throws Exception {
+        DataSource delegate = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        PreparedStatement pstmt = mock(PreparedStatement.class);
+        SQLException failure = new SQLException("simulated SET ROLE fabt_app rejection (28P01)", "28P01");
+
+        when(delegate.getConnection()).thenReturn(conn);
+        when(conn.prepareStatement(anyString())).thenReturn(pstmt);
+        when(pstmt.execute()).thenThrow(failure);
+
+        RlsDataSourceConfig.RlsAwareDataSource wrapper =
+                new RlsDataSourceConfig.RlsAwareDataSource(delegate, null);
+
+        assertThatThrownBy(wrapper::getConnection)
+                .as("B12: the SQLException from applyRlsContext must propagate, not be swallowed")
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("SET ROLE fabt_app rejection");
+
+        verify(conn).close();
+    }
+
+    @Test
+    @DisplayName("getConnection(): success path does NOT call close() (connection is handed to caller)")
+    void applyRlsContextSuccess_connectionHandedToCaller() throws Exception {
+        DataSource delegate = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        PreparedStatement pstmt = mock(PreparedStatement.class);
+
+        when(delegate.getConnection()).thenReturn(conn);
+        when(conn.prepareStatement(anyString())).thenReturn(pstmt);
+        when(pstmt.execute()).thenReturn(true);
+
+        RlsDataSourceConfig.RlsAwareDataSource wrapper =
+                new RlsDataSourceConfig.RlsAwareDataSource(delegate, null);
+
+        Connection returned = wrapper.getConnection();
+
+        assertThat(returned)
+                .as("Success path hands the prepared connection back to the caller unchanged")
+                .isSameAs(conn);
+        verify(conn, never()).close();
+    }
+
+    @Test
+    @DisplayName("getConnection(String,String): same close-on-failure contract applies")
+    void credentialOverload_appliesSameFailureContract() throws Exception {
+        DataSource delegate = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        PreparedStatement pstmt = mock(PreparedStatement.class);
+        SQLException failure = new SQLException("role lookup failed", "42704");
+
+        when(delegate.getConnection("u", "p")).thenReturn(conn);
+        when(conn.prepareStatement(anyString())).thenReturn(pstmt);
+        when(pstmt.execute()).thenThrow(failure);
+
+        RlsDataSourceConfig.RlsAwareDataSource wrapper =
+                new RlsDataSourceConfig.RlsAwareDataSource(delegate, null);
+
+        assertThatThrownBy(() -> wrapper.getConnection("u", "p"))
+                .isInstanceOf(SQLException.class);
+
+        verify(conn).close();
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/RlsAwareDataSourceFailureTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/RlsAwareDataSourceFailureTest.java
@@ -20,17 +20,26 @@ import org.junit.jupiter.api.Test;
 /**
  * Unit test for the v0.43 B12 invariant (task 3.18 hardening): when
  * {@code RlsAwareDataSource.applyRlsContext} fails mid-setup, the borrowed
- * connection MUST be closed before the {@link SQLException} escapes — a
- * half-configured connection returned to Hikari would carry stale
- * {@code app.tenant_id} / {@code app.dv_access} from a prior tenant and
- * leak RLS-scoped data on the next borrow.
+ * connection MUST be closed before the {@link SQLException} escapes.
  *
- * <p>Testing this via a real Testcontainers Postgres is awkward because
- * manufacturing a {@code SET ROLE} failure requires DB-level GRANT
- * manipulation. Since the decorator's error path is a small 5-line
+ * <p><b>Safety chain in prod.</b> Calling {@code close()} on a HikariCP
+ * proxy does NOT destroy the physical connection — it returns the proxy
+ * to the pool with whatever session state was set before the failure.
+ * The actual safety property is: (a) the decorator closes the proxy,
+ * releasing it back to the pool, and (b) the NEXT borrow triggers
+ * another {@code applyRlsContext} which overwrites the session GUCs
+ * with the new caller's context (or empty for null TenantContext). A
+ * half-configured connection therefore does not carry stale tenant
+ * bindings into a subsequent request — the re-apply on borrow is the
+ * load-bearing invariant, not connection-destruction.
+ *
+ * <p>Testing the chain via a real Testcontainers Postgres is awkward
+ * because manufacturing a {@code SET ROLE} failure requires DB-level
+ * GRANT manipulation. Since the decorator's error path is a small
  * try/catch (see {@link RlsDataSourceConfig.RlsAwareDataSource#applyRlsContext}),
- * a targeted unit test of the wrapper with mocked JDBC types is both
- * sufficient and faster.
+ * a targeted unit test of the wrapper with mocked JDBC types covers the
+ * close-on-failure contract; the re-apply-on-borrow half is covered by
+ * {@code TenantIdPoolBleedTest} + {@code PgauditApplicationNameDriftTest}.
  */
 @DisplayName("RlsAwareDataSource B12 — connection-setup failure closes the connection (task #165)")
 class RlsAwareDataSourceFailureTest {
@@ -78,6 +87,34 @@ class RlsAwareDataSourceFailureTest {
                 .as("Success path hands the prepared connection back to the caller unchanged")
                 .isSameAs(conn);
         verify(conn, never()).close();
+    }
+
+    @Test
+    @DisplayName("getConnection(): if close() itself throws, the original failure is preserved as the primary cause")
+    void closeFailureIsSuppressedNotMasked() throws Exception {
+        DataSource delegate = mock(DataSource.class);
+        Connection conn = mock(Connection.class);
+        PreparedStatement pstmt = mock(PreparedStatement.class);
+        SQLException primary = new SQLException("primary: SET ROLE failed", "28P01");
+        SQLException secondary = new SQLException("secondary: close failed", "08006");
+
+        when(delegate.getConnection()).thenReturn(conn);
+        when(conn.prepareStatement(anyString())).thenReturn(pstmt);
+        when(pstmt.execute()).thenThrow(primary);
+        org.mockito.Mockito.doThrow(secondary).when(conn).close();
+
+        RlsDataSourceConfig.RlsAwareDataSource wrapper =
+                new RlsDataSourceConfig.RlsAwareDataSource(delegate, null);
+
+        assertThatThrownBy(wrapper::getConnection)
+                .as("Primary failure must not be masked by the close() failure — "
+                        + "diagnostic chain would be lost otherwise")
+                .isSameAs(primary);
+
+        assertThat(primary.getSuppressed())
+                .as("Secondary close() failure captured as suppressed on the primary")
+                .hasSize(1);
+        assertThat(primary.getSuppressed()[0]).isSameAs(secondary);
     }
 
     @Test

--- a/deploy/pgaudit.conf
+++ b/deploy/pgaudit.conf
@@ -15,3 +15,11 @@ shared_preload_libraries = 'pgaudit'
 # log sink so promtail/Loki picks it up. No separate pgaudit log file.
 log_destination = 'stderr'
 logging_collector = off
+
+# v0.45.0 task 3.11 — include application_name in every log line so
+# pgaudit entries carry the tenant UUID. RlsDataSourceConfig sets
+# application_name = 'fabt:tenant:<uuid>' on every connection borrow,
+# co-located with app.tenant_id in a single statement (drift-safety
+# covered by PgauditApplicationNameDriftTest). Trailing space is
+# significant — Postgres concatenates the message right after.
+log_line_prefix = '%m [%p] %q%u@%d app=%a '

--- a/deploy/prod-state.json
+++ b/deploy/prod-state.json
@@ -1,6 +1,7 @@
 {
+  "schemaVersion": 1,
   "snapshotTakenAt": "2026-04-19",
   "snapshotOriginRelease": "v0.44.3",
   "appliedMigrationsHighWaterMark": 74,
-  "notes": "Committed snapshot of prod state. Source of truth for CI's Flyway HWM guard (scripts/ci/check-flyway-migration-versions.sh). Updated post-deploy by the release runbook step 'Flyway out-of-order posture maintenance'. appliedMigrationsHighWaterMark reflects the highest V{N}__ version applied to prod; a new repo migration with version <= this value fails CI."
+  "notes": "Committed snapshot of prod state. Source of truth for CI's Flyway HWM guard (scripts/ci/check-flyway-migration-versions.sh). Updated post-deploy by the release runbook step 'Flyway out-of-order posture maintenance'. appliedMigrationsHighWaterMark reflects the highest V{N}__ version applied to prod; a new repo migration with version <= this value fails CI. Bump schemaVersion when adding fields that consumers must reason about (e.g., bridgeComposeActive, pgServerVersionNum)."
 }

--- a/deploy/prod-state.json
+++ b/deploy/prod-state.json
@@ -1,0 +1,6 @@
+{
+  "snapshotTakenAt": "2026-04-19",
+  "snapshotOriginRelease": "v0.44.3",
+  "appliedMigrationsHighWaterMark": 74,
+  "notes": "Committed snapshot of prod state. Source of truth for CI's Flyway HWM guard (scripts/ci/check-flyway-migration-versions.sh). Updated post-deploy by the release runbook step 'Flyway out-of-order posture maintenance'. appliedMigrationsHighWaterMark reflects the highest V{N}__ version applied to prod; a new repo migration with version <= this value fails CI."
+}

--- a/deploy/release-gate-pins.txt
+++ b/deploy/release-gate-pins.txt
@@ -1,0 +1,26 @@
+# release-gate-pins.txt — committed SHA-256 attestations for v0.45.0+.
+#
+# Format: <relative-path>\t<sha256-hex>\t<release-tag>
+#
+# scripts/ci/verify-release-gate-pins.sh enforces that the SHA-256 of
+# the committed file matches the pin on every CI run. A mismatch means
+# the file was edited without an accompanying pin update — either the
+# edit was inadvertent (revert the file) or it's intentional and the
+# pin needs to move.
+#
+# Updating a pin REQUIRES:
+#   1. The file content change was reviewed by the CODEOWNERS entry for
+#      that path (@ccradle for /docs/security/**).
+#   2. The old tag's CHANGELOG entry is frozen; only the NEXT release
+#      may bump the pin.
+#   3. The reviewer signs off in writing (commit author trailer is fine).
+#
+# Lines starting with '#' are comments; blank lines ignored.
+#
+# Known limitation: sha256sum on Windows/Git-Bash emits LF-normalized
+# output, while on a Linux CI runner it reads the file verbatim. If a
+# file contains mixed line endings the hashes will differ across
+# platforms. All files pinned here use LF line endings (.gitattributes
+# enforces text=auto for docs/**/*.md).
+
+docs/security/pg-policies-snapshot.md	abca0e94b7626bf855b200a677a1cdd54d3522610417ad3f76c383240e004207	v0.45.0

--- a/deploy/release-gate-pins.txt
+++ b/deploy/release-gate-pins.txt
@@ -17,10 +17,10 @@
 #
 # Lines starting with '#' are comments; blank lines ignored.
 #
-# Known limitation: sha256sum on Windows/Git-Bash emits LF-normalized
-# output, while on a Linux CI runner it reads the file verbatim. If a
-# file contains mixed line endings the hashes will differ across
-# platforms. All files pinned here use LF line endings (.gitattributes
-# enforces text=auto for docs/**/*.md).
+# Hashes are computed against the LF-normalized content of each file —
+# verify-release-gate-pins.sh pipes through `tr -d '\r'` before sha256sum
+# so the pin is platform-agnostic (a Windows Git checkout with CRLF and
+# a Linux CI checkout with LF produce the same hash). Recompute locally
+# with: tr -d '\r' < path/to/file | sha256sum
 
-docs/security/pg-policies-snapshot.md	abca0e94b7626bf855b200a677a1cdd54d3522610417ad3f76c383240e004207	v0.45.0
+docs/security/pg-policies-snapshot.md	70618354df1234c69c2bb64d226b7b850177a8f450c4f080e5396c8deb30c6a0	v0.45.0

--- a/docs/FOR-DEVELOPERS.md
+++ b/docs/FOR-DEVELOPERS.md
@@ -30,7 +30,7 @@ Three deployment tiers allow the same codebase to serve communities of vastly di
 | Layer | Technology |
 |---|---|
 | Backend | Java 25, Spring Boot 4.0, Spring MVC, Spring Data JDBC, Virtual Threads |
-| Database | PostgreSQL 16.6+, Flyway (65 migrations, latest V74), Row Level Security (D14 tenant-RLS + FORCE RLS on 7 regulated tables: `audit_events`, `hmis_audit_log`, `hmis_outbox`, `password_reset_token`, `one_time_access_code`, `tenant_key_material`, `kid_to_tenant_key`; plus DV shelters + notifications), pgaudit extension (Debian + PGDG image) for detection-of-last-resort |
+| Database | PostgreSQL 16.5+ (enforced by `PgVersionGate` at boot; floor doubles as CVE gate), Flyway (65 migrations, latest V74; renumber-forward posture from v0.45 — see `deploy/prod-state.json`), Row Level Security (D14 tenant-RLS + FORCE RLS on 7 regulated tables: `audit_events`, `hmis_audit_log`, `hmis_outbox`, `password_reset_token`, `one_time_access_code`, `tenant_key_material`, `kid_to_tenant_key`; plus DV shelters + notifications), pgaudit extension (Debian + PGDG image) for detection-of-last-resort, `application_name = 'fabt:tenant:<uuid>'` co-located with `app.tenant_id` so pgaudit log lines carry tenant UUID |
 | Cache | Caffeine L1 / + Redis L2 (Standard/Full) |
 | Events | Spring Events (Lite) / Kafka (Full) |
 | Auth | JWT (per-tenant HKDF-SHA256 signing keys + opaque `kid` header + revocation registry) + OAuth2/OIDC + API Keys (hybrid). Per-tenant DEK-envelope (v1 `FABT` magic + kid + AES-GCM) for secrets at rest — see `design-a3-encryption-envelope.md` + `design-a4-jwt-refactor.md`. |

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1104,6 +1104,57 @@ SELECT current_setting('app.tenant_id', true);
 
 ---
 
+## Flyway Out-of-Order Posture (v0.45+)
+
+### Why prod's history is permanently out-of-order
+
+The Phase A/A5/B release train landed Flyway versions in non-sequential order on prod:
+
+| Release | Deployed | Migrations added |
+|---|---|---|
+| v0.42.1 | 2026-04-18 | V74 (A5 re-encrypt under per-tenant DEKs) |
+| v0.43.1 | 2026-04-18 | V67–V72 (Phase B FORCE RLS + indexes) |
+| v0.44.1 | 2026-04-18 | V73 (pgaudit session parameters) |
+
+Because V67–V72 were numerically below the already-applied V74 at v0.43.1 deploy time, and V73 was below V74 at v0.44.1 deploy time, Flyway refused to apply them without `spring.flyway.out-of-order=true`. Prod has run that flag (supplied via `~/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml`) on every backend container ever since.
+
+The `flyway_schema_history.installed_rank` sequence therefore reads: …V66 → V74 → V67 → V68 → V69 → V70 → V71 → V72 → V73 — permanently out of installed order. This stays this way until the Flyway B-baseline reset planned for ~v0.60 (see `project_prod_baseline_strategy.md`).
+
+### What changed at v0.45
+
+The Phase B close-out warroom chose **renumber-forward** (option b) over permanent `out-of-order=true` (option a) or keeping the bridge indefinitely (option c):
+
+- **Strict ordering stays on by default** — no `spring.flyway.out-of-order` in `application.yml`.
+- **Every new migration going forward MUST have version > the prod HWM** committed in `deploy/prod-state.json`. A CI guard (`scripts/ci/check-flyway-migration-versions.sh`, wired into `.github/workflows/ci.yml` as `flyway-hwm-guard`) rejects PRs that add migrations below the HWM.
+- **The `docker-compose.prod-v0.43-flyway-ooo.yml` bridge stays on the VM for v0.45** (belt-and-suspenders in case of startup-validation edge cases), then **can be removed after the first successful v0.45+ deploy** that adds only ≥ V75 migrations (the HWM advances monotonically; once the history contains only in-order additions past V74, strict mode works again).
+
+### Post-deploy HWM-snapshot update
+
+After every deploy that applies new migrations:
+
+1. SSH to the VM and capture the new HWM:
+   ```bash
+   docker compose exec -T postgres psql -U postgres -d fabt -tAc \
+       "SELECT max(version::int) FROM flyway_schema_history WHERE success = true AND version ~ '^[0-9]+$'"
+   ```
+2. Update `deploy/prod-state.json` with the new `appliedMigrationsHighWaterMark`, `snapshotTakenAt` (today's date), and `snapshotOriginRelease` (the release tag). Commit to main.
+3. If the bridge compose file is no longer needed (i.e., all post-v0.44 migrations are ≥ V75), drop it from the override chain:
+   ```bash
+   # On the VM
+   docker compose -f docker-compose.yml \
+       -f ~/fabt-secrets/docker-compose.prod.yml \
+       -f ~/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml \
+       up -d backend
+   # The v0.43-flyway-ooo.yml is intentionally dropped from this list.
+   ```
+4. Verify startup: `docker compose logs --tail=100 backend | grep -i "out-of-order\|SPRING_FLYWAY_OUT_OF_ORDER"` — the `out-of-order` log line should no longer appear.
+
+### Blast radius of a missed renumber
+
+If CI somehow misses a below-HWM migration (e.g., `flyway-hwm-guard` job disabled, or the snapshot is stale) and the migration reaches prod with strict mode on, the backend fails to start at Flyway validation. The VM runs the last-green image; restoring service is `./dev-start.sh stop + rename file to V{HWM+1}__* + redeploy`, ~15 minutes. No data risk because Flyway refused to run the migration in the first place.
+
+---
+
 ## PostgreSQL Minor-Version Bump Checklist (v0.45+)
 
 Phase B installed `PgVersionGate` (a `@PostConstruct` check in `org.fabt.shared.security`) that halts JVM boot when the live server reports `server_version_num < 160005` (PostgreSQL 16.5). The floor is both a correctness gate (older versions lack `pg_policies.permissive`) and a security gate (PG 16.6 was the first release free of CVE-2024-10977).

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1104,6 +1104,21 @@ SELECT current_setting('app.tenant_id', true);
 
 ---
 
+## PostgreSQL Minor-Version Bump Checklist (v0.45+)
+
+Phase B installed `PgVersionGate` (a `@PostConstruct` check in `org.fabt.shared.security`) that halts JVM boot when the live server reports `server_version_num < 160005` (PostgreSQL 16.5). The floor is both a correctness gate (older versions lack `pg_policies.permissive`) and a security gate (PG 16.6 was the first release free of CVE-2024-10977).
+
+When bumping the PostgreSQL image on the VM or in CI, work the following checklist so the floor keeps pace:
+
+1. **Review the release notes + CVE advisories** for every minor release crossed. PostgreSQL CVEs at https://www.postgresql.org/support/security/. If any CVE advisory names the version you were running as affected, the floor MUST move above it.
+2. **Update `PgVersionGate.MIN_SERVER_VERSION_NUM`** to the new floor if CVE-driven. The test class `PgVersionGateTest` reads the same constant, so a single edit covers both layers.
+3. **Rebuild `deploy/pgaudit.Dockerfile`** against the new base (`postgres:<new-minor>-bookworm`) and tag it `fabt-pgaudit:v<release>`.
+4. **Run a full CI pass** (`mvn verify`) to exercise the new image against every integration test.
+5. **Deploy to the VM** following the pgaudit install steps below; verify `SHOW server_version_num` returns the expected value before accepting the deploy.
+6. **Note the new floor + CVE status** in the release's `docs/oracle-update-notes-v<release>.md`.
+
+---
+
 ## pgaudit Management (v0.44+)
 
 Phase B's detection-of-last-resort for cleared FORCE ROW LEVEL SECURITY relies on the pgaudit PostgreSQL extension emitting a log line for every DDL statement (including `ALTER TABLE … NO FORCE ROW LEVEL SECURITY`). Phase B has a 60s gauge (`ForceRlsHealthGauge`) but that's a slow tripwire; pgaudit catches the DDL within milliseconds.

--- a/docs/runbook.md
+++ b/docs/runbook.md
@@ -1157,7 +1157,7 @@ If CI somehow misses a below-HWM migration (e.g., `flyway-hwm-guard` job disable
 
 ## PostgreSQL Minor-Version Bump Checklist (v0.45+)
 
-Phase B installed `PgVersionGate` (a `@PostConstruct` check in `org.fabt.shared.security`) that halts JVM boot when the live server reports `server_version_num < 160005` (PostgreSQL 16.5). The floor is both a correctness gate (older versions lack `pg_policies.permissive`) and a security gate (PG 16.6 was the first release free of CVE-2024-10977).
+Phase B installed `PgVersionGate` (a `@PostConstruct` check in `org.fabt.shared.security`) that halts JVM boot when the live server reports `server_version_num < 160005` (PostgreSQL 16.5). The floor is both a correctness gate (older versions lack `pg_policies.permissive`) and a security gate (PG 16.5 is the first release containing the fix for CVE-2024-10977 — see [postgresql.org/support/security/CVE-2024-10977](https://www.postgresql.org/support/security/CVE-2024-10977/) for fixed-version list).
 
 When bumping the PostgreSQL image on the VM or in CI, work the following checklist so the floor keeps pace:
 

--- a/scripts/ci/check-flyway-migration-versions.sh
+++ b/scripts/ci/check-flyway-migration-versions.sh
@@ -1,0 +1,107 @@
+#!/usr/bin/env bash
+#
+# check-flyway-migration-versions.sh — v0.45.0 Flyway HWM guard.
+#
+# Enforces the renumber-forward posture chosen in the Phase B close-out
+# warroom (#151): every NEW Flyway migration file added in this branch
+# must have version strictly greater than prod's current applied HWM
+# (committed in deploy/prod-state.json).
+#
+# The rule exists because prod's flyway_schema_history has a permanently
+# out-of-order installed_rank sequence (V74 was applied at v0.42.1, then
+# V67-V72 at v0.43.1, then V73 at v0.44.1) and lives with that history
+# until the Flyway B-baseline reset at ~v0.60 (see
+# docs/runbook.md -> 'Flyway Out-of-Order Posture'). Adding a new
+# migration below the HWM would require SPRING_FLYWAY_OUT_OF_ORDER=true
+# to apply, which is the temporary bridge we are retiring.
+#
+# Usage (local):
+#   BASE_REF=origin/main ./scripts/ci/check-flyway-migration-versions.sh
+#
+# Usage (CI):
+#   Runs against the PR base branch automatically.
+#
+# Exit codes:
+#   0 = all new migrations are above HWM (or no new migrations)
+#   1 = at least one new migration violates the HWM rule
+#   2 = environmental failure (jq missing, deploy/prod-state.json missing)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+SNAPSHOT=deploy/prod-state.json
+if [[ ! -f "$SNAPSHOT" ]]; then
+    echo "FAIL: $SNAPSHOT not found. Cannot determine HWM." >&2
+    exit 2
+fi
+
+# Parse HWM without adding a jq dependency on Windows / GitHub runners.
+# The field is written as: "appliedMigrationsHighWaterMark": 74
+HWM=$(sed -nE 's/.*"appliedMigrationsHighWaterMark"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$SNAPSHOT" | head -n1)
+if ! [[ "$HWM" =~ ^[0-9]+$ ]]; then
+    echo "FAIL: appliedMigrationsHighWaterMark in $SNAPSHOT is not an integer: '$HWM'" >&2
+    exit 2
+fi
+
+BASE_REF="${BASE_REF:-origin/main}"
+if ! git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    # In shallow-cloned CI builds, BASE_REF might not exist. Fetch it.
+    git fetch --no-tags --depth=50 origin "${BASE_REF#origin/}" 2>/dev/null || true
+fi
+
+MIGRATION_GLOBS=(
+    'backend/src/main/resources/db/migration/V*.sql'
+    'backend/src/main/java/db/migration/V*.java'
+)
+
+# Collect newly-added migration files since BASE_REF. If BASE_REF still
+# isn't resolvable (first commit on a branch), fall back to checking all
+# migrations — strictly stricter than needed, but safe.
+if git rev-parse --verify "$BASE_REF" >/dev/null 2>&1; then
+    NEW_FILES=$(git diff --name-only --diff-filter=A "$BASE_REF...HEAD" -- "${MIGRATION_GLOBS[@]}" 2>/dev/null || true)
+else
+    echo "WARN: $BASE_REF unresolvable; scanning all repo migrations." >&2
+    NEW_FILES=$(printf '%s\n' "${MIGRATION_GLOBS[@]}" | xargs -I{} sh -c 'ls {} 2>/dev/null' || true)
+fi
+
+if [[ -z "$NEW_FILES" ]]; then
+    echo "✓ No new Flyway migrations in this diff (HWM = $HWM)."
+    exit 0
+fi
+
+VIOLATIONS=()
+for file in $NEW_FILES; do
+    basename=$(basename "$file")
+    # Match V<digits>[_<digits>]__rest
+    version=$(printf '%s\n' "$basename" | sed -nE 's/^V([0-9]+)(_[0-9]+)?__.*$/\1/p')
+    if [[ -z "$version" ]]; then
+        echo "WARN: cannot parse Flyway version from $basename — skipping" >&2
+        continue
+    fi
+    if (( version <= HWM )); then
+        VIOLATIONS+=("$basename (version $version)")
+    fi
+done
+
+if (( ${#VIOLATIONS[@]} > 0 )); then
+    echo "FAIL: ${#VIOLATIONS[@]} new migration(s) below HWM ($HWM):"
+    for v in "${VIOLATIONS[@]}"; do
+        echo "    - $v"
+    done
+    cat <<EOF
+
+Per the v0.45.0 Flyway renumber-forward posture, new migrations MUST
+have version strictly greater than the prod HWM in deploy/prod-state.json.
+This avoids the SPRING_FLYWAY_OUT_OF_ORDER bridge compose overlay on the
+VM. Background: docs/runbook.md -> 'Flyway Out-of-Order Posture'.
+
+Fix: rename the listed file(s) to a version greater than $HWM and update
+any references in tests / migration-list docs.
+EOF
+    exit 1
+fi
+
+COUNT=$(printf '%s\n' "$NEW_FILES" | wc -l | tr -d ' ')
+echo "✓ $COUNT new migration(s) all above HWM ($HWM)."

--- a/scripts/ci/check-flyway-migration-versions.sh
+++ b/scripts/ci/check-flyway-migration-versions.sh
@@ -24,7 +24,7 @@
 # Exit codes:
 #   0 = all new migrations are above HWM (or no new migrations)
 #   1 = at least one new migration violates the HWM rule
-#   2 = environmental failure (jq missing, deploy/prod-state.json missing)
+#   2 = environmental failure (deploy/prod-state.json missing, unknown schemaVersion)
 
 set -euo pipefail
 
@@ -37,8 +37,13 @@ if [[ ! -f "$SNAPSHOT" ]]; then
     exit 2
 fi
 
-# Parse HWM without adding a jq dependency on Windows / GitHub runners.
-# The field is written as: "appliedMigrationsHighWaterMark": 74
+# Parse without adding a jq dependency on Windows / GitHub runners.
+# Fields are written as: "fieldName": <int>
+SCHEMA=$(sed -nE 's/.*"schemaVersion"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$SNAPSHOT" | head -n1)
+if [[ "$SCHEMA" != "1" ]]; then
+    echo "FAIL: $SNAPSHOT has schemaVersion='$SCHEMA' — this script understands version 1 only. Bump the script after adding new fields." >&2
+    exit 2
+fi
 HWM=$(sed -nE 's/.*"appliedMigrationsHighWaterMark"[[:space:]]*:[[:space:]]*([0-9]+).*/\1/p' "$SNAPSHOT" | head -n1)
 if ! [[ "$HWM" =~ ^[0-9]+$ ]]; then
     echo "FAIL: appliedMigrationsHighWaterMark in $SNAPSHOT is not an integer: '$HWM'" >&2

--- a/scripts/ci/verify-release-gate-pins.sh
+++ b/scripts/ci/verify-release-gate-pins.sh
@@ -1,0 +1,70 @@
+#!/usr/bin/env bash
+#
+# verify-release-gate-pins.sh — v0.45.0 warroom W-CHANGELOG-1 guard.
+#
+# Verifies that every SHA-256 pin in deploy/release-gate-pins.txt matches
+# the current file's actual hash. Without this check the pins are
+# decorative — an operator could edit docs/security/pg-policies-
+# snapshot.md without updating the pin, and the drift would only surface
+# at deploy-time sha256sum comparison.
+#
+# Usage:
+#   ./scripts/ci/verify-release-gate-pins.sh
+#
+# Exit codes:
+#   0 = all pins match actual file SHA-256
+#   1 = at least one pin mismatch
+#   2 = environmental failure (sha256sum missing, pins file missing)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+PINS=deploy/release-gate-pins.txt
+if [[ ! -f "$PINS" ]]; then
+    echo "FAIL: $PINS not found" >&2
+    exit 2
+fi
+if ! command -v sha256sum &>/dev/null; then
+    echo "FAIL: sha256sum required but not installed" >&2
+    exit 2
+fi
+
+FAIL=0
+COUNT=0
+while IFS=$'\t' read -r path pinned release || [[ -n "$path" ]]; do
+    # Skip comments + blank lines.
+    [[ -z "$path" || "$path" =~ ^[[:space:]]*# ]] && continue
+
+    COUNT=$((COUNT + 1))
+    if [[ ! -f "$path" ]]; then
+        echo "FAIL: pinned file $path does not exist (release $release)"
+        FAIL=1
+        continue
+    fi
+    actual=$(sha256sum "$path" | awk '{print $1}')
+    if [[ "$actual" != "$pinned" ]]; then
+        echo "FAIL: SHA-256 drift on $path (pinned at $release)"
+        echo "    pinned:  $pinned"
+        echo "    actual:  $actual"
+        FAIL=1
+    fi
+done < "$PINS"
+
+if (( FAIL == 1 )); then
+    cat <<EOF
+
+Fix: update deploy/release-gate-pins.txt with the new SHA-256 (and bump
+the release-tag column), OR revert the file change if the drift was
+accidental. The pin is the compliance-grade attestation that what was
+reviewed in the CODEOWNERS-signed PR is what shipped.
+EOF
+    exit 1
+fi
+
+if (( COUNT == 0 )); then
+    echo "WARN: no pins declared in $PINS" >&2
+    exit 0
+fi
+echo "✓ $COUNT release-gate SHA-256 pin(s) verified"

--- a/scripts/ci/verify-release-gate-pins.sh
+++ b/scripts/ci/verify-release-gate-pins.sh
@@ -43,7 +43,11 @@ while IFS=$'\t' read -r path pinned release || [[ -n "$path" ]]; do
         FAIL=1
         continue
     fi
-    actual=$(sha256sum "$path" | awk '{print $1}')
+    # Normalize line endings (strip CR) before hashing so the pin is
+    # platform-agnostic. Without this, a Windows Git checkout with CRLF
+    # produces a different SHA-256 than a Linux CI runner with LF —
+    # CI fails even though both checkouts represent the same file.
+    actual=$(tr -d '\r' < "$path" | sha256sum | awk '{print $1}')
     if [[ "$actual" != "$pinned" ]]; then
         echo "FAIL: SHA-256 drift on $path (pinned at $release)"
         echo "    pinned:  $pinned"


### PR DESCRIPTION
## Summary

Phase B close-out bundle per the multi-tenant-production-readiness `v0.45.0` warroom decisions. Six logical commits tightening existing Phase B invariants (FORCE RLS on 7 regulated tables, pgaudit-driven detection-of-last-resort) without changing production surface.

- **#167 PgVersionGate** — `@PostConstruct` halts JVM boot when `server_version_num < 160005` (PG 16.5, the CVE-2024-10977 floor). Paired IT + 4 unit tests cover all branches.
- **#168 pgaudit tenant tag** — `application_name = 'fabt:tenant:<uuid>'` co-located with `app.tenant_id` in `RlsDataSourceConfig`. `%a` added to `deploy/pgaudit.conf` log_line_prefix. Drift-safety pinned by `PgauditApplicationNameDriftTest` (sequential + null + concurrent virtual-thread + transaction-scoped-override cases).
- **#151 Flyway renumber-forward** — `deploy/prod-state.json` committed HWM snapshot, `scripts/ci/check-flyway-migration-versions.sh` + `flyway-hwm-guard` CI job reject PRs that add a migration at-or-below prod HWM (74).
- **#165 Phase B residual ITs** — tasks 3.14 (SECURITY DEFINER ArchUnit-for-SQL), 3.18 (B12 connection-setup failure), 3.19 (current_user=fabt_app), 3.21 (cross-tenant RLS), 3.22 (owner-bypass prevention), 3.24 (pgaudit log-entry — already shipped).
- **#166 Warroom strong-warnings** — W-GAUGE-3 (ForceRlsHealthGauge `java.sql.Array` rewrite), W-B-FIXA-1 (TenantKeyRotationService pool-reuse IT), W-CHANGELOG-1 (SHA-256 pin in `deploy/release-gate-pins.txt` + CI verifier), W-CHANGELOG-3 (new `.github/CODEOWNERS`).

Two pre-push warroom review cycles (visible in commits `8676954` and `6da65c4`) caught + fixed a CVE-wording error in the runbook, added schemaVersion validation to the Flyway guard, and hardened the test assertions to SQLSTATE rather than English error messages.

## Tests

- 24/24 green on the new/modified classes: `PgVersionGateTest` (2), `PgVersionGateUnitTest` (4), `PgauditApplicationNameDriftTest` (4), `PhaseBRlsEnforcementTest` (4), `RlsAwareDataSourceFailureTest` (4), `ForceRlsHealthGaugeTest` (1), `TenantKeyRotationSetConfigReuseTest` (2), `MigrationLintTest` (1), plus regression-check on `TenantIdPoolBleedTest` (2).
- Manual verification of both new CI guards: `flyway-hwm-guard` fails on a below-HWM commit, passes on green; `release-gate-pin-verify` fails on file drift, passes on match.

## Test plan

- [ ] CI: backend Maven verify passes
- [ ] CI: `flyway-hwm-guard` passes (no new migrations in this PR)
- [ ] CI: `release-gate-pin-verify` passes (pg-policies snapshot unchanged)
- [ ] CI: `pgaudit-image-tests` profile passes (V73 + `@Tag("pgaudit")` sweep)
- [ ] Review `.github/CODEOWNERS` path coverage (migrations catch-all includes V67-V74)
- [ ] Confirm CHANGELOG [v0.45.0] section is accurate before tagging
- [ ] After merge: bump `backend/pom.xml` 0.44.3 → 0.45.0 on main, tag v0.45.0, deploy

## Post-merge deploy notes

The SPRING_FLYWAY_OUT_OF_ORDER bridge compose overlay on the VM can remain for v0.45 as belt-and-suspenders. Once v0.45 deploys cleanly with no new <=V74 migrations, the override file can be dropped from the compose chain per the runbook's new "Flyway Out-of-Order Posture" section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)