### PR TITLE
Phase C task 4.4 — EscalationPolicyService split + findByTenantAndId

### DIFF
--- a/backend/src/main/java/org/fabt/notification/service/EscalationPolicyService.java
+++ b/backend/src/main/java/org/fabt/notification/service/EscalationPolicyService.java
@@ -2,7 +2,10 @@ package org.fabt.notification.service;
 
 import java.time.Duration;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -11,7 +14,11 @@ import java.util.regex.Pattern;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
 
+import io.micrometer.core.instrument.Counter;
 import io.micrometer.core.instrument.MeterRegistry;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.audit.DetachedAuditPersister;
 import org.fabt.shared.security.TenantUnscoped;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 
@@ -91,6 +98,8 @@ public class EscalationPolicyService {
     private static final Pattern THRESHOLD_ID_PATTERN = Pattern.compile("^[a-z0-9_]{1,32}$");
 
     private final EscalationPolicyRepository repository;
+    private final DetachedAuditPersister detachedAuditPersister;
+    private final MeterRegistry meterRegistry;
 
     /**
      * Cache for findById lookups (batch job hot path).
@@ -122,17 +131,69 @@ public class EscalationPolicyService {
             .build();
 
     /**
-     * Constructor. Binds the two Caffeine caches to Micrometer via
+     * Cache for request-path lookups by {@code (tenantId, policyId)} — introduced
+     * in Phase C task 4.4 per design-c D-C-2. The caller passes their current
+     * {@code TenantContext.getTenantId()} explicitly; the service verifies on
+     * miss that the stored policy's {@code tenantId} matches (or is the
+     * platform-default NULL) and rejects otherwise. Prevents the
+     * cross-tenant-policy-leak class that would exist if a request path
+     * called {@link #findByIdForBatch} (which is intentionally {@code @TenantUnscoped}).
+     *
+     * <p><b>TTL shape matches {@link #policyById}</b> ({@code expireAfterAccess(10 min)})
+     * because {@code (tenantId, policyId)} identifies an immutable version —
+     * {@code expireAfterWrite} would be semantically wrong (the entry never
+     * goes stale, only cold). This is the same reasoning that applies to
+     * {@link #policyById}. Note that {@link #currentPolicyByTenant} uses
+     * {@code expireAfterWrite} because its key {@code (tenantId, eventType)}
+     * points to <em>whatever is current</em> — which IS mutated by
+     * {@link #update(String, List, UUID)}. (D-4.4-5 warroom resolution.)</p>
+     *
+     * <p><b>Platform-default N× duplication is intentional.</b> If N tenants
+     * each look up platform-default policy {@code p}, we cache {@code (A, p)},
+     * {@code (B, p)}, {@code (C, p)}, ... separately. N × ~500-byte records is
+     * trivial memory at our tenant scale; the complexity of a shared
+     * {@code (null, p)} fallback cache lookup is not worth the savings
+     * (D-4.4-1 warroom resolution).</p>
+     *
+     * <p><b>TODO(task 4.b)</b>: first request-path caller migration. No
+     * production code path currently invokes {@link #findByTenantAndId} — it
+     * exists today to (a) direct offenders of the Family C ArchUnit rule
+     * (task 4.2) away from {@link #findByIdForBatch}, and (b) land the
+     * on-read tenant-verification + observability contract with testing
+     * discipline before the first real caller. When task 4.b migrates a
+     * caller, remove this TODO note.</p>
+     */
+    private final Cache<PolicyKey, EscalationPolicy> policyByTenantAndId = Caffeine.newBuilder()
+            .maximumSize(500)
+            .expireAfterAccess(Duration.ofMinutes(10))
+            .recordStats()
+            .build();
+
+    /**
+     * Constructor. Binds the three Caffeine caches to Micrometer via
      * {@link CaffeineCacheMetrics#monitor} using fabt-prefixed cache names.
      * The emitted metric family is {@code cache.gets{cache="fabt.escalation.policy.by-id",result="hit|miss"}}
-     * and analogous for {@code current-by-tenant} — hit rate is a downstream
-     * Grafana/PromQL formula, not a directly emitted metric (T-53,
-     * Alex Chen review 2026-04-12).
+     * and analogous for {@code current-by-tenant} + {@code by-tenant-and-id} —
+     * hit rate is a downstream Grafana/PromQL formula, not a directly emitted
+     * metric (T-53, Alex Chen review 2026-04-12).
+     *
+     * <p>The Phase C task 4.4 addition of {@code policyByTenantAndId} (and its
+     * {@link DetachedAuditPersister} dependency for cross-tenant-reject audit
+     * rows) leaves {@link #findByIdForBatch} untouched — the batch path's
+     * unscoped access is reserved for {@code @Scheduled} callers via the
+     * {@code EscalationPolicyBatchOnlyArchitectureTest} ArchUnit rule.</p>
      */
-    public EscalationPolicyService(EscalationPolicyRepository repository, MeterRegistry meterRegistry) {
+    public EscalationPolicyService(EscalationPolicyRepository repository,
+                                    DetachedAuditPersister detachedAuditPersister,
+                                    MeterRegistry meterRegistry) {
         this.repository = repository;
+        this.detachedAuditPersister = detachedAuditPersister;
+        this.meterRegistry = meterRegistry;
         CaffeineCacheMetrics.monitor(meterRegistry, policyById, "fabt.escalation.policy.by-id");
         CaffeineCacheMetrics.monitor(meterRegistry, currentPolicyByTenant, "fabt.escalation.policy.current-by-tenant");
+        CaffeineCacheMetrics.monitor(meterRegistry, policyByTenantAndId, "fabt.escalation.policy.by-tenant-and-id");
+        log.info("EscalationPolicyService caches initialised: policyById (size=500, access=10m), "
+                + "currentPolicyByTenant (size=200, write=5m), policyByTenantAndId (size=500, access=10m)");
     }
 
     /**
@@ -157,6 +218,65 @@ public class EscalationPolicyService {
         Optional<EscalationPolicy> loaded = repository.findById(id);
         loaded.ifPresent(p -> policyById.put(id, p));
         return loaded;
+    }
+
+    /**
+     * Tenant-scoped policy lookup by policy id — the request-path counterpart
+     * to {@link #findByIdForBatch}. Introduced in Phase C task 4.4 per design-c
+     * D-C-2 and spec {@code escalation-policy-service-cache-split}.
+     *
+     * <p>Both arguments MUST be non-null — a null {@code tenantId} or
+     * {@code policyId} from a request path is always a bug (TenantContext
+     * unbound, missing route parameter, etc.) and should surface as
+     * {@link NullPointerException} rather than a silent empty per
+     * {@code feedback_never_skip_silently.md}. The batch-only
+     * {@link #findByIdForBatch} tolerates null-id because "missing policy row"
+     * is legitimately expected when a snapshotted policy was deleted — that
+     * exemption does NOT apply here. (D-4.4-4 warroom resolution.)</p>
+     *
+     * <p>On cache miss, the method loads via
+     * {@link EscalationPolicyRepository#findById} and verifies the returned
+     * policy's {@code tenantId} either matches the caller's {@code tenantId}
+     * OR is {@code null} (platform-default row, accessible from any tenant
+     * by design). A mismatch (cross-tenant reach) returns
+     * {@link Optional#empty()} — matching the D3 no-existence-leak posture
+     * applied elsewhere in FABT (cross-tenant resource lookups return 404,
+     * not 403, so an attacker cannot confirm existence) — AND emits a
+     * {@link AuditEventTypes#CROSS_TENANT_POLICY_READ} audit row via
+     * {@link DetachedAuditPersister} (REQUIRES_NEW) so the security signal
+     * survives attacker-triggered caller rollback, mirroring
+     * {@code TenantScopedCacheService.get}'s treatment of
+     * {@code CROSS_TENANT_CACHE_READ} (Marcus warroom lens, design-c D-C-9).
+     * The {@code fabt.cache.get{cache="escalation.policy.by-tenant-and-id",result="cross_tenant_reject"}}
+     * Micrometer counter is also incremented.</p>
+     *
+     * <p>No {@code @TenantUnscoped} annotation — this method IS tenant-scoped
+     * by on-read verification; it is the safe alternative to
+     * {@link #findByIdForBatch} for non-batch callers.</p>
+     *
+     * @throws NullPointerException if either argument is null
+     */
+    public Optional<EscalationPolicy> findByTenantAndId(UUID tenantId, UUID policyId) {
+        Objects.requireNonNull(tenantId, "tenantId");
+        Objects.requireNonNull(policyId, "policyId");
+        PolicyKey key = new PolicyKey(tenantId, policyId);
+        EscalationPolicy cached = policyByTenantAndId.getIfPresent(key);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+        Optional<EscalationPolicy> loaded = repository.findById(policyId);
+        if (loaded.isEmpty()) {
+            return Optional.empty();
+        }
+        EscalationPolicy p = loaded.get();
+        if (p.tenantId() == null || p.tenantId().equals(tenantId)) {
+            policyByTenantAndId.put(key, p);
+            return Optional.of(p);
+        }
+        // Cross-tenant reach: emit security-evidence audit + reject counter +
+        // return empty (no existence leak).
+        emitCrossTenantPolicyReject(tenantId, policyId, p.tenantId());
+        return Optional.empty();
     }
 
     /**
@@ -190,6 +310,9 @@ public class EscalationPolicyService {
         platformDefault.ifPresent(p -> {
             currentPolicyByTenant.put(key, p);
             currentPolicyByTenant.put(new CurrentKey(null, eventType), p);
+            // Batch pre-warm — request paths use findByTenantAndId (task 4.4) which
+            // has its own cache; this warm exists only to help findByIdForBatch
+            // resolve the same id later in the scheduled job cycle.
             policyById.put(p.id(), p);
         });
         return platformDefault;
@@ -326,8 +449,50 @@ public class EscalationPolicyService {
     public void clearCaches_testOnly() {
         currentPolicyByTenant.invalidateAll();
         policyById.invalidateAll();
+        policyByTenantAndId.invalidateAll();
+    }
+
+    /**
+     * Emit the CROSS_TENANT_POLICY_READ security-evidence audit row + counter.
+     * Called from {@link #findByTenantAndId} when the stored policy's tenantId
+     * does not match the caller's AND the policy is not a platform-default.
+     *
+     * <p>Uses {@link DetachedAuditPersister} so the audit row commits under
+     * {@code PROPAGATION_REQUIRES_NEW} — survives attacker-triggered caller
+     * rollback. Same mechanism as
+     * {@code TenantScopedCacheService.get → CROSS_TENANT_CACHE_READ}.</p>
+     */
+    private void emitCrossTenantPolicyReject(UUID readerTenant, UUID policyId, UUID observedTenant) {
+        log.error("CROSS_TENANT_POLICY_READ readerTenant={} policyId={} observedTenant={}",
+                readerTenant, policyId, observedTenant);
+        if (meterRegistry != null) {
+            Counter.builder("fabt.cache.get")
+                    .tag("cache", "fabt.escalation.policy.by-tenant-and-id")
+                    .tag("tenant", readerTenant.toString())
+                    .tag("result", "cross_tenant_reject")
+                    .register(meterRegistry)
+                    .increment();
+        }
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("policyId", policyId.toString());
+        details.put("expectedTenant", readerTenant.toString());
+        details.put("observedTenant", observedTenant.toString());
+        detachedAuditPersister.persistDetached(readerTenant, new AuditEventRecord(
+                TenantContext.getUserId(),
+                null,
+                AuditEventTypes.CROSS_TENANT_POLICY_READ,
+                details,
+                null));
     }
 
     /** Cache key for the {@code currentPolicyByTenant} cache. */
     private record CurrentKey(UUID tenantId, String eventType) {}
+
+    /**
+     * Cache key for the {@link #policyByTenantAndId} cache. Tenant + policy
+     * UUID together identify a specific immutable policy version that the
+     * caller's tenant has access to (either as owner or via platform-default
+     * fallback).
+     */
+    private record PolicyKey(UUID tenantId, UUID policyId) {}
 }

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
@@ -180,6 +180,23 @@ public final class AuditEventTypes {
      */
     public static final String MALFORMED_CACHE_ENTRY = "MALFORMED_CACHE_ENTRY";
 
+    /**
+     * Emitted by {@code EscalationPolicyService.findByTenantAndId} when the
+     * on-read tenant verification detects that the stored policy's
+     * {@code tenantId} does not match the caller's {@code TenantContext} AND
+     * the policy is not a platform-default (null-tenant) row.
+     *
+     * <p>Detail blob: {@code {policyId, expectedTenant, observedTenant}}.
+     * Actor: current user from {@code TenantContext.getUserId()}. Target: {@code null}.
+     *
+     * <p>Persisted via {@link DetachedAuditPersister} with
+     * {@code PROPAGATION_REQUIRES_NEW} — mirrors {@link #CROSS_TENANT_CACHE_READ}
+     * (task 4.1, design-c D-C-9). A cross-tenant read is security-evidence
+     * and must survive attacker-triggered caller rollback. Phase C task 4.4
+     * (EscalationPolicyService split) wires the first caller.
+     */
+    public static final String CROSS_TENANT_POLICY_READ = "CROSS_TENANT_POLICY_READ";
+
     private AuditEventTypes() {
         // utility class — do not instantiate
     }

--- a/backend/src/test/java/org/fabt/architecture/EscalationPolicyBatchOnlyArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/architecture/EscalationPolicyBatchOnlyArchitectureTest.java
@@ -1,0 +1,69 @@
+package org.fabt.architecture;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * Phase C task 4.4 ArchUnit guard for
+ * {@code EscalationPolicyService.findByIdForBatch(UUID)}.
+ *
+ * <p>Per design-c D-C-2 and spec {@code escalation-policy-service-cache-split}:
+ * {@code findByIdForBatch} is {@code @TenantUnscoped} by design because the
+ * escalation batch job resolves policies across tenants in a single pass
+ * with no {@code TenantContext} bound. That method MUST be reserved for the
+ * scheduled batch job — request paths that need a policy by id MUST use
+ * {@code findByTenantAndId(UUID, UUID)} which enforces on-read tenant
+ * verification and emits {@code CROSS_TENANT_POLICY_READ} audit rows on
+ * reject.</p>
+ *
+ * <p>The rule restricts callers by <b>package</b>: only classes in
+ * {@code org.fabt.referral.batch..} may call {@code findByIdForBatch}. The
+ * Phase C spec's original phrasing was "callable only from {@code @Scheduled}
+ * methods", but Spring Batch chains {@code @Scheduled} → Job → Step → Tasklet
+ * and the actual invocation happens inside a helper method in
+ * {@code ReferralEscalationJobConfig}, not directly on the {@code @Scheduled}
+ * method. Static call-graph reachability across that chain is not something
+ * ArchUnit does natively and a custom {@code ArchCondition} for it would be
+ * disproportionate work for a single-digit rule. Package-based restriction is
+ * a superset that achieves the same intent: a future non-batch class ever
+ * landing in {@code org.fabt.referral.batch..} would need warroom sign-off
+ * at code-review (same gate). (D-4.4-2 warroom resolution.)</p>
+ *
+ * <p>Today's only legitimate caller is
+ * {@code org.fabt.referral.batch.ReferralEscalationJobConfig} (line ~260).</p>
+ */
+@DisplayName("ArchUnit Phase C 4.4 — findByIdForBatch callable only from org.fabt.referral.batch")
+class EscalationPolicyBatchOnlyArchitectureTest {
+
+    private static final String BATCH_PACKAGE = "org.fabt.referral.batch..";
+
+    @Test
+    @DisplayName("findByIdForBatch callable only from org.fabt.referral.batch..")
+    void findByIdForBatch_isBatchOnly() {
+        var classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("org.fabt..");
+
+        ArchRule rule = noClasses()
+                .that().resideOutsideOfPackage(BATCH_PACKAGE)
+                .should().callMethod(
+                        "org.fabt.notification.service.EscalationPolicyService",
+                        "findByIdForBatch",
+                        "java.util.UUID")
+                .because("findByIdForBatch is @TenantUnscoped — reserved for the "
+                        + "scheduled escalation batch job (ReferralEscalationJobConfig). "
+                        + "Request paths MUST use findByTenantAndId(UUID, UUID) which "
+                        + "enforces tenant scoping on the returned policy and emits "
+                        + "CROSS_TENANT_POLICY_READ audit rows on cross-tenant reach. "
+                        + "Package-based restriction approximates the spec's "
+                        + "@Scheduled-caller intent because Spring Batch's chain is "
+                        + "not statically reachable from ArchUnit. Design-c D-C-2.");
+
+        rule.check(classes);
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/TenantGuardArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/architecture/TenantGuardArchitectureTest.java
@@ -131,7 +131,20 @@ class TenantGuardArchitectureTest {
             // Subscription: findById then manual tenantId equality check
             // (pre-D11 pattern, migrating to findByIdAndTenantId in
             // multi-tenant-production-readiness companion change).
-            "SubscriptionService.findRecentDeliveries"
+            "SubscriptionService.findRecentDeliveries",
+            // Phase C task 4.4: findByTenantAndId IS the tenant guard for
+            // EscalationPolicy request-path lookups by policy UUID. It calls
+            // repository.findById(policyId) then verifies policy.tenantId
+            // matches the caller's tenantId OR is null (platform-default row,
+            // accessible from any tenant by design). Mismatch returns empty +
+            // emits CROSS_TENANT_POLICY_READ audit row via DetachedAuditPersister
+            // (REQUIRES_NEW) + cross_tenant_reject Micrometer counter. The
+            // EscalationPolicyRepository has no findByIdAndTenantId method
+            // because platform-default rows (tenant_id IS NULL) must remain
+            // accessible from any tenant context — a strict equality join
+            // would incorrectly filter them out. Design-c D-C-2 + spec
+            // escalation-policy-service-cache-split.
+            "EscalationPolicyService.findByTenantAndId"
     );
 
     private static final Set<String> WRITE_METHODS = Set.of(

--- a/backend/src/test/java/org/fabt/notification/service/EscalationPolicyServiceCacheMetricsTest.java
+++ b/backend/src/test/java/org/fabt/notification/service/EscalationPolicyServiceCacheMetricsTest.java
@@ -11,6 +11,7 @@ import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import org.fabt.notification.domain.EscalationPolicy;
 import org.fabt.notification.repository.EscalationPolicyRepository;
+import org.fabt.shared.audit.DetachedAuditPersister;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -60,7 +61,7 @@ class EscalationPolicyServiceCacheMetricsTest {
     void policyById_recordsHitCounter() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         EscalationPolicyRepository repository = mock(EscalationPolicyRepository.class);
-        EscalationPolicyService service = new EscalationPolicyService(repository, registry);
+        EscalationPolicyService service = new EscalationPolicyService(repository, mock(DetachedAuditPersister.class), registry);
 
         UUID policyId = UUID.randomUUID();
         EscalationPolicy policy = samplePolicy(policyId);
@@ -101,7 +102,7 @@ class EscalationPolicyServiceCacheMetricsTest {
     void currentPolicyByTenant_recordsHitCounter() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         EscalationPolicyRepository repository = mock(EscalationPolicyRepository.class);
-        EscalationPolicyService service = new EscalationPolicyService(repository, registry);
+        EscalationPolicyService service = new EscalationPolicyService(repository, mock(DetachedAuditPersister.class), registry);
 
         UUID tenantId = UUID.randomUUID();
         EscalationPolicy policy = samplePolicy(UUID.randomUUID());
@@ -140,7 +141,7 @@ class EscalationPolicyServiceCacheMetricsTest {
     void coldCache_recordsMissCounter() {
         SimpleMeterRegistry registry = new SimpleMeterRegistry();
         EscalationPolicyRepository repository = mock(EscalationPolicyRepository.class);
-        EscalationPolicyService service = new EscalationPolicyService(repository, registry);
+        EscalationPolicyService service = new EscalationPolicyService(repository, mock(DetachedAuditPersister.class), registry);
 
         UUID policyId = UUID.randomUUID();
         when(repository.findById(any(UUID.class)))

--- a/backend/src/test/java/org/fabt/notification/service/EscalationPolicyServiceTest.java
+++ b/backend/src/test/java/org/fabt/notification/service/EscalationPolicyServiceTest.java
@@ -3,19 +3,25 @@ package org.fabt.notification.service;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
 
 import org.fabt.notification.domain.EscalationPolicy;
 import org.fabt.notification.repository.EscalationPolicyRepository;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.audit.DetachedAuditPersister;
 import org.fabt.shared.web.TenantContext;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -42,16 +48,25 @@ import static org.mockito.Mockito.when;
 class EscalationPolicyServiceTest {
 
     private EscalationPolicyRepository repository;
+    private DetachedAuditPersister detachedAuditPersister;
+    private SimpleMeterRegistry meterRegistry;
     private EscalationPolicyService service;
 
     @BeforeEach
     void setUp() {
         repository = mock(EscalationPolicyRepository.class);
+        // DetachedAuditPersister is mocked at the service boundary — the
+        // EscalationPolicyService only invokes persistDetached on cross-tenant
+        // reject; Phase C task 4.1 already exercises the real REQUIRES_NEW
+        // persistence path against Testcontainers Postgres in
+        // TenantScopedCacheAuditRollbackIntegrationTest.
+        detachedAuditPersister = mock(DetachedAuditPersister.class);
         // SimpleMeterRegistry is a real (non-mock) Micrometer registry that
         // records no-op bindings without requiring a Spring context. Used
         // here because the service constructor wires CaffeineCacheMetrics
         // into the registry at construction time (T-53).
-        service = new EscalationPolicyService(repository, new SimpleMeterRegistry());
+        meterRegistry = new SimpleMeterRegistry();
+        service = new EscalationPolicyService(repository, detachedAuditPersister, meterRegistry);
     }
 
     private static EscalationPolicy.Threshold threshold(String id, Duration at, String severity, String... roles) {
@@ -275,5 +290,195 @@ class EscalationPolicyServiceTest {
                 .isInstanceOf(IllegalArgumentException.class);
 
         verify(repository, never()).insertNewVersion(any(), anyString(), any(), any());
+    }
+
+    // -------------------------------------------------------------------------
+    // findByTenantAndId — Phase C task 4.4 split (request-path counterpart to
+    // findByIdForBatch with on-read tenant verification). Spec:
+    // escalation-policy-service-cache-split. Design-c D-C-2 / D-4.4-{1..5}.
+    // -------------------------------------------------------------------------
+
+    @Nested
+    @DisplayName("findByTenantAndId (Phase C task 4.4)")
+    class FindByTenantAndId {
+
+        private static final UUID TENANT_A = UUID.fromString("aaaa0000-0000-0000-0000-000000000001");
+        private static final UUID TENANT_B = UUID.fromString("bbbb0000-0000-0000-0000-000000000002");
+
+        private EscalationPolicy tenantOwnedPolicy(UUID tenantId) {
+            return new EscalationPolicy(
+                    UUID.randomUUID(), tenantId, "dv-referral", 1,
+                    validPolicy().thresholds(), Instant.now(), null);
+        }
+
+        private EscalationPolicy platformDefaultPolicy() {
+            return new EscalationPolicy(
+                    UUID.randomUUID(), null, "dv-referral", 1,
+                    validPolicy().thresholds(), Instant.now(), null);
+        }
+
+        @Test
+        @DisplayName("cachesSubsequentLookups — same (tenant, policyId) hits cache after first call")
+        void cachesSubsequentLookups() {
+            EscalationPolicy p = tenantOwnedPolicy(TENANT_A);
+            when(repository.findById(p.id())).thenReturn(Optional.of(p));
+
+            assertThat(service.findByTenantAndId(TENANT_A, p.id())).contains(p);
+            assertThat(service.findByTenantAndId(TENANT_A, p.id())).contains(p);
+            assertThat(service.findByTenantAndId(TENANT_A, p.id())).contains(p);
+
+            verify(repository, times(1)).findById(p.id());
+        }
+
+        @Test
+        @DisplayName("crossTenantReadReturnsEmpty — policy owned by A, B's read returns empty + emits audit + counter increments")
+        void crossTenantReadReturnsEmpty() {
+            EscalationPolicy p = tenantOwnedPolicy(TENANT_A);
+            when(repository.findById(p.id())).thenReturn(Optional.of(p));
+
+            // Sanity check: TENANT_A can read.
+            assertThat(service.findByTenantAndId(TENANT_A, p.id())).contains(p);
+
+            // Cross-tenant reach by TENANT_B.
+            assertThat(service.findByTenantAndId(TENANT_B, p.id())).isEmpty();
+
+            // DetachedAuditPersister invoked with CROSS_TENANT_POLICY_READ for TENANT_B.
+            ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+            verify(detachedAuditPersister).persistDetached(eq(TENANT_B), captor.capture());
+            assertThat(captor.getValue().action()).isEqualTo(AuditEventTypes.CROSS_TENANT_POLICY_READ);
+
+            // cross_tenant_reject counter incremented for TENANT_B.
+            double rejectCount = meterRegistry.counter("fabt.cache.get",
+                    "cache", "fabt.escalation.policy.by-tenant-and-id",
+                    "tenant", TENANT_B.toString(),
+                    "result", "cross_tenant_reject").count();
+            assertThat(rejectCount).isEqualTo(1.0);
+        }
+
+        @Test
+        @DisplayName("crossTenantReadDoesNotCache — after reject, legit owner A's read still hits repo (no poisoning)")
+        void crossTenantReadDoesNotCache() {
+            EscalationPolicy p = tenantOwnedPolicy(TENANT_A);
+            when(repository.findById(p.id())).thenReturn(Optional.of(p));
+
+            // B tries and gets rejected.
+            assertThat(service.findByTenantAndId(TENANT_B, p.id())).isEmpty();
+
+            // A's subsequent read must go to the repo (not served from any cache
+            // line B's read might have touched).
+            assertThat(service.findByTenantAndId(TENANT_A, p.id())).contains(p);
+
+            // repo.findById was called twice — once for B's rejected lookup
+            // and once for A's legit lookup. Neither was served from cache
+            // because B's cross-tenant reject intentionally does NOT cache.
+            verify(repository, times(2)).findById(p.id());
+        }
+
+        @Test
+        @DisplayName("platformDefaultAccessibleFromAnyTenant — policy.tenantId=null, both tenants succeed, separate cache entries")
+        void platformDefaultAccessibleFromAnyTenant() {
+            EscalationPolicy platformDefault = platformDefaultPolicy();
+            when(repository.findById(platformDefault.id())).thenReturn(Optional.of(platformDefault));
+
+            assertThat(service.findByTenantAndId(TENANT_A, platformDefault.id())).contains(platformDefault);
+            assertThat(service.findByTenantAndId(TENANT_B, platformDefault.id())).contains(platformDefault);
+
+            // Each tenant has a separate cache entry → two repo calls, one per
+            // tenant. D-4.4-1: N× duplication accepted for rare platform-default rows.
+            verify(repository, times(2)).findById(platformDefault.id());
+
+            // Subsequent reads hit cache; no additional repo calls.
+            assertThat(service.findByTenantAndId(TENANT_A, platformDefault.id())).contains(platformDefault);
+            assertThat(service.findByTenantAndId(TENANT_B, platformDefault.id())).contains(platformDefault);
+            verify(repository, times(2)).findById(platformDefault.id());
+        }
+
+        @Test
+        @DisplayName("separateCacheEntriesByTenant — two tenants each own different policies by distinct UUIDs")
+        void separateCacheEntriesByTenant() {
+            EscalationPolicy pA = tenantOwnedPolicy(TENANT_A);
+            EscalationPolicy pB = tenantOwnedPolicy(TENANT_B);
+            when(repository.findById(pA.id())).thenReturn(Optional.of(pA));
+            when(repository.findById(pB.id())).thenReturn(Optional.of(pB));
+
+            assertThat(service.findByTenantAndId(TENANT_A, pA.id())).contains(pA);
+            assertThat(service.findByTenantAndId(TENANT_B, pB.id())).contains(pB);
+
+            // Keys are distinct: (A, pA.id) and (B, pB.id). No cross-collision.
+            verify(repository, times(1)).findById(pA.id());
+            verify(repository, times(1)).findById(pB.id());
+        }
+
+        @Test
+        @DisplayName("throwsOnNullTenantId — fail-loud per feedback_never_skip_silently")
+        void throwsOnNullTenantId() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> service.findByTenantAndId(null, UUID.randomUUID()))
+                    .withMessageContaining("tenantId");
+        }
+
+        @Test
+        @DisplayName("throwsOnNullPolicyId — fail-loud per feedback_never_skip_silently")
+        void throwsOnNullPolicyId() {
+            assertThatNullPointerException()
+                    .isThrownBy(() -> service.findByTenantAndId(UUID.randomUUID(), null))
+                    .withMessageContaining("policyId");
+        }
+
+        @Test
+        @DisplayName("cacheEntrySurvivesPolicyUpdate — policies are immutable-by-id; update() does NOT invalidate by-tenant-and-id cache")
+        void cacheEntrySurvivesPolicyUpdate() {
+            UUID actor = UUID.randomUUID();
+            EscalationPolicy v1 = tenantOwnedPolicy(TENANT_A);
+            EscalationPolicy v2 = new EscalationPolicy(
+                    UUID.randomUUID(), TENANT_A, "dv-referral", 2,
+                    validPolicy().thresholds(), Instant.now(), actor);
+
+            // Prime the by-tenant-and-id cache for v1.
+            when(repository.findById(v1.id())).thenReturn(Optional.of(v1));
+            assertThat(service.findByTenantAndId(TENANT_A, v1.id())).contains(v1);
+
+            // Publish v2 via update() — inserts a NEW policy with a NEW id.
+            when(repository.insertNewVersion(eq(TENANT_A), eq("dv-referral"), any(), eq(actor)))
+                    .thenReturn(v2);
+            TenantContext.runWithContext(TENANT_A, false,
+                    () -> service.update("dv-referral", v2.thresholds(), actor));
+
+            // v1's cache entry must survive — by-id lookups for v1 still resolve
+            // without a repo hit. (Policies are immutable once inserted; old
+            // referrals that snapshotted v1 still need v1 to remain resolvable.)
+            assertThat(service.findByTenantAndId(TENANT_A, v1.id())).contains(v1);
+            verify(repository, times(1)).findById(v1.id());
+        }
+    }
+
+    @Test
+    @DisplayName("clearCaches_testOnly also clears policyByTenantAndId (Phase C task 4.4)")
+    void clearCachesTestOnly_clearsNewCache() {
+        UUID tenantA = UUID.fromString("aaaa0000-0000-0000-0000-000000000001");
+        EscalationPolicy p = new EscalationPolicy(
+                UUID.randomUUID(), tenantA, "dv-referral", 1,
+                validPolicy().thresholds(), Instant.now(), null);
+        when(repository.findById(p.id())).thenReturn(Optional.of(p));
+
+        // Populate all three caches.
+        service.findByIdForBatch(p.id());                  // policyById
+        service.findByTenantAndId(tenantA, p.id());        // policyByTenantAndId
+        when(repository.findCurrentByTenantAndEventType(tenantA, "dv-referral"))
+                .thenReturn(Optional.of(p));
+        service.getCurrentForTenant(tenantA, "dv-referral"); // currentPolicyByTenant
+
+        service.clearCaches_testOnly();
+
+        // Next reads must go back to the repo.
+        service.findByIdForBatch(p.id());
+        service.findByTenantAndId(tenantA, p.id());
+        service.getCurrentForTenant(tenantA, "dv-referral");
+
+        // findByIdForBatch + findByTenantAndId use SEPARATE caches (policyById +
+        // policyByTenantAndId), so each pre-clear + post-clear call pair hits
+        // the repo independently: 2 before + 2 after = 4 total findById calls.
+        verify(repository, times(4)).findById(p.id());
+        verify(repository, times(2)).findCurrentByTenantAndEventType(tenantA, "dv-referral");
     }
 }

--- a/backend/src/test/java/org/fabt/notification/service/EscalationPolicyServiceTest.java
+++ b/backend/src/test/java/org/fabt/notification/service/EscalationPolicyServiceTest.java
@@ -426,6 +426,86 @@ class EscalationPolicyServiceTest {
         }
 
         @Test
+        @DisplayName("policyNotFound — repository empty returns empty without invoking DetachedAuditPersister (not-found is not a cross-tenant event)")
+        void policyNotFound() {
+            UUID missingId = UUID.randomUUID();
+            when(repository.findById(missingId)).thenReturn(Optional.empty());
+
+            assertThat(service.findByTenantAndId(TENANT_A, missingId)).isEmpty();
+
+            // Confirm the empty came from the DB path (not a null-guard short-circuit
+            // or a cached empty). Warroom polish-nit.
+            verify(repository).findById(missingId);
+
+            // Not-found is NOT a cross-tenant reach — DetachedAuditPersister MUST NOT fire.
+            verify(detachedAuditPersister, never()).persistDetached(any(), any());
+
+            // cross_tenant_reject counter MUST NOT increment.
+            double rejectCount = meterRegistry.counter("fabt.cache.get",
+                    "cache", "fabt.escalation.policy.by-tenant-and-id",
+                    "tenant", TENANT_A.toString(),
+                    "result", "cross_tenant_reject").count();
+            assertThat(rejectCount).isEqualTo(0.0);
+        }
+
+        @Test
+        @DisplayName("concurrentCrossTenantIsolation — A and B race on same policyId (A owns); A succeeds, B rejected per-reader with audit+counter, no poisoning")
+        void concurrentCrossTenantIsolation() throws Exception {
+            EscalationPolicy pA = tenantOwnedPolicy(TENANT_A);
+            when(repository.findById(pA.id())).thenReturn(Optional.of(pA));
+
+            int perTenant = 8;
+            java.util.concurrent.CountDownLatch startGate = new java.util.concurrent.CountDownLatch(1);
+            java.util.concurrent.CountDownLatch doneGate = new java.util.concurrent.CountDownLatch(perTenant * 2);
+            java.util.concurrent.atomic.AtomicReference<Throwable> caught =
+                    new java.util.concurrent.atomic.AtomicReference<>();
+
+            Runnable aReader = () -> {
+                try {
+                    startGate.await();
+                    assertThat(service.findByTenantAndId(TENANT_A, pA.id())).contains(pA);
+                } catch (Throwable t) {
+                    caught.compareAndSet(null, t);
+                } finally {
+                    doneGate.countDown();
+                }
+            };
+            Runnable bReader = () -> {
+                try {
+                    startGate.await();
+                    assertThat(service.findByTenantAndId(TENANT_B, pA.id())).isEmpty();
+                } catch (Throwable t) {
+                    caught.compareAndSet(null, t);
+                } finally {
+                    doneGate.countDown();
+                }
+            };
+
+            for (int i = 0; i < perTenant; i++) {
+                Thread.ofVirtual().start(aReader);
+                Thread.ofVirtual().start(bReader);
+            }
+            startGate.countDown();
+            doneGate.await();
+
+            assertThat(caught.get()).isNull();
+
+            // Every B-reader must produce an audit row — no cache-put on the reject
+            // path means each B-call individually calls DetachedAuditPersister.
+            // Pins the contract that cross-tenant rejects are NOT deduplicated by
+            // a racing cache entry.
+            verify(detachedAuditPersister, times(perTenant))
+                    .persistDetached(eq(TENANT_B), any(AuditEventRecord.class));
+
+            // Reject counter total equals perTenant (one per B-call).
+            double bRejectCount = meterRegistry.counter("fabt.cache.get",
+                    "cache", "fabt.escalation.policy.by-tenant-and-id",
+                    "tenant", TENANT_B.toString(),
+                    "result", "cross_tenant_reject").count();
+            assertThat(bRejectCount).isEqualTo((double) perTenant);
+        }
+
+        @Test
         @DisplayName("cacheEntrySurvivesPolicyUpdate — policies are immutable-by-id; update() does NOT invalidate by-tenant-and-id cache")
         void cacheEntrySurvivesPolicyUpdate() {
             UUID actor = UUID.randomUUID();

--- a/backend/src/test/java/org/fabt/shared/audit/AuditEventTypesTest.java
+++ b/backend/src/test/java/org/fabt/shared/audit/AuditEventTypesTest.java
@@ -126,4 +126,13 @@ class AuditEventTypesTest {
                 .isNotBlank()
                 .isEqualTo("MALFORMED_CACHE_ENTRY");
     }
+
+    @Test
+    @DisplayName("CROSS_TENANT_POLICY_READ has stable value (security-evidence audit — Phase C task 4.4)")
+    void crossTenantPolicyRead() {
+        assertThat(AuditEventTypes.CROSS_TENANT_POLICY_READ)
+                .isNotNull()
+                .isNotBlank()
+                .isEqualTo("CROSS_TENANT_POLICY_READ");
+    }
 }


### PR DESCRIPTION
## Summary

Phase C task 4.4 per design-c D-C-2 + spec `escalation-policy-service-cache-split`. Must land before task 4.2 (Family C basic ArchUnit rule) so that rule is green on first run.

Adds `findByTenantAndId(UUID tenantId, UUID policyId)` as the request-path counterpart to the existing `@TenantUnscoped` `findByIdForBatch(UUID)`. Three contracts:

1. **Tenant-scoped on-read verification** — cache miss loads via `repository.findById` + verifies `policy.tenantId` matches caller's OR is null (platform default, accessible from any tenant). Mismatch returns `Optional.empty()` (D3 no-existence-leak).
2. **Security-evidence audit** — cross-tenant reach emits `CROSS_TENANT_POLICY_READ` audit row via `DetachedAuditPersister` (REQUIRES_NEW) + `cross_tenant_reject` Micrometer counter. Mirrors the `CROSS_TENANT_CACHE_READ` path from task 4.1.
3. **ArchUnit guard** — new `EscalationPolicyBatchOnlyArchitectureTest` restricts `findByIdForBatch` callers to `org.fabt.referral.batch..` (today's only legitimate caller: `ReferralEscalationJobConfig`).

Wrapper design went through warroom stress-test before code (plan file at `~/.claude/plans/virtual-discovering-wadler.md`). Six lens verdicts — 2 must-fixes (Marcus: audit+counter on reject; Riley: cache-survives-update + extended clearCaches_testOnly coverage) + 1 TTL pick-alternative (match `policyById` shape because `(tenantId, policyId)` identifies an immutable version) + 1 null-handling pick-alternative (fail-loud `requireNonNull` per `feedback_never_skip_silently.md`) — all folded in.

## Test plan

- [x] `EscalationPolicyServiceTest.FindByTenantAndId` @Nested — 8 new tests (caching, cross-tenant reject + audit + counter, cross-tenant-does-not-cache, platform-default-accessible-from-any-tenant, separate-cache-entries, null-tenant fail-loud, null-policy-id fail-loud, cache-survives-update)
- [x] Extended `clearCaches_testOnly` test covers the new cache
- [x] `AuditEventTypesTest` pin for new constant (12 pins total)
- [x] `EscalationPolicyBatchOnlyArchitectureTest` — 1 test
- [x] `EscalationPolicyServiceCacheMetricsTest` updated to 3-arg constructor
- [x] All existing architecture + service tests still green
- [x] **Full run: `mvn test -Dtest=*Architecture*,EscalationPolicyService*,AuditEventTypesTest` → 70/70 passed, 0 failures**

## Not in this PR

- Task 4.2 — ArchUnit Family C basic rule (depends on 4.4 green, lands next)
- Task 4.3 — Family C extended scope
- Task 4.b — migrate the 7 existing cache call sites (BedSearchService, AvailabilityService, AnalyticsService)
- `@TenantUnscopedCache` annotation (Phase C future; for 4.4 the existing `@TenantUnscoped` on `findByIdForBatch` is the marker)
- First production caller of `findByTenantAndId` — per spec, the method lands with the split so the Family C rule can direct offenders to it; first caller migrates in task 4.b

🤖 Generated with [Claude Code](https://claude.com/claude-code)