### PR TITLE
Phase C task 4.1 — TenantScopedCacheService wrapper + REQUIRES_NEW cross-tenant audit

### DIFF
--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
@@ -126,6 +126,60 @@ public final class AuditEventTypes {
      */
     public static final String SHELTER_REACTIVATED = "SHELTER_REACTIVATED";
 
+    // ---- multi-tenant-production-readiness Phase C (cache isolation) ----
+
+    /**
+     * Emitted by {@code TenantScopedCacheService.invalidateTenant(UUID)} when
+     * a tenant's cache entries are evicted across every registered cache name.
+     * Fires at tenant suspend / hard-delete (Phase F F4) and on demand by the
+     * platform-admin API.
+     *
+     * <p>Detail blob: {@code {tenantId, perCacheEvictionCounts: {cacheName: N, ...}}}.
+     * Actor: {@code null} for FSM-driven calls; platform-admin UUID for manual
+     * invalidations. Target: {@code null} (operation scope is the tenant itself).
+     *
+     * <p>Persisted via the event-bus path ({@code ApplicationEventPublisher} →
+     * {@code AuditEventService.onAuditEvent} → {@code AuditEventPersister} with
+     * {@code PROPAGATION_REQUIRED}). Normal rollback semantics apply: operator-
+     * initiated invalidations are not attacker-triggered, so the usual "audit
+     * joins caller tx" contract is correct.
+     */
+    public static final String TENANT_CACHE_INVALIDATED = "TENANT_CACHE_INVALIDATED";
+
+    /**
+     * Emitted by {@code TenantScopedCacheService.get} when the on-read tenant
+     * verification (cached-value stamp mismatch) detects that the envelope's
+     * stamped tenant does not match the reader's {@code TenantContext}.
+     *
+     * <p>Detail blob: {@code {cacheName, expectedTenant, observedTenant}}.
+     * Actor: current user from {@code TenantContext.getUserId()}. Target: {@code null}.
+     *
+     * <p><b>Persisted via {@link DetachedAuditPersister}</b> with
+     * {@code PROPAGATION_REQUIRES_NEW} — NOT the normal event-bus path. Rationale:
+     * this is a security-evidence signal. An attacker who triggers a cross-tenant
+     * read in a transactional endpoint and relies on the subsequent
+     * {@code IllegalStateException} to roll the caller's transaction back must
+     * NOT be able to erase the audit trail. REQUIRES_NEW commits the audit row
+     * independently so it survives the caller's rollback. Marcus Webb warroom
+     * lens, Phase C task 4.1 skeleton review (design-c D-C-9).
+     */
+    public static final String CROSS_TENANT_CACHE_READ = "CROSS_TENANT_CACHE_READ";
+
+    /**
+     * Emitted by {@code TenantScopedCacheService.get} when it encounters a
+     * cache entry whose underlying value is not a {@code TenantScopedValue}
+     * envelope. Indicates a caller wrote via raw {@code CacheService} (bypassing
+     * the wrapper) — either a pre-migration call site not yet converted
+     * (task 4.b) or a new call site slipping past the ArchUnit Family C rule.
+     *
+     * <p>Detail blob: {@code {cacheName, observedType}}. Value fragments are
+     * NOT included (avoid leaking cached payload into audit rows).
+     *
+     * <p>Persisted via the event-bus path (not security-evidence; shouldn't happen
+     * at all once task 4.b completes call-site migration).
+     */
+    public static final String MALFORMED_CACHE_ENTRY = "MALFORMED_CACHE_ENTRY";
+
     private AuditEventTypes() {
         // utility class — do not instantiate
     }

--- a/backend/src/main/java/org/fabt/shared/audit/DetachedAuditPersister.java
+++ b/backend/src/main/java/org/fabt/shared/audit/DetachedAuditPersister.java
@@ -1,0 +1,103 @@
+package org.fabt.shared.audit;
+
+import java.util.UUID;
+
+import org.fabt.shared.audit.repository.AuditEventRepository;
+import org.fabt.shared.config.JsonString;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import tools.jackson.databind.ObjectMapper;
+
+/**
+ * Persists audit events under {@code PROPAGATION_REQUIRES_NEW} — sibling to
+ * {@link AuditEventPersister}'s {@code REQUIRED} path.
+ *
+ * <p><b>Why this exists (Marcus Webb lens, Phase C task 4.1 warroom, design-c
+ * D-C-9).</b> The default event-bus audit path ({@code ApplicationEventPublisher}
+ * → {@link AuditEventService#onAuditEvent} → {@link AuditEventPersister} with
+ * {@code PROPAGATION_REQUIRED}) joins the caller's transaction. If the caller
+ * rolls back, the audit row rolls back with it. For most audits this is the
+ * correct contract: an action that rolled back shouldn't audit as having
+ * happened.
+ *
+ * <p>For security-evidence audits — specifically
+ * {@link AuditEventTypes#CROSS_TENANT_CACHE_READ} emitted from
+ * {@code TenantScopedCacheService.get} when on-read tenant verification detects
+ * a stamp mismatch — this rollback-coupling is an anti-feature. An attacker who
+ * triggers a cross-tenant read in a transactional endpoint and relies on the
+ * subsequent {@code IllegalStateException} to roll the caller back would erase
+ * the one audit signal proving the attempt happened.
+ *
+ * <p>{@code REQUIRES_NEW} cuts the audit row loose — it commits in its own
+ * transaction, independent of the caller's fate.
+ *
+ * <p><b>Scope.</b> Reserved for security-evidence audit events that must
+ * survive caller rollback. Today's call sites:
+ * <ul>
+ *   <li>{@code TenantScopedCacheService.get} → {@code CROSS_TENANT_CACHE_READ}</li>
+ * </ul>
+ *
+ * <p>New call sites MUST be reviewed at the PR gate — adopt this path ONLY when
+ * the audit is load-bearing for security forensics. The event-bus path remains
+ * correct for the other 99% of audit rows.
+ *
+ * <p>Marked {@code public} (sibling {@link AuditEventPersister} is package-private)
+ * so non-{@code shared.audit} beans — specifically the cache wrapper — can call it
+ * directly without routing through {@link AuditEventService}'s event listener.
+ */
+@Service
+public class DetachedAuditPersister {
+
+    private static final Logger log = LoggerFactory.getLogger(DetachedAuditPersister.class);
+
+    private final AuditEventRepository repository;
+    private final JdbcTemplate jdbc;
+    private final ObjectMapper objectMapper;
+
+    public DetachedAuditPersister(AuditEventRepository repository,
+                                   JdbcTemplate jdbc,
+                                   ObjectMapper objectMapper) {
+        this.repository = repository;
+        this.jdbc = jdbc;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Binds {@code app.tenant_id} for this {@code REQUIRES_NEW} transaction,
+     * serialises the event's {@code details} object into a {@link JsonString},
+     * and persists an {@link AuditEventEntity}.
+     *
+     * <p>Independent of any caller transaction. Caller rollbacks do NOT affect
+     * the persisted row.
+     */
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    public void persistDetached(UUID tenantId, AuditEventRecord event) {
+        try {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                    String.class, tenantId.toString());
+            JsonString details = null;
+            if (event.details() != null) {
+                details = new JsonString(objectMapper.writeValueAsString(event.details()));
+            }
+            AuditEventEntity entity = new AuditEventEntity(
+                    tenantId,
+                    event.actorUserId(),
+                    event.targetUserId(),
+                    event.action(),
+                    details,
+                    event.ipAddress());
+            repository.save(entity);
+        } catch (Exception e) {
+            // Swallow + log: the security-evidence contract is best-effort; the
+            // caller's IllegalStateException (the reason we're here) has already
+            // fired and will propagate. We log loudly so an operator can follow
+            // up, but do NOT re-throw (that would mask the original ISE).
+            log.error("DetachedAuditPersister failed for action={} tenant={}: {}",
+                    event.action(), tenantId, e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/audit/DetachedAuditPersister.java
+++ b/backend/src/main/java/org/fabt/shared/audit/DetachedAuditPersister.java
@@ -2,10 +2,13 @@ package org.fabt.shared.audit;
 
 import java.util.UUID;
 
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
 import org.fabt.shared.audit.repository.AuditEventRepository;
 import org.fabt.shared.config.JsonString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Propagation;
@@ -57,13 +60,16 @@ public class DetachedAuditPersister {
     private final AuditEventRepository repository;
     private final JdbcTemplate jdbc;
     private final ObjectMapper objectMapper;
+    private final MeterRegistry meterRegistry;
 
     public DetachedAuditPersister(AuditEventRepository repository,
                                    JdbcTemplate jdbc,
-                                   ObjectMapper objectMapper) {
+                                   ObjectMapper objectMapper,
+                                   ObjectProvider<MeterRegistry> meterRegistryProvider) {
         this.repository = repository;
         this.jdbc = jdbc;
         this.objectMapper = objectMapper;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
     }
 
     /**
@@ -96,6 +102,19 @@ public class DetachedAuditPersister {
             // caller's IllegalStateException (the reason we're here) has already
             // fired and will propagate. We log loudly so an operator can follow
             // up, but do NOT re-throw (that would mask the original ISE).
+            //
+            // Also emit `fabt.audit.detached_failed.count{action}` so the swallow
+            // has a metric signal, not only a log line (Jordan + Marcus warroom,
+            // code review round 2026-04-19 PM). Operator alerts on this counter
+            // going non-zero with the same urgency as
+            // `fabt.audit.rls_rejected.count` — both represent lost audit rows.
+            if (meterRegistry != null) {
+                Counter.builder("fabt.audit.detached_failed.count")
+                        .tag("action", event.action() == null ? "unknown" : event.action())
+                        .description("DetachedAuditPersister persist failures (security-evidence audit rows lost due to DB contention / schema / RLS rejection)")
+                        .register(meterRegistry)
+                        .increment();
+            }
             log.error("DetachedAuditPersister failed for action={} tenant={}: {}",
                     event.action(), tenantId, e.getMessage(), e);
         }

--- a/backend/src/main/java/org/fabt/shared/cache/CacheService.java
+++ b/backend/src/main/java/org/fabt/shared/cache/CacheService.java
@@ -12,4 +12,35 @@ public interface CacheService {
     void evict(String cacheName, String key);
 
     void evictAll(String cacheName);
+
+    /**
+     * Evicts every entry in {@code cacheName} whose key starts with {@code prefix}.
+     * Returns the number of entries evicted.
+     *
+     * <p>Added in Phase C (multi-tenant-production-readiness) to support
+     * {@code TenantScopedCacheService.invalidateTenant(UUID)} without coupling
+     * the wrapper to a specific cache implementation.
+     *
+     * <p>Implementation guidance:
+     * <ul>
+     *   <li>Caffeine: filter {@code cache.asMap().keySet()} by prefix + invalidate each match.</li>
+     *   <li>Redis L2 (future, per redis-pooling-adr.md shape 2/3):
+     *       {@code SCAN 0 MATCH "<prefix>*" COUNT 1000} iteratively with
+     *       {@code UNLINK} per batch. {@code UNLINK} is non-blocking on the Redis
+     *       main thread; {@code DEL} and {@code KEYS} are explicitly rejected
+     *       per Redis Inc.'s Feb 2026 guidance for multi-tenant deployments.</li>
+     * </ul>
+     *
+     * <p>If {@code cacheName} has never been written to, returns {@code 0} without
+     * throwing. A malformed or absent cache is NOT an error from the caller's
+     * perspective — the tenant-lifecycle FSM is allowed to invalidate a never-
+     * written tenant.
+     *
+     * @param cacheName the logical cache name (one of {@link CacheNames})
+     * @param prefix the key prefix to match; callers pass the tenant prefix
+     *               (e.g. {@code "<tenantUuid>|"}) from
+     *               {@code TenantScopedCacheService}
+     * @return count of entries evicted; {@code 0} if the cache is empty or absent
+     */
+    long evictAllByPrefix(String cacheName, String prefix);
 }

--- a/backend/src/main/java/org/fabt/shared/cache/CaffeineCacheService.java
+++ b/backend/src/main/java/org/fabt/shared/cache/CaffeineCacheService.java
@@ -25,6 +25,11 @@ public class CaffeineCacheService implements CacheService {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Optional<T> get(String cacheName, String key, Class<T> type) {
+        // Under TenantScopedCacheService ownership (Phase C), the wrapper fetches
+        // as Object.class + pattern-matches `instanceof TenantScopedValue<?>` so
+        // the unchecked cast below is effectively always Object→Object. The
+        // `type` parameter is retained for direct (pre-wrapper) callers that
+        // still exist until task 4.b migrates the 7 known call sites.
         Cache<String, Object> cache = caches.get(cacheName);
         if (cache == null) {
             return Optional.empty();

--- a/backend/src/main/java/org/fabt/shared/cache/CaffeineCacheService.java
+++ b/backend/src/main/java/org/fabt/shared/cache/CaffeineCacheService.java
@@ -59,4 +59,17 @@ public class CaffeineCacheService implements CacheService {
             cache.invalidateAll();
         }
     }
+
+    @Override
+    public long evictAllByPrefix(String cacheName, String prefix) {
+        Cache<String, Object> cache = caches.get(cacheName);
+        if (cache == null) {
+            return 0L;
+        }
+        java.util.List<String> toEvict = cache.asMap().keySet().stream()
+                .filter(k -> k.startsWith(prefix))
+                .toList();
+        toEvict.forEach(cache::invalidate);
+        return toEvict.size();
+    }
 }

--- a/backend/src/main/java/org/fabt/shared/cache/TenantScopedCacheService.java
+++ b/backend/src/main/java/org/fabt/shared/cache/TenantScopedCacheService.java
@@ -1,0 +1,343 @@
+package org.fabt.shared.cache;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.time.Duration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.Gauge;
+import io.micrometer.core.instrument.MeterRegistry;
+import jakarta.annotation.PostConstruct;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.audit.DetachedAuditPersister;
+import org.fabt.shared.web.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.stereotype.Service;
+
+/**
+ * Tenant-scoped wrapper around {@link CacheService} — the single source of
+ * truth for tenant-safe cache access in FABT.
+ *
+ * <p>Published as a <b>distinct Spring bean</b> named {@code tenantScopedCacheService},
+ * NOT as {@code @Primary} over the underlying {@link CacheService}. Callers that
+ * want tenant scoping inject this class explicitly; callers that carry a
+ * {@code @TenantUnscopedCache} justification keep using the raw {@link CacheService}.
+ * This separation is intentional — {@code @Primary} would silently double-prefix
+ * any legacy call site that already manually embeds {@code tenantId} in the key.
+ *
+ * <h2>Four load-bearing contracts</h2>
+ *
+ * <ol>
+ *   <li><b>Key prefix.</b> Every {@code get}/{@code put}/{@code evict} prepends
+ *       {@code TenantContext.getTenantId() + "|"} to the caller's logical key.
+ *       Separator is pipe (not colon) so existing composite call-site keys like
+ *       {@code AnalyticsService}'s {@code tenantId + ":" + from + ":" + to}
+ *       remain visually unambiguous during migration (design-c D-C-10).</li>
+ *   <li><b>Value stamp + verify.</b> On write, values are wrapped in a
+ *       {@link TenantScopedValue} envelope stamped with the writer's tenant.
+ *       On read, the envelope's stamp is verified against the reader's
+ *       {@code TenantContext}; mismatch throws {@code CROSS_TENANT_CACHE_READ}.
+ *       This is a <em>second</em> isolation control — prefix defends the read
+ *       side, stamp-and-verify defends the write side (design-c D-C-13).</li>
+ *   <li><b>{@code invalidateTenant(UUID)}.</b> Iterates the eager-seeded
+ *       {@link #registeredCacheNames} registry (populated at {@code @PostConstruct}
+ *       from {@link CacheNames} reflection — NOT lazily on first put per
+ *       design-c D-C-8) and evicts every entry matching
+ *       {@code <tenantId>|*} via {@link CacheService#evictAllByPrefix}.
+ *       Idempotent across retries; emits an audit row with per-cache eviction
+ *       counts. Called from the tenant-lifecycle FSM (Phase F F4) and the
+ *       platform-admin API.</li>
+ *   <li><b>Observability.</b> Every {@code get}/{@code put} emits Micrometer
+ *       counters {@code fabt.cache.get{cache,tenant,result}} +
+ *       {@code fabt.cache.put{cache,tenant}}. Result ∈
+ *       {{@code hit, miss, cross_tenant_reject, malformed_entry}}. Tag
+ *       {@code tenant} (not {@code tenant_id}) matches the G4 OTel baggage key.</li>
+ * </ol>
+ *
+ * <h2>Exception posture</h2>
+ *
+ * <p>All {@code IllegalStateException} / {@code IllegalArgumentException}
+ * messages produced by this class carry ONLY short action tags
+ * ({@code TENANT_CONTEXT_UNBOUND}, {@code CROSS_TENANT_CACHE_READ},
+ * {@code MALFORMED_CACHE_ENTRY}). UUIDs, keys, and payload fragments go to
+ * audit rows + structured logs — never to exception messages (prevents
+ * information disclosure through {@code GlobalExceptionHandler}; design-c
+ * D-C-11 + OWASP ASVS 5.0 §7.4.1).
+ *
+ * <h2>Audit routing</h2>
+ *
+ * <ul>
+ *   <li>{@code TENANT_CACHE_INVALIDATED} — normal event-bus path
+ *       ({@link ApplicationEventPublisher} →
+ *       {@code AuditEventService.onAuditEvent} → {@code AuditEventPersister}
+ *       REQUIRED). Operator-initiated; rollback-coupling is correct.</li>
+ *   <li>{@code CROSS_TENANT_CACHE_READ} — detached REQUIRES_NEW path via
+ *       {@link DetachedAuditPersister}. Security evidence must survive
+ *       attacker-triggered caller rollback.</li>
+ *   <li>{@code MALFORMED_CACHE_ENTRY} — event-bus path; not attacker-triggered
+ *       (indicates a wrapper-bypass bug on the write side, task 4.b migration
+ *       not yet complete).</li>
+ * </ul>
+ *
+ * @see TenantScopedValue
+ * @see DetachedAuditPersister
+ * @see CacheService#evictAllByPrefix
+ */
+@Service
+public class TenantScopedCacheService {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantScopedCacheService.class);
+
+    /** Separator between tenant prefix and caller's logical key. See design-c D-C-10. */
+    static final String PREFIX_SEPARATOR = "|";
+
+    // Cardinality budget (observability):
+    //   N_tenants × N_caches × N_results × N_ops
+    //   = 100 × 11 × 4 × 2
+    //   = ~8800 time-series maximum.
+    // Acceptable within Prometheus's practical per-metric-family ceiling.
+    // Review if pooled tenant count grows past 500.
+
+    private final CacheService delegate;
+    private final ApplicationEventPublisher eventPublisher;
+    private final DetachedAuditPersister detachedAuditPersister;
+    private final MeterRegistry meterRegistry;
+
+    /**
+     * Authoritative registry of cache names the wrapper will iterate during
+     * {@code invalidateTenant}. Seeded eagerly at {@code @PostConstruct} from
+     * {@link CacheNames} reflection (design-c D-C-8) — a lazy-on-first-put
+     * registry would silently no-op after JVM restart for tenants that haven't
+     * yet been written to, turning the Phase F tenant-suspension page at 3am
+     * into a false "succeeded" signal.
+     */
+    private final Set<String> registeredCacheNames = ConcurrentHashMap.newKeySet();
+
+    public TenantScopedCacheService(CacheService delegate,
+                                     ApplicationEventPublisher eventPublisher,
+                                     DetachedAuditPersister detachedAuditPersister,
+                                     ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this.delegate = delegate;
+        this.eventPublisher = eventPublisher;
+        this.detachedAuditPersister = detachedAuditPersister;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
+    }
+
+    @PostConstruct
+    void seedRegisteredCacheNames() {
+        for (Field f : CacheNames.class.getFields()) {
+            if (Modifier.isStatic(f.getModifiers()) && f.getType() == String.class) {
+                try {
+                    Object v = f.get(null);
+                    if (v instanceof String s && !s.isBlank()) {
+                        registeredCacheNames.add(s);
+                    }
+                } catch (IllegalAccessException e) {
+                    // CacheNames is a public interface with public static final String
+                    // fields; this cannot happen in practice.
+                    throw new IllegalStateException(
+                            "TenantScopedCacheService failed to reflect CacheNames.", e);
+                }
+            }
+        }
+        if (registeredCacheNames.isEmpty()) {
+            throw new IllegalStateException(
+                    "TenantScopedCacheService found no cache names in CacheNames reflection. "
+                    + "Refusing to start — invalidateTenant would silently no-op.");
+        }
+        log.info("TenantScopedCacheService eager-seeded with {} cache names: {}",
+                registeredCacheNames.size(), registeredCacheNames);
+        if (meterRegistry != null) {
+            Gauge.builder("fabt.cache.registered_cache_names",
+                            registeredCacheNames, Set::size)
+                    .description("Number of cache names seeded into TenantScopedCacheService at startup")
+                    .register(meterRegistry);
+        }
+    }
+
+    /**
+     * Tenant-scoped get with on-read envelope verification.
+     *
+     * @throws IllegalStateException tagged {@code TENANT_CONTEXT_UNBOUND} if no
+     *         TenantContext is bound; tagged {@code CROSS_TENANT_CACHE_READ} if
+     *         the stored envelope's stamp does not match the reader's tenant;
+     *         tagged {@code MALFORMED_CACHE_ENTRY} if the stored value is not a
+     *         {@link TenantScopedValue} or its inner value's type does not match
+     *         the caller's requested type.
+     */
+    public <T> Optional<T> get(String cacheName, String key, Class<T> type) {
+        UUID tenantId = requireTenantContext();
+        String scopedKey = tenantId + PREFIX_SEPARATOR + key;
+
+        // Fetch as Object.class (not TenantScopedValue.class) so a raw
+        // non-envelope payload written by a wrapper-bypass caller surfaces as
+        // MALFORMED_CACHE_ENTRY — NOT a bare ClassCastException from the
+        // delegate's generic unchecked cast at the return-type use site.
+        Optional<Object> raw = delegate.get(cacheName, scopedKey, Object.class);
+        if (raw.isEmpty()) {
+            recordGet(cacheName, tenantId, "miss");
+            return Optional.empty();
+        }
+
+        if (!(raw.get() instanceof TenantScopedValue<?> envelope)) {
+            handleMalformedEntry(cacheName, tenantId, raw.get().getClass().getName());
+            recordGet(cacheName, tenantId, "malformed_entry");
+            throw new IllegalStateException("MALFORMED_CACHE_ENTRY");
+        }
+
+        if (!tenantId.equals(envelope.tenantId())) {
+            handleCrossTenantRead(cacheName, tenantId, envelope.tenantId());
+            recordGet(cacheName, tenantId, "cross_tenant_reject");
+            throw new IllegalStateException("CROSS_TENANT_CACHE_READ");
+        }
+
+        Object v = envelope.value();
+        if (v != null && !type.isInstance(v)) {
+            handleMalformedEntry(cacheName, tenantId, v.getClass().getName());
+            recordGet(cacheName, tenantId, "malformed_entry");
+            throw new IllegalStateException("MALFORMED_CACHE_ENTRY");
+        }
+
+        recordGet(cacheName, tenantId, "hit");
+        return Optional.ofNullable(type.cast(v));
+    }
+
+    /**
+     * Tenant-scoped put with value stamping.
+     *
+     * @throws IllegalStateException tagged {@code TENANT_CONTEXT_UNBOUND} if no
+     *         TenantContext is bound.
+     * @throws IllegalArgumentException if {@code value} is null (belt-and-
+     *         suspenders with the Family C ArchUnit rule rejecting
+     *         {@code put(…, null, …)} call sites).
+     */
+    public <T> void put(String cacheName, String key, T value, Duration ttl) {
+        if (value == null) {
+            throw new IllegalArgumentException("TenantScopedCacheService.put value must not be null");
+        }
+        UUID tenantId = requireTenantContext();
+        String scopedKey = tenantId + PREFIX_SEPARATOR + key;
+        delegate.put(cacheName, scopedKey, new TenantScopedValue<>(tenantId, value), ttl);
+        recordPut(cacheName, tenantId);
+    }
+
+    /** Tenant-scoped evict. */
+    public void evict(String cacheName, String key) {
+        UUID tenantId = requireTenantContext();
+        String scopedKey = tenantId + PREFIX_SEPARATOR + key;
+        delegate.evict(cacheName, scopedKey);
+    }
+
+    /**
+     * Evicts every cache entry whose key begins with the given tenant's prefix
+     * across every registered cache name. Idempotent across retries.
+     *
+     * <p>Emits an {@code audit_events} row with action
+     * {@link AuditEventTypes#TENANT_CACHE_INVALIDATED} and per-cache eviction
+     * counts in the details column. Uses the normal event-bus audit path
+     * (operator-initiated; rollback-coupling is correct here).
+     *
+     * <p>Does NOT require a bound {@code TenantContext} — this method is called
+     * from the tenant-lifecycle FSM and platform-admin API, neither of which
+     * necessarily carries the target tenant's context.
+     */
+    public void invalidateTenant(UUID tenantId) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        String prefix = tenantId + PREFIX_SEPARATOR;
+        Map<String, Long> perCacheEvictions = new LinkedHashMap<>();
+        long total = 0L;
+        for (String cacheName : registeredCacheNames) {
+            long evicted = delegate.evictAllByPrefix(cacheName, prefix);
+            perCacheEvictions.put(cacheName, evicted);
+            total += evicted;
+        }
+        log.info("TENANT_CACHE_INVALIDATED tenant={} totalEvicted={} perCache={}",
+                tenantId, total, perCacheEvictions);
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("tenantId", tenantId.toString());
+        details.put("totalEvicted", total);
+        details.put("perCacheEvictionCounts", perCacheEvictions);
+        eventPublisher.publishEvent(new AuditEventRecord(
+                TenantContext.getUserId(),
+                null,
+                AuditEventTypes.TENANT_CACHE_INVALIDATED,
+                details,
+                null));
+    }
+
+    // --- private helpers ---
+
+    private UUID requireTenantContext() {
+        UUID tid = TenantContext.getTenantId();
+        if (tid == null) {
+            throw new IllegalStateException("TENANT_CONTEXT_UNBOUND");
+        }
+        return tid;
+    }
+
+    private void recordGet(String cacheName, UUID tenantId, String result) {
+        if (meterRegistry == null) return;
+        Counter.builder("fabt.cache.get")
+                .tag("cache", cacheName)
+                .tag("tenant", tenantId.toString())
+                .tag("result", result)
+                .register(meterRegistry)
+                .increment();
+    }
+
+    private void recordPut(String cacheName, UUID tenantId) {
+        if (meterRegistry == null) return;
+        Counter.builder("fabt.cache.put")
+                .tag("cache", cacheName)
+                .tag("tenant", tenantId.toString())
+                .register(meterRegistry)
+                .increment();
+    }
+
+    private void handleCrossTenantRead(String cacheName, UUID readerTenant, UUID stampedTenant) {
+        log.error("CROSS_TENANT_CACHE_READ cache={} readerTenant={} stampedTenant={}",
+                cacheName, readerTenant, stampedTenant);
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("cacheName", cacheName);
+        details.put("expectedTenant", readerTenant.toString());
+        details.put("observedTenant", stampedTenant.toString());
+        detachedAuditPersister.persistDetached(readerTenant, new AuditEventRecord(
+                TenantContext.getUserId(),
+                null,
+                AuditEventTypes.CROSS_TENANT_CACHE_READ,
+                details,
+                null));
+    }
+
+    private void handleMalformedEntry(String cacheName, UUID readerTenant, String observedType) {
+        log.error("MALFORMED_CACHE_ENTRY cache={} readerTenant={} observedType={}",
+                cacheName, readerTenant, observedType);
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("cacheName", cacheName);
+        details.put("observedType", observedType);
+        eventPublisher.publishEvent(new AuditEventRecord(
+                TenantContext.getUserId(),
+                null,
+                AuditEventTypes.MALFORMED_CACHE_ENTRY,
+                details,
+                null));
+    }
+
+    // --- test accessors (package-private) ---
+
+    /** Package-private for tests: the eager-seeded registry snapshot. */
+    Set<String> registeredCacheNamesSnapshot() {
+        return Set.copyOf(registeredCacheNames);
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/cache/TenantScopedCacheService.java
+++ b/backend/src/main/java/org/fabt/shared/cache/TenantScopedCacheService.java
@@ -124,6 +124,19 @@ public class TenantScopedCacheService {
      */
     private final Set<String> registeredCacheNames = ConcurrentHashMap.newKeySet();
 
+    /**
+     * Per-tag-combination Counter cache. Counters are created lazily on first
+     * use then reused — avoids the per-op {@code MeterRegistry} tag-map lookup
+     * in {@code Counter.builder(...).register(...)} that BedSearch's hot path
+     * (~1k QPS) would otherwise incur. Sam Okafor's warroom review, code review
+     * round 2026-04-19 PM.
+     */
+    private final Map<GetCounterKey, Counter> getCounters = new ConcurrentHashMap<>();
+    private final Map<PutCounterKey, Counter> putCounters = new ConcurrentHashMap<>();
+
+    private record GetCounterKey(String cacheName, UUID tenantId, String result) {}
+    private record PutCounterKey(String cacheName, UUID tenantId) {}
+
     public TenantScopedCacheService(CacheService delegate,
                                      ApplicationEventPublisher eventPublisher,
                                      DetachedAuditPersister detachedAuditPersister,
@@ -288,21 +301,25 @@ public class TenantScopedCacheService {
 
     private void recordGet(String cacheName, UUID tenantId, String result) {
         if (meterRegistry == null) return;
-        Counter.builder("fabt.cache.get")
-                .tag("cache", cacheName)
-                .tag("tenant", tenantId.toString())
-                .tag("result", result)
-                .register(meterRegistry)
-                .increment();
+        getCounters.computeIfAbsent(
+                new GetCounterKey(cacheName, tenantId, result),
+                k -> Counter.builder("fabt.cache.get")
+                        .tag("cache", k.cacheName())
+                        .tag("tenant", k.tenantId().toString())
+                        .tag("result", k.result())
+                        .register(meterRegistry)
+        ).increment();
     }
 
     private void recordPut(String cacheName, UUID tenantId) {
         if (meterRegistry == null) return;
-        Counter.builder("fabt.cache.put")
-                .tag("cache", cacheName)
-                .tag("tenant", tenantId.toString())
-                .register(meterRegistry)
-                .increment();
+        putCounters.computeIfAbsent(
+                new PutCounterKey(cacheName, tenantId),
+                k -> Counter.builder("fabt.cache.put")
+                        .tag("cache", k.cacheName())
+                        .tag("tenant", k.tenantId().toString())
+                        .register(meterRegistry)
+        ).increment();
     }
 
     private void handleCrossTenantRead(String cacheName, UUID readerTenant, UUID stampedTenant) {

--- a/backend/src/main/java/org/fabt/shared/cache/TenantScopedValue.java
+++ b/backend/src/main/java/org/fabt/shared/cache/TenantScopedValue.java
@@ -1,0 +1,27 @@
+package org.fabt.shared.cache;
+
+import java.util.UUID;
+
+/**
+ * Envelope that stamps every cache value with the tenant that wrote it.
+ *
+ * <p>Enables on-read tenant verification per
+ * {@code docs/architecture/redis-pooling-adr.md} "Cached-value tenant
+ * verification" — a second isolation control alongside the key prefix.
+ * Prefix defends the read side (reader cannot guess another tenant's keys);
+ * stamp-and-verify defends the write side (a caller with wrong TenantContext
+ * bound cannot silently poison another tenant's keyspace). Both must fail
+ * in the same direction for a cross-tenant leak.
+ *
+ * <p>The stamp is the {@link java.util.UUID} of the tenant bound at write
+ * time (via {@code TenantContext.getTenantId()}), NOT a field extracted
+ * from the payload. This is deliberate: a payload that itself contains a
+ * {@code tenantId} field was populated by the same wrong-context caller
+ * that will pass the wrapper's inner check. Stamping at the wrapper level
+ * captures the execution-context tenant independently of whatever the
+ * payload says.
+ *
+ * @param tenantId tenant context bound at write time
+ * @param value caller's cached value (may be any serialisable type)
+ */
+public record TenantScopedValue<T>(UUID tenantId, T value) {}

--- a/backend/src/main/java/org/fabt/shared/cache/TieredCacheService.java
+++ b/backend/src/main/java/org/fabt/shared/cache/TieredCacheService.java
@@ -80,4 +80,23 @@ public class TieredCacheService implements CacheService {
         }
         // TODO: Evict from L2 (Redis)
     }
+
+    @Override
+    public long evictAllByPrefix(String cacheName, String prefix) {
+        Cache<String, Object> l1 = l1Caches.get(cacheName);
+        long l1Evicted = 0L;
+        if (l1 != null) {
+            java.util.List<String> toEvict = l1.asMap().keySet().stream()
+                    .filter(k -> k.startsWith(prefix))
+                    .toList();
+            toEvict.forEach(l1::invalidate);
+            l1Evicted = toEvict.size();
+        }
+        // TODO: Evict from L2 (Redis) when L2 is wired (per redis-pooling-adr.md
+        // shape 2 or 3). Implementation contract:
+        //   SCAN 0 MATCH "<prefix>*" COUNT 1000 + UNLINK per batch.
+        //   Never KEYS or DEL (both main-thread-blocking on large key counts).
+        //   Return sum of L1 + L2 evictions once L2 is live.
+        return l1Evicted;
+    }
 }

--- a/backend/src/main/java/org/fabt/shared/cache/TieredCacheService.java
+++ b/backend/src/main/java/org/fabt/shared/cache/TieredCacheService.java
@@ -34,6 +34,10 @@ public class TieredCacheService implements CacheService {
     @Override
     @SuppressWarnings("unchecked")
     public <T> Optional<T> get(String cacheName, String key, Class<T> type) {
+        // Under TenantScopedCacheService ownership (Phase C), the wrapper fetches
+        // as Object.class + pattern-matches `instanceof TenantScopedValue<?>` so
+        // the unchecked cast below is effectively always Object→Object. The
+        // `type` parameter is retained for direct (pre-wrapper) callers.
         // Check L1 first
         Cache<String, Object> l1 = l1Caches.get(cacheName);
         if (l1 != null) {

--- a/backend/src/test/java/org/fabt/shared/audit/AuditEventTypesTest.java
+++ b/backend/src/test/java/org/fabt/shared/audit/AuditEventTypesTest.java
@@ -97,4 +97,33 @@ class AuditEventTypesTest {
     void escalationPolicyUpdated() {
         assertThat(AuditEventTypes.ESCALATION_POLICY_UPDATED).isEqualTo("ESCALATION_POLICY_UPDATED");
     }
+
+    // ---- multi-tenant-production-readiness Phase C (cache isolation) ----
+
+    @Test
+    @DisplayName("TENANT_CACHE_INVALIDATED has stable value")
+    void tenantCacheInvalidated() {
+        assertThat(AuditEventTypes.TENANT_CACHE_INVALIDATED)
+                .isNotNull()
+                .isNotBlank()
+                .isEqualTo("TENANT_CACHE_INVALIDATED");
+    }
+
+    @Test
+    @DisplayName("CROSS_TENANT_CACHE_READ has stable value (security-evidence audit)")
+    void crossTenantCacheRead() {
+        assertThat(AuditEventTypes.CROSS_TENANT_CACHE_READ)
+                .isNotNull()
+                .isNotBlank()
+                .isEqualTo("CROSS_TENANT_CACHE_READ");
+    }
+
+    @Test
+    @DisplayName("MALFORMED_CACHE_ENTRY has stable value")
+    void malformedCacheEntry() {
+        assertThat(AuditEventTypes.MALFORMED_CACHE_ENTRY)
+                .isNotNull()
+                .isNotBlank()
+                .isEqualTo("MALFORMED_CACHE_ENTRY");
+    }
 }

--- a/backend/src/test/java/org/fabt/shared/cache/CaffeineCacheServiceEvictAllByPrefixTest.java
+++ b/backend/src/test/java/org/fabt/shared/cache/CaffeineCacheServiceEvictAllByPrefixTest.java
@@ -1,0 +1,91 @@
+package org.fabt.shared.cache;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Covers the Phase C {@link CacheService#evictAllByPrefix} API extension on
+ * the Caffeine implementation. See spec
+ * {@code cache-service-evict-all-by-prefix} + design-c D-C-12.
+ */
+@DisplayName("CaffeineCacheService.evictAllByPrefix")
+class CaffeineCacheServiceEvictAllByPrefixTest {
+
+    private CaffeineCacheService cache;
+
+    @BeforeEach
+    void setUp() {
+        // 60s default TTL per application.yml; tests complete well inside that window.
+        cache = new CaffeineCacheService(60L);
+    }
+
+    @Test
+    @DisplayName("Evicts only keys starting with prefix; returns count")
+    void evictsOnlyPrefixedKeys() {
+        Duration ttl = Duration.ofSeconds(30);
+        cache.put("shelter-profile", "tenantA|s1", "valueA1", ttl);
+        cache.put("shelter-profile", "tenantA|s2", "valueA2", ttl);
+        cache.put("shelter-profile", "tenantB|s1", "valueB1", ttl);
+
+        long evicted = cache.evictAllByPrefix("shelter-profile", "tenantA|");
+
+        assertThat(evicted).isEqualTo(2L);
+        assertThat(cache.get("shelter-profile", "tenantA|s1", String.class)).isEmpty();
+        assertThat(cache.get("shelter-profile", "tenantA|s2", String.class)).isEmpty();
+        assertThat(cache.get("shelter-profile", "tenantB|s1", String.class))
+                .contains("valueB1");
+    }
+
+    @Test
+    @DisplayName("Returns 0 on never-written cache name — no NPE")
+    void returnsZeroOnAbsentCache() {
+        long evicted = cache.evictAllByPrefix("never-written", "tenantA|");
+        assertThat(evicted).isEqualTo(0L);
+    }
+
+    @Test
+    @DisplayName("Returns 0 when no key matches prefix")
+    void returnsZeroOnNoMatch() {
+        cache.put("shelter-profile", "tenantB|s1", "valueB1", Duration.ofSeconds(30));
+
+        long evicted = cache.evictAllByPrefix("shelter-profile", "tenantA|");
+
+        assertThat(evicted).isEqualTo(0L);
+        assertThat(cache.get("shelter-profile", "tenantB|s1", String.class))
+                .contains("valueB1");
+    }
+
+    @Test
+    @DisplayName("Empty-prefix evicts all keys (implementation detail; documented)")
+    void emptyPrefixEvictsAll() {
+        cache.put("shelter-profile", "tenantA|s1", "a", Duration.ofSeconds(30));
+        cache.put("shelter-profile", "tenantB|s1", "b", Duration.ofSeconds(30));
+
+        long evicted = cache.evictAllByPrefix("shelter-profile", "");
+
+        assertThat(evicted).isEqualTo(2L);
+        assertThat(cache.get("shelter-profile", "tenantA|s1", String.class)).isEmpty();
+        assertThat(cache.get("shelter-profile", "tenantB|s1", String.class)).isEmpty();
+    }
+
+    @Test
+    @DisplayName("Idempotent — repeated calls after full eviction return 0")
+    void idempotent() {
+        cache.put("shelter-profile", "tenantA|s1", "a", Duration.ofSeconds(30));
+
+        long first = cache.evictAllByPrefix("shelter-profile", "tenantA|");
+        long second = cache.evictAllByPrefix("shelter-profile", "tenantA|");
+
+        assertThat(first).isEqualTo(1L);
+        assertThat(second).isEqualTo(0L);
+
+        Optional<String> miss = cache.get("shelter-profile", "tenantA|s1", String.class);
+        assertThat(miss).isEmpty();
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheAuditRollbackIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheAuditRollbackIntegrationTest.java
@@ -74,7 +74,7 @@ class TenantScopedCacheAuditRollbackIntegrationTest extends BaseIntegrationTest 
                 new TenantScopedValue<>(TENANT_A, "poisoned-value"),
                 Duration.ofSeconds(60));
 
-        long beforeCount = countCrossTenantAudits();
+        long beforeCount = countCrossTenantAuditsAsTenant(TENANT_B);
 
         // Execute the cross-tenant read inside a caller transaction that rolls back.
         // TransactionTemplate is used explicitly so the rollback happens inside a
@@ -94,31 +94,41 @@ class TenantScopedCacheAuditRollbackIntegrationTest extends BaseIntegrationTest 
                 .withMessage("CROSS_TENANT_CACHE_READ");
 
         // The outer tx has rolled back. The DetachedAuditPersister row should still
-        // be present because it ran under PROPAGATION_REQUIRES_NEW.
-        long afterCount = countCrossTenantAudits();
+        // be present because it ran under PROPAGATION_REQUIRES_NEW. Phase B V69 applies
+        // FORCE RLS on audit_events, so the verification read MUST bind app.tenant_id
+        // to TENANT_B (via TenantContext) or the RLS policy filters the row out.
+        long afterCount = countCrossTenantAuditsAsTenant(TENANT_B);
         assertThat(afterCount)
                 .as("CROSS_TENANT_CACHE_READ audit row must survive the caller's rollback")
                 .isEqualTo(beforeCount + 1);
 
         // Verify the row's tenant + action are correct
-        List<AuditEventEntity> rows = findCrossTenantAuditsForTenant(TENANT_B);
+        List<AuditEventEntity> rows = TenantContext.callWithContext(TENANT_B, false,
+                () -> findCrossTenantAuditsForTenant(TENANT_B));
         assertThat(rows).isNotEmpty();
         AuditEventEntity latest = rows.get(rows.size() - 1);
         assertThat(latest.getAction()).isEqualTo(AuditEventTypes.CROSS_TENANT_CACHE_READ);
         assertThat(latest.getTenantId()).isEqualTo(TENANT_B);
     }
 
-    private long countCrossTenantAudits() {
-        Long count = jdbc.queryForObject(
-                "SELECT COUNT(*) FROM audit_events WHERE action = ?",
-                Long.class,
-                AuditEventTypes.CROSS_TENANT_CACHE_READ);
-        return count != null ? count : 0L;
+    /**
+     * Counts CROSS_TENANT_CACHE_READ rows under a bound TenantContext. Phase B V69
+     * FORCE RLS on audit_events filters reads by tenant_id = fabt_current_tenant_id()
+     * — a query run with no TenantContext returns empty because
+     * current_setting('app.tenant_id', true) returns NULL.
+     */
+    private long countCrossTenantAuditsAsTenant(UUID tenantId) {
+        return TenantContext.callWithContext(tenantId, false, () -> {
+            Long count = jdbc.queryForObject(
+                    "SELECT COUNT(*) FROM audit_events WHERE action = ? AND tenant_id = ?",
+                    Long.class,
+                    AuditEventTypes.CROSS_TENANT_CACHE_READ,
+                    tenantId);
+            return count != null ? count : 0L;
+        });
     }
 
     private List<AuditEventEntity> findCrossTenantAuditsForTenant(UUID tenantId) {
-        // Use the owner role so RLS doesn't filter for us; test contexts run under
-        // fabt_test owner which has BYPASSRLS per Phase B setup.
         return jdbc.query(
                 "SELECT id, timestamp, tenant_id, actor_user_id, target_user_id, action, "
                 + "details, ip_address FROM audit_events "

--- a/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheAuditRollbackIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheAuditRollbackIntegrationTest.java
@@ -1,0 +1,136 @@
+package org.fabt.shared.cache;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.shared.audit.AuditEventEntity;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.audit.repository.AuditEventRepository;
+import org.fabt.shared.web.TenantContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+
+/**
+ * Task 4.9g — cross-tenant-read audit row persists across caller rollback.
+ *
+ * <p>Validates design-c D-C-9 + spec {@code tenant-scoped-cache-value-verification}
+ * "Cross-tenant-read audit survives caller rollback" scenario. Marcus Webb's
+ * warroom concern: an attacker who triggers a cross-tenant read inside a
+ * transactional endpoint should NOT be able to erase the audit evidence by
+ * forcing a rollback. The {@link org.fabt.shared.audit.DetachedAuditPersister}
+ * with {@code PROPAGATION_REQUIRES_NEW} cuts the audit row loose from the
+ * caller's transaction fate.
+ *
+ * <p>This is an integration test (not unit) because REQUIRES_NEW semantics
+ * require a real Spring transaction manager + proxy. Extends {@link BaseIntegrationTest}
+ * for Testcontainers Postgres.
+ */
+@DisplayName("TenantScopedCacheService — CROSS_TENANT_CACHE_READ audit survives caller rollback")
+class TenantScopedCacheAuditRollbackIntegrationTest extends BaseIntegrationTest {
+
+    private static final UUID TENANT_A = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000001");
+    private static final UUID TENANT_B = UUID.fromString("aaaaaaaa-0000-0000-0000-000000000002");
+
+    @Autowired
+    private TenantScopedCacheService wrapper;
+
+    @Autowired
+    private CacheService rawCache;
+
+    @Autowired
+    private TransactionTemplate txTemplate;
+
+    @Autowired
+    private AuditEventRepository auditRepository;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Test
+    @DisplayName("4.9g — CROSS_TENANT_CACHE_READ audit row remains committed after caller rollback")
+    void crossTenantAuditSurvivesCallerRollback() {
+        // Ensure the test tenants exist in the tenant table — both CROSS_TENANT_CACHE_READ
+        // audits AND the outer transaction's set_config rely on FKs to real tenants.
+        jdbc.update("INSERT INTO tenant (id, slug, name, state) VALUES (?, ?, ?, 'ACTIVE') "
+                + "ON CONFLICT (id) DO NOTHING",
+                TENANT_A, "audit-rollback-a", "Audit Rollback A");
+        jdbc.update("INSERT INTO tenant (id, slug, name, state) VALUES (?, ?, ?, 'ACTIVE') "
+                + "ON CONFLICT (id) DO NOTHING",
+                TENANT_B, "audit-rollback-b", "Audit Rollback B");
+
+        // Prime the cache directly with a payload stamped tenantA under tenantB's
+        // prefixed key — the write-side-poisoning failure mode that the wrapper's
+        // stamp/verify defends against.
+        String tenantBScopedKey = TENANT_B + "|s1";
+        rawCache.put(CacheNames.SHELTER_PROFILE, tenantBScopedKey,
+                new TenantScopedValue<>(TENANT_A, "poisoned-value"),
+                Duration.ofSeconds(60));
+
+        long beforeCount = countCrossTenantAudits();
+
+        // Execute the cross-tenant read inside a caller transaction that rolls back.
+        // TransactionTemplate is used explicitly so the rollback happens inside a
+        // real Spring transaction (not just a bare uncommitted connection).
+        assertThatIllegalStateException()
+                .isThrownBy(() ->
+                        TenantContext.runWithContext(TENANT_B, false, () ->
+                                txTemplate.executeWithoutResult(status -> {
+                                    // Bind app.tenant_id for the caller's tx (Phase B B11 ordering)
+                                    jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                                            String.class, TENANT_B.toString());
+                                    // Trigger cross-tenant read — wrapper throws, tx rolls back
+                                    wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class);
+                                })
+                        )
+                )
+                .withMessage("CROSS_TENANT_CACHE_READ");
+
+        // The outer tx has rolled back. The DetachedAuditPersister row should still
+        // be present because it ran under PROPAGATION_REQUIRES_NEW.
+        long afterCount = countCrossTenantAudits();
+        assertThat(afterCount)
+                .as("CROSS_TENANT_CACHE_READ audit row must survive the caller's rollback")
+                .isEqualTo(beforeCount + 1);
+
+        // Verify the row's tenant + action are correct
+        List<AuditEventEntity> rows = findCrossTenantAuditsForTenant(TENANT_B);
+        assertThat(rows).isNotEmpty();
+        AuditEventEntity latest = rows.get(rows.size() - 1);
+        assertThat(latest.getAction()).isEqualTo(AuditEventTypes.CROSS_TENANT_CACHE_READ);
+        assertThat(latest.getTenantId()).isEqualTo(TENANT_B);
+    }
+
+    private long countCrossTenantAudits() {
+        Long count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM audit_events WHERE action = ?",
+                Long.class,
+                AuditEventTypes.CROSS_TENANT_CACHE_READ);
+        return count != null ? count : 0L;
+    }
+
+    private List<AuditEventEntity> findCrossTenantAuditsForTenant(UUID tenantId) {
+        // Use the owner role so RLS doesn't filter for us; test contexts run under
+        // fabt_test owner which has BYPASSRLS per Phase B setup.
+        return jdbc.query(
+                "SELECT id, timestamp, tenant_id, actor_user_id, target_user_id, action, "
+                + "details, ip_address FROM audit_events "
+                + "WHERE tenant_id = ? AND action = ? ORDER BY timestamp",
+                (rs, rowNum) -> {
+                    AuditEventEntity e = new AuditEventEntity();
+                    e.setId((UUID) rs.getObject("id"));
+                    e.setTimestamp(rs.getTimestamp("timestamp").toInstant());
+                    e.setTenantId((UUID) rs.getObject("tenant_id"));
+                    e.setAction(rs.getString("action"));
+                    return e;
+                },
+                tenantId, AuditEventTypes.CROSS_TENANT_CACHE_READ);
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheServiceUnitTest.java
@@ -1,0 +1,394 @@
+package org.fabt.shared.cache;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.audit.DetachedAuditPersister;
+import org.fabt.shared.web.TenantContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+import static org.assertj.core.api.Assertions.assertThatIllegalStateException;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link TenantScopedCacheService}.
+ *
+ * <p>Covers Phase C tasks 4.8 (missing context), 4.9 (prefix isolation),
+ * 4.9b (invalidateTenant isolation), 4.9c (cross-tenant poisoning),
+ * 4.9d (malformed entry), 4.9e (idempotency), 4.9f (post-restart empty-
+ * registry safety), 4.9h (null-value rejection). Task 4.9g is an
+ * integration test covered separately.
+ */
+@DisplayName("TenantScopedCacheService")
+class TenantScopedCacheServiceUnitTest {
+
+    private static final UUID TENANT_A = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID TENANT_B = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    private CacheService delegate;
+    private ApplicationEventPublisher eventPublisher;
+    private DetachedAuditPersister detachedAuditPersister;
+    private MeterRegistry meterRegistry;
+    private TenantScopedCacheService wrapper;
+
+    @BeforeEach
+    void setUp() {
+        delegate = new CaffeineCacheService(60L);
+        eventPublisher = mock(ApplicationEventPublisher.class);
+        detachedAuditPersister = mock(DetachedAuditPersister.class);
+        meterRegistry = new SimpleMeterRegistry();
+
+        @SuppressWarnings("unchecked")
+        ObjectProvider<MeterRegistry> provider = mock(ObjectProvider.class);
+        when(provider.getIfAvailable()).thenReturn(meterRegistry);
+
+        wrapper = new TenantScopedCacheService(delegate, eventPublisher,
+                detachedAuditPersister, provider);
+        wrapper.seedRegisteredCacheNames();
+    }
+
+    // ---- Task 4.9f — post-restart empty-registry safety (also: eager seed) ----
+
+    @Test
+    @DisplayName("4.9f — eager seed populates registry from CacheNames, non-empty")
+    void eagerSeedPopulatesRegistry() {
+        assertThat(wrapper.registeredCacheNamesSnapshot())
+                .isNotEmpty()
+                .contains(CacheNames.SHELTER_PROFILE)
+                .contains(CacheNames.SHELTER_LIST)
+                .contains(CacheNames.SHELTER_AVAILABILITY)
+                .contains(CacheNames.ANALYTICS_UTILIZATION);
+    }
+
+    @Test
+    @DisplayName("4.9f — invalidateTenant on never-written tenant iterates all seeded caches + returns zero per cache")
+    void invalidateTenantOnNeverWrittenTenantIteratesAllCaches() {
+        // Fresh wrapper, no puts yet. invalidateTenant must NOT NPE and must iterate.
+        wrapper.invalidateTenant(TENANT_A);
+
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        AuditEventRecord audit = captor.getValue();
+
+        assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_CACHE_INVALIDATED);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> details = (java.util.Map<String, Object>) audit.details();
+        assertThat(details.get("tenantId")).isEqualTo(TENANT_A.toString());
+        assertThat(details.get("totalEvicted")).isEqualTo(0L);
+        // per-cache counts map includes every seeded cache name with 0 evictions
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Long> perCache = (java.util.Map<String, Long>) details.get("perCacheEvictionCounts");
+        assertThat(perCache).isNotEmpty();
+        assertThat(perCache.values()).allMatch(count -> count == 0L);
+    }
+
+    // ---- Task 4.8 — missing TenantContext fails fast on get + put ----
+
+    @Nested
+    @DisplayName("4.8 — missing TenantContext")
+    class MissingContext {
+
+        @Test
+        @DisplayName("get throws TENANT_CONTEXT_UNBOUND with no UUID in message")
+        void getThrowsWithoutContext() {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> wrapper.get(CacheNames.SHELTER_PROFILE, "k", String.class))
+                    .withMessage("TENANT_CONTEXT_UNBOUND");
+        }
+
+        @Test
+        @DisplayName("put throws TENANT_CONTEXT_UNBOUND with no UUID in message")
+        void putThrowsWithoutContext() {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> wrapper.put(CacheNames.SHELTER_PROFILE, "k", "v", Duration.ofSeconds(10)))
+                    .withMessage("TENANT_CONTEXT_UNBOUND");
+        }
+
+        @Test
+        @DisplayName("evict throws TENANT_CONTEXT_UNBOUND")
+        void evictThrowsWithoutContext() {
+            assertThatIllegalStateException()
+                    .isThrownBy(() -> wrapper.evict(CacheNames.SHELTER_PROFILE, "k"))
+                    .withMessage("TENANT_CONTEXT_UNBOUND");
+        }
+    }
+
+    // ---- Task 4.9 — key prefix + hit/miss semantics ----
+
+    @Test
+    @DisplayName("4.9 — tenant A put + tenant A get returns value; tenant B get returns miss")
+    void prefixIsolatesTenants() {
+        TenantContext.runWithContext(TENANT_A, false, () ->
+                wrapper.put(CacheNames.SHELTER_PROFILE, "s1", "valueA", Duration.ofSeconds(30))
+        );
+        Optional<String> aRead = TenantContext.callWithContext(TENANT_A, false, () ->
+                wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+        );
+        Optional<String> bRead = TenantContext.callWithContext(TENANT_B, false, () ->
+                wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+        );
+
+        assertThat(aRead).contains("valueA");
+        assertThat(bRead).isEmpty();
+    }
+
+    @Test
+    @DisplayName("4.9 — pipe separator produces <tenantId>|<key> effective key")
+    void usesPipeSeparator() {
+        TenantContext.runWithContext(TENANT_A, false, () ->
+                wrapper.put(CacheNames.SHELTER_PROFILE, "s1", "v", Duration.ofSeconds(30))
+        );
+        // Verify underlying key is <tenantId>|s1
+        Optional<TenantScopedValue> raw = delegate.get(CacheNames.SHELTER_PROFILE,
+                TENANT_A + "|s1", TenantScopedValue.class);
+        assertThat(raw).isPresent();
+        assertThat(raw.get().tenantId()).isEqualTo(TENANT_A);
+        assertThat(raw.get().value()).isEqualTo("v");
+    }
+
+    @Test
+    @DisplayName("4.9 — hit counter increments; miss counter increments")
+    void countersIncrement() {
+        TenantContext.runWithContext(TENANT_A, false, () -> {
+            wrapper.put(CacheNames.SHELTER_PROFILE, "s1", "v", Duration.ofSeconds(30));
+            wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class);
+            wrapper.get(CacheNames.SHELTER_PROFILE, "does-not-exist", String.class);
+        });
+
+        double hits = meterRegistry.counter("fabt.cache.get",
+                "cache", CacheNames.SHELTER_PROFILE,
+                "tenant", TENANT_A.toString(),
+                "result", "hit").count();
+        double misses = meterRegistry.counter("fabt.cache.get",
+                "cache", CacheNames.SHELTER_PROFILE,
+                "tenant", TENANT_A.toString(),
+                "result", "miss").count();
+        double puts = meterRegistry.counter("fabt.cache.put",
+                "cache", CacheNames.SHELTER_PROFILE,
+                "tenant", TENANT_A.toString()).count();
+
+        assertThat(hits).isEqualTo(1.0);
+        assertThat(misses).isEqualTo(1.0);
+        assertThat(puts).isEqualTo(1.0);
+    }
+
+    // ---- Task 4.9b — invalidateTenant scope ----
+
+    @Test
+    @DisplayName("4.9b — invalidateTenant(A) evicts A across all caches; B entries survive")
+    void invalidateTenantScope() {
+        TenantContext.runWithContext(TENANT_A, false, () -> {
+            wrapper.put(CacheNames.SHELTER_PROFILE, "s1", "va1", Duration.ofSeconds(30));
+            wrapper.put(CacheNames.SHELTER_LIST, "list", "la", Duration.ofSeconds(30));
+        });
+        TenantContext.runWithContext(TENANT_B, false, () -> {
+            wrapper.put(CacheNames.SHELTER_PROFILE, "s1", "vb1", Duration.ofSeconds(30));
+            wrapper.put(CacheNames.SHELTER_LIST, "list", "lb", Duration.ofSeconds(30));
+        });
+
+        wrapper.invalidateTenant(TENANT_A);
+
+        Optional<String> aMiss = TenantContext.callWithContext(TENANT_A, false, () ->
+                wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+        );
+        Optional<String> bHit = TenantContext.callWithContext(TENANT_B, false, () ->
+                wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+        );
+
+        assertThat(aMiss).isEmpty();
+        assertThat(bHit).contains("vb1");
+    }
+
+    @Test
+    @DisplayName("4.9b — invalidateTenant emits audit row with per-cache eviction counts")
+    void invalidateTenantEmitsAudit() {
+        TenantContext.runWithContext(TENANT_A, false, () -> {
+            wrapper.put(CacheNames.SHELTER_PROFILE, "s1", "v", Duration.ofSeconds(30));
+            wrapper.put(CacheNames.SHELTER_PROFILE, "s2", "v", Duration.ofSeconds(30));
+            wrapper.put(CacheNames.SHELTER_LIST, "list", "v", Duration.ofSeconds(30));
+        });
+        Mockito.clearInvocations(eventPublisher);
+
+        wrapper.invalidateTenant(TENANT_A);
+
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        AuditEventRecord audit = captor.getValue();
+
+        assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_CACHE_INVALIDATED);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Object> details = (java.util.Map<String, Object>) audit.details();
+        assertThat(details.get("totalEvicted")).isEqualTo(3L);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, Long> perCache = (java.util.Map<String, Long>) details.get("perCacheEvictionCounts");
+        assertThat(perCache.get(CacheNames.SHELTER_PROFILE)).isEqualTo(2L);
+        assertThat(perCache.get(CacheNames.SHELTER_LIST)).isEqualTo(1L);
+    }
+
+    // ---- Task 4.9c — cross-tenant cache-poisoning regression (stamp/verify defence) ----
+
+    @Test
+    @DisplayName("4.9c — cross-tenant read throws CROSS_TENANT_CACHE_READ + emits DetachedAuditPersister call")
+    void crossTenantReadThrows() {
+        // Write an envelope stamped with TENANT_A directly into the raw cache
+        // under TENANT_B's prefixed key (simulates a wrapper-bypass write with
+        // wrong context — the #1 2025-2026 cache-leak pattern).
+        String tenantBKey = TENANT_B + "|s1";
+        delegate.put(CacheNames.SHELTER_PROFILE, tenantBKey,
+                new TenantScopedValue<>(TENANT_A, "poisoned-value"),
+                Duration.ofSeconds(30));
+
+        assertThatIllegalStateException()
+                .isThrownBy(() ->
+                        TenantContext.callWithContext(TENANT_B, false, () ->
+                                wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+                        )
+                )
+                .withMessage("CROSS_TENANT_CACHE_READ");
+
+        // cross_tenant_reject counter increments
+        double rejected = meterRegistry.counter("fabt.cache.get",
+                "cache", CacheNames.SHELTER_PROFILE,
+                "tenant", TENANT_B.toString(),
+                "result", "cross_tenant_reject").count();
+        assertThat(rejected).isEqualTo(1.0);
+
+        // DetachedAuditPersister called with CROSS_TENANT_CACHE_READ
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(detachedAuditPersister).persistDetached(eq(TENANT_B), captor.capture());
+        assertThat(captor.getValue().action()).isEqualTo(AuditEventTypes.CROSS_TENANT_CACHE_READ);
+
+        // No event-bus audit for this security-evidence event
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    @DisplayName("4.9c — exception message carries ONLY action tag, no UUIDs (no information disclosure)")
+    void crossTenantExceptionMessageSanitised() {
+        String tenantBKey = TENANT_B + "|s1";
+        delegate.put(CacheNames.SHELTER_PROFILE, tenantBKey,
+                new TenantScopedValue<>(TENANT_A, "v"), Duration.ofSeconds(30));
+
+        try {
+            TenantContext.runWithContext(TENANT_B, false, () ->
+                    wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+            );
+        } catch (IllegalStateException e) {
+            assertThat(e.getMessage()).isEqualTo("CROSS_TENANT_CACHE_READ");
+            assertThat(e.getMessage()).doesNotContain(TENANT_A.toString());
+            assertThat(e.getMessage()).doesNotContain(TENANT_B.toString());
+            return;
+        }
+        throw new AssertionError("Expected IllegalStateException was not thrown");
+    }
+
+    // ---- Task 4.9d — malformed entry defence ----
+
+    @Test
+    @DisplayName("4.9d — raw non-envelope payload in cache triggers MALFORMED_CACHE_ENTRY")
+    void malformedEntryThrows() {
+        // Caller bypasses the wrapper and writes a raw String payload directly
+        // (simulates a pre-migration call site not yet converted by task 4.b).
+        String tenantAKey = TENANT_A + "|s1";
+        delegate.put(CacheNames.SHELTER_PROFILE, tenantAKey,
+                "raw-string-not-envelope", Duration.ofSeconds(30));
+
+        assertThatIllegalStateException()
+                .isThrownBy(() ->
+                        TenantContext.callWithContext(TENANT_A, false, () ->
+                                wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+                        )
+                )
+                .withMessage("MALFORMED_CACHE_ENTRY");
+
+        double malformed = meterRegistry.counter("fabt.cache.get",
+                "cache", CacheNames.SHELTER_PROFILE,
+                "tenant", TENANT_A.toString(),
+                "result", "malformed_entry").count();
+        assertThat(malformed).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("4.9d — envelope's inner value of wrong type triggers MALFORMED_CACHE_ENTRY")
+    void envelopeWrongInnerTypeThrows() {
+        // Envelope is valid but its inner value is an Integer; caller asks for String.
+        String tenantAKey = TENANT_A + "|s1";
+        delegate.put(CacheNames.SHELTER_PROFILE, tenantAKey,
+                new TenantScopedValue<>(TENANT_A, Integer.valueOf(42)),
+                Duration.ofSeconds(30));
+
+        assertThatIllegalStateException()
+                .isThrownBy(() ->
+                        TenantContext.callWithContext(TENANT_A, false, () ->
+                                wrapper.get(CacheNames.SHELTER_PROFILE, "s1", String.class)
+                        )
+                )
+                .withMessage("MALFORMED_CACHE_ENTRY");
+    }
+
+    // ---- Task 4.9e — invalidateTenant idempotency ----
+
+    @Test
+    @DisplayName("4.9e — invalidateTenant is idempotent: second call returns 0")
+    void invalidateTenantIdempotent() {
+        TenantContext.runWithContext(TENANT_A, false, () -> {
+            wrapper.put(CacheNames.SHELTER_PROFILE, "s1", "v", Duration.ofSeconds(30));
+        });
+
+        wrapper.invalidateTenant(TENANT_A);
+        wrapper.invalidateTenant(TENANT_A);
+
+        // Two audit rows emitted (one per call)
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(eventPublisher, times(2)).publishEvent(captor.capture());
+
+        List<AuditEventRecord> rows = captor.getAllValues();
+        @SuppressWarnings("unchecked")
+        long firstTotal = ((Number) ((java.util.Map<String, Object>) rows.get(0).details())
+                .get("totalEvicted")).longValue();
+        @SuppressWarnings("unchecked")
+        long secondTotal = ((Number) ((java.util.Map<String, Object>) rows.get(1).details())
+                .get("totalEvicted")).longValue();
+
+        assertThat(firstTotal).isEqualTo(1L);
+        assertThat(secondTotal).isEqualTo(0L);
+    }
+
+    // ---- Task 4.9h — defensive null-value rejection ----
+
+    @Test
+    @DisplayName("4.9h — put(null) throws IllegalArgumentException immediately; no cache write")
+    void nullValueRejected() {
+        TenantContext.runWithContext(TENANT_A, false, () -> {
+            assertThatIllegalArgumentException()
+                    .isThrownBy(() -> wrapper.put(CacheNames.SHELTER_PROFILE, "s1", null,
+                            Duration.ofSeconds(30)));
+        });
+
+        // No raw entry written
+        Optional<TenantScopedValue> raw = delegate.get(CacheNames.SHELTER_PROFILE,
+                TENANT_A + "|s1", TenantScopedValue.class);
+        assertThat(raw).isEmpty();
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/shared/cache/TenantScopedCacheServiceUnitTest.java
@@ -4,6 +4,8 @@ import java.time.Duration;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicReference;
 
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
@@ -56,6 +58,9 @@ class TenantScopedCacheServiceUnitTest {
     void setUp() {
         delegate = new CaffeineCacheService(60L);
         eventPublisher = mock(ApplicationEventPublisher.class);
+        // DetachedAuditPersister is mocked at the TenantScopedCacheService boundary
+        // so the wrapper tests don't need real DB or tx manager wiring. The 4.9g IT
+        // exercises the real persister + REQUIRES_NEW rollback behaviour.
         detachedAuditPersister = mock(DetachedAuditPersister.class);
         meterRegistry = new SimpleMeterRegistry();
 
@@ -191,6 +196,68 @@ class TenantScopedCacheServiceUnitTest {
         assertThat(hits).isEqualTo(1.0);
         assertThat(misses).isEqualTo(1.0);
         assertThat(puts).isEqualTo(1.0);
+    }
+
+    // ---- Task 4.9 extension — concurrent puts from two tenants ----
+
+    @Test
+    @DisplayName("4.9 — concurrent puts from two tenants persist independently (no race)")
+    void concurrentPutsSurvive() throws InterruptedException {
+        int iterations = 50;
+        CountDownLatch startGate = new CountDownLatch(1);
+        CountDownLatch doneGate = new CountDownLatch(2);
+        AtomicReference<Throwable> caught = new AtomicReference<>();
+
+        Runnable writerA = () -> {
+            try {
+                startGate.await();
+                TenantContext.runWithContext(TENANT_A, false, () -> {
+                    for (int i = 0; i < iterations; i++) {
+                        wrapper.put(CacheNames.SHELTER_PROFILE, "k" + i, "A-" + i,
+                                Duration.ofSeconds(30));
+                    }
+                });
+            } catch (Throwable t) {
+                caught.compareAndSet(null, t);
+            } finally {
+                doneGate.countDown();
+            }
+        };
+        Runnable writerB = () -> {
+            try {
+                startGate.await();
+                TenantContext.runWithContext(TENANT_B, false, () -> {
+                    for (int i = 0; i < iterations; i++) {
+                        wrapper.put(CacheNames.SHELTER_PROFILE, "k" + i, "B-" + i,
+                                Duration.ofSeconds(30));
+                    }
+                });
+            } catch (Throwable t) {
+                caught.compareAndSet(null, t);
+            } finally {
+                doneGate.countDown();
+            }
+        };
+
+        Thread t1 = Thread.ofVirtual().start(writerA);
+        Thread t2 = Thread.ofVirtual().start(writerB);
+        startGate.countDown();
+        doneGate.await();
+
+        assertThat(caught.get()).isNull();
+
+        // Both tenants' envelopes survive under their correct prefix — zero cross-contamination
+        for (int i = 0; i < iterations; i++) {
+            final int idx = i;
+            String aVal = TenantContext.callWithContext(TENANT_A, false, () ->
+                    wrapper.get(CacheNames.SHELTER_PROFILE, "k" + idx, String.class).orElse(null)
+            );
+            String bVal = TenantContext.callWithContext(TENANT_B, false, () ->
+                    wrapper.get(CacheNames.SHELTER_PROFILE, "k" + idx, String.class).orElse(null)
+            );
+            assertThat(aVal).as("tenant A read for k%d", idx).isEqualTo("A-" + idx);
+            assertThat(bVal).as("tenant B read for k%d", idx).isEqualTo("B-" + idx);
+        }
     }
 
     // ---- Task 4.9b — invalidateTenant scope ----


### PR DESCRIPTION
## Summary

First real code of Phase C (cache isolation) in `multi-tenant-production-readiness`. Introduces `TenantScopedCacheService` — a Spring-bean decorator over the existing `CacheService` that enforces tenant isolation at four layers:

1. **Key prefix** with `|` separator from `TenantContext.getTenantId()` (missing context → `TENANT_CONTEXT_UNBOUND` ISE).
2. **Value stamp-and-verify** via `TenantScopedValue<T>(UUID tenantId, T value)` envelope. On write, stamped with the caller's tenant; on read, mismatch throws `CROSS_TENANT_CACHE_READ` — defends the write side (prefix alone defends read side only).
3. **`invalidateTenant(UUID)`** iterates an eager-seeded registry (populated at `@PostConstruct` from `CacheNames` reflection — not lazy on first put, which would silently no-op on fresh pods). Idempotent. Emits `TENANT_CACHE_INVALIDATED` audit row with per-cache eviction counts. Backed by new `CacheService.evictAllByPrefix` API (Caffeine keyset filter; Redis L2 TODO per ADR shape 2/3 documents `SCAN MATCH + UNLINK`).
4. **Observability** via `fabt.cache.get{cache,tenant,result}` + `fabt.cache.put{cache,tenant}` Micrometer counters (result ∈ `hit|miss|cross_tenant_reject|malformed_entry`). Counter references cached per tag-combination to avoid hot-path `MeterRegistry` walks.

## Security-evidence audit path

`CROSS_TENANT_CACHE_READ` rows are persisted via new `DetachedAuditPersister` under `@Transactional(propagation = REQUIRES_NEW)` so the audit survives attacker-triggered caller rollback. An attacker who triggers a cross-tenant read inside a transactional endpoint and relies on the subsequent ISE to roll back would otherwise erase the only audit signal proving the attempt happened (Marcus Webb's warroom concern; design-c D-C-9).

Normal audit events (`TENANT_CACHE_INVALIDATED`, `MALFORMED_CACHE_ENTRY`) use the existing event-bus path — their rollback-coupling is correct.

Exception messages carry only short action tags — never UUIDs, keys, or payload fragments. Prevents information disclosure through `GlobalExceptionHandler` (OWASP ASVS 5.0 §7.4.1).

## Related OpenSpec artifacts (already merged on `main`)

- Spec: `openspec/changes/multi-tenant-production-readiness/specs/tenant-scoped-cache/spec.md` (3 new requirements: `tenant-scoped-cache-value-verification`, `cache-service-evict-all-by-prefix`, `tenant-scoped-cache-observability`)
- Design decisions D-C-8 through D-C-13: `openspec/changes/multi-tenant-production-readiness/design-c-cache-isolation.md`
- Redis posture ADR: `docs/architecture/redis-pooling-adr.md`
- Task breakdown ticked: `tasks.md` 4.0 / 4.0b / 4.1 / 4.1a / 4.1b / 4.1c / 4.8 / 4.9 / 4.9b-f / 4.9h ✅; 4.9g IT green

## Commits

- `c4e9541` — initial wrapper + 32 unit tests (all green on first mvn pass after a CCE round-trip: `TenantScopedValue.class` cast was deferring to wrapper's variable assignment → moved to `Object.class` + `instanceof` pattern match)
- `173138d` — post-warroom code review polish: Counter caching (Sam), `fabt.audit.detached_failed.count` metric (Marcus + Jordan), concurrent-puts unit test (Riley), 4.9g IT green (Riley's FORCE-RLS read-side filtering), delegate comments (Alex)

## Test plan

- [x] `TenantScopedCacheServiceUnitTest` — 17 tests covering tasks 4.8, 4.9, 4.9b, 4.9c, 4.9d, 4.9e, 4.9f, 4.9h + concurrent-puts
- [x] `CaffeineCacheServiceEvictAllByPrefixTest` — 5 tests on the new `CacheService` API
- [x] `AuditEventTypesTest` — 3 new pins for `TENANT_CACHE_INVALIDATED` / `CROSS_TENANT_CACHE_READ` / `MALFORMED_CACHE_ENTRY`
- [x] `TenantScopedCacheAuditRollbackIntegrationTest` — 4.9g: cross-tenant audit row survives caller rollback against Testcontainers Postgres with Phase B V69 FORCE RLS active (REQUIRES_NEW proven)
- [x] Full `TenantScopedCacheService*` + `CaffeineCacheServiceEvictAll*` + `AuditEventTypes*` suite: **34/34 green, 0 failures**

## Not in this PR (next Phase C tasks)

- **4.4** EscalationPolicyService split (before Family C ArchUnit rule lands so rule is green on first run)
- **4.2** Family C basic rule
- **4.3** Family C extended scope (`*.api` + `*.security` + `*.auth.*`)
- **4.5** PR template + CODEOWNERS gate
- **4.6** Reflection-driven bleed test
- **4.7** Negative-cache guardrail
- **4.b** Migrate the 7 existing manually-prefixed call sites (`BedSearchService`, `AvailabilityService`, `AnalyticsService`) — must strip caller-side `tenantId + ":"` prefix in the same commit to avoid `<tenant>|<tenant>:key` double-prefixing

🤖 Generated with [Claude Code](https://claude.com/claude-code)