### PR TITLE
Phase C tasks 4.2 + 4.3 + 4.5 — Family C ArchUnit rules + annotations + CI review gate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,3 +62,22 @@
 # The release-gate file itself — ownership must not be self-editable
 # without a second-pair review in a larger team. Solo for now.
 /.github/CODEOWNERS  @ccradle
+
+# Phase C Family C cache-isolation annotations — ownership of the
+# annotation DEFINITIONS. Catches edits to the annotation contract itself
+# (signature changes, retention changes, deprecation). Does NOT catch new
+# USAGES of the annotation on other files — that's handled by the CI
+# grep job in .github/workflows/ci.yml which posts a PR-comment
+# auto-requesting @ccradle review whenever a PR introduces a new
+# @TenantUnscopedCache or @TenantScopedByConstruction occurrence. See
+# design-c D-4.23-2 warroom resolution: CODEOWNERS is path-based, not
+# diff-content-based, so the annotation-usage gate requires a different
+# mechanism.
+/backend/src/main/java/org/fabt/shared/security/TenantUnscopedCache.java  @ccradle
+/backend/src/main/java/org/fabt/shared/security/TenantScopedByConstruction.java  @ccradle
+
+# Family C ArchUnit rule — the test class + SAFE_SITES-style allowlist.
+# Adding a new allowlist entry is semantically "I am deliberately opting
+# out of the rule for this site"; warrants the same review rigor as the
+# annotation additions above.
+/backend/src/test/java/org/fabt/architecture/FamilyCArchitectureTest.java  @ccradle

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,51 @@
+<!-- Delete sections that don't apply. -->
+
+## Summary
+
+<!-- 1-3 bullets: what changed and why. -->
+
+## Test plan
+
+<!-- bulleted markdown checklist of TODOs for testing the PR -->
+
+## Security + tenant-isolation review gates
+
+If this PR modifies any tenant-isolation-adjacent surface, confirm the relevant
+gates below. Unchecked boxes without deliberate justification may block review.
+
+- [ ] **No new `@TenantUnscoped`** introductions (bypasses Family A tenant-guard
+      rule). If new usage is required, confirm the justification string explains
+      why the annotated method is safe to call a tenant-owned repository without
+      a tenant predicate, and request `@ccradle` review.
+- [ ] **No new `@TenantUnscopedCache`** introductions (Phase C Family C, task
+      4.2+4.3). If this PR introduces a new `@TenantUnscopedCache`, I confirm
+      the justification explains why tenant scoping would be incorrect for this
+      cache (e.g., key is globally unique, pre-auth, or carries tenant discriminator
+      structurally). The CI grep job will auto-request `@ccradle` review.
+- [ ] **No new `@TenantScopedByConstruction`** introductions (Phase C Family C).
+      If added, confirm both (a) the cache key includes `tenantId` (composite
+      key record or tenantId-typed key) AND (b) the read path has an explicit
+      `tenantId`-match check that emits `CROSS_TENANT_*` audit + counter on
+      mismatch. The CI grep job will auto-request `@ccradle` review.
+- [ ] **No new `FamilyCArchitectureTest.PENDING_MIGRATION_SITES` entries.**
+      Task 4.b migrates the existing allowlist entries to
+      `TenantScopedCacheService`; adding NEW entries defeats the point of the
+      rule. If you added a new `CacheService.get/put/evict` call site from a
+      service/api/security/auth-package class, route it through
+      `TenantScopedCacheService` instead of adding an allowlist exemption.
+
+## Flyway / RLS
+
+- [ ] No new Flyway migrations OR new migrations are above HWM and carry
+      `@tenant-safe` / `@tenant-destructive` comments.
+- [ ] No `SECURITY DEFINER` in SQL migrations (blocked by `MigrationLintTest`).
+- [ ] If RLS policies change: `docs/security/pg-policies-snapshot.md` +
+      `deploy/release-gate-pins.txt` updated.
+
+## Legal
+
+- [ ] No overclaiming language ("compliant", "guarantees", "equivalent to") in
+      code comments, docs, or UI strings — use "designed to support" per
+      `feedback_legal_claims_review.md`.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -44,8 +44,9 @@ gates below. Unchecked boxes without deliberate justification may block review.
 
 ## Legal
 
-- [ ] No overclaiming language ("compliant", "guarantees", "equivalent to") in
-      code comments, docs, or UI strings — use "designed to support" per
-      `feedback_legal_claims_review.md`.
+- [ ] No overclaiming-compliance language in code comments, docs, or UI
+      strings — prefer the "designed to support" pattern per
+      `feedback_legal_claims_review.md`. The `legal-language-scan.sh` CI
+      job lists the specific forbidden words; run it locally if unsure.
 
 🤖 Generated with [Claude Code](https://claude.com/claude-code)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,16 +138,39 @@ jobs:
           set -eo pipefail
           BASE_SHA="${{ github.event.pull_request.base.sha }}"
           HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+
+          # Hardening (warroom PR #137 post-commit review — Jordan): verify
+          # both SHAs resolve BEFORE the diff. Previous version used
+          # `git diff ... | grep ... || true`, which masked a broken diff as
+          # "zero new usages" — the review gate could be silently bypassed if
+          # a fork re-push pruned the base SHA. Fail loud on unresolvable
+          # SHAs instead.
+          if ! git rev-parse --verify --quiet "$BASE_SHA^{commit}" >/dev/null; then
+            echo "::error::base SHA $BASE_SHA does not resolve in this checkout — cannot compute diff. Refusing to skip the review gate."
+            exit 1
+          fi
+          if ! git rev-parse --verify --quiet "$HEAD_SHA^{commit}" >/dev/null; then
+            echo "::error::head SHA $HEAD_SHA does not resolve in this checkout — cannot compute diff. Refusing to skip the review gate."
+            exit 1
+          fi
+
           # Count NEW occurrences (added lines) containing the annotations
           # in the PR diff. Exclude the annotation definitions themselves
           # (TenantUnscopedCache.java, TenantScopedByConstruction.java) so
-          # edits to the annotations don't self-trigger.
-          NEW_USAGES=$(git diff "$BASE_SHA" "$HEAD_SHA" -- \
+          # edits to the annotations don't self-trigger. Use a tmpfile to
+          # separate pipeline-failure detection from grep's no-match exit
+          # code (grep returns 1 on zero matches, which set -o pipefail
+          # would otherwise treat as fatal).
+          DIFF_FILE=$(mktemp)
+          git diff "$BASE_SHA" "$HEAD_SHA" -- \
               ':(exclude)backend/src/main/java/org/fabt/shared/security/TenantUnscopedCache.java' \
               ':(exclude)backend/src/main/java/org/fabt/shared/security/TenantScopedByConstruction.java' \
-              | grep -E '^\+[^+]' \
-              | grep -cE '@TenantUnscopedCache\(|@TenantScopedByConstruction\(' \
-              || true)
+              > "$DIFF_FILE"
+          # Added-line count of the two annotation constructors; `grep -c`
+          # returns 0 on no match (without exit 1 because it reads from file).
+          NEW_USAGES=$(grep -cE '^\+[^+].*@TenantUnscopedCache\(|^\+[^+].*@TenantScopedByConstruction\(' "$DIFF_FILE" || true)
+          rm -f "$DIFF_FILE"
+
           echo "new_usages=$NEW_USAGES" >> "$GITHUB_OUTPUT"
           if [ "$NEW_USAGES" -gt 0 ]; then
             echo "::notice::PR introduces $NEW_USAGES new @TenantUnscopedCache / @TenantScopedByConstruction usage(s) — @ccradle review required."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,82 @@ jobs:
       - name: Scan for overclaimed compliance language
         run: bash infra/scripts/legal-language-scan.sh .
 
+  family-c-annotation-review-gate:
+    # Phase C task 4.5: auto-request @ccradle review on any PR that
+    # introduces a new @TenantUnscopedCache or @TenantScopedByConstruction
+    # usage. CODEOWNERS is path-based and does NOT trigger when a new
+    # annotation is added to an existing file — this job closes that gap
+    # per design-c D-4.23-2 warroom resolution.
+    name: Family C annotation review gate (4.5)
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Detect new @TenantUnscopedCache / @TenantScopedByConstruction usages
+        id: detect
+        run: |
+          set -eo pipefail
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.event.pull_request.head.sha }}"
+          # Count NEW occurrences (added lines) containing the annotations
+          # in the PR diff. Exclude the annotation definitions themselves
+          # (TenantUnscopedCache.java, TenantScopedByConstruction.java) so
+          # edits to the annotations don't self-trigger.
+          NEW_USAGES=$(git diff "$BASE_SHA" "$HEAD_SHA" -- \
+              ':(exclude)backend/src/main/java/org/fabt/shared/security/TenantUnscopedCache.java' \
+              ':(exclude)backend/src/main/java/org/fabt/shared/security/TenantScopedByConstruction.java' \
+              | grep -E '^\+[^+]' \
+              | grep -cE '@TenantUnscopedCache\(|@TenantScopedByConstruction\(' \
+              || true)
+          echo "new_usages=$NEW_USAGES" >> "$GITHUB_OUTPUT"
+          if [ "$NEW_USAGES" -gt 0 ]; then
+            echo "::notice::PR introduces $NEW_USAGES new @TenantUnscopedCache / @TenantScopedByConstruction usage(s) — @ccradle review required."
+          else
+            echo "No new annotation usages detected in this PR."
+          fi
+      - name: Post review-required comment
+        if: steps.detect.outputs.new_usages != '0'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const newUsages = '${{ steps.detect.outputs.new_usages }}';
+            const body = [
+              '## Family C annotation review gate',
+              '',
+              `This PR introduces **${newUsages} new** \`@TenantUnscopedCache\` / \`@TenantScopedByConstruction\` usage(s).`,
+              '',
+              'Per Phase C task 4.5 (warroom D-4.23-2): every new introduction requires `@ccradle` review to verify the justification.',
+              '',
+              'Reviewer checklist (per annotation):',
+              '- For `@TenantUnscopedCache`: confirm the justification describes a structurally platform-wide key space (globally unique UUID, token hash, JTI, pre-auth slug, etc.).',
+              '- For `@TenantScopedByConstruction`: confirm (a) the key includes `tenantId` structurally AND (b) the read path has an explicit `tenantId`-match check that emits `CROSS_TENANT_*` audit + counter on mismatch.',
+              '',
+              'Auto-requesting `@ccradle` as reviewer.',
+            ].join('\n');
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              body,
+            });
+            // Auto-request @ccradle as reviewer (no-op if already requested)
+            try {
+              await github.rest.pulls.requestReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: context.issue.number,
+                reviewers: ['ccradle'],
+              });
+            } catch (e) {
+              // Author cannot request themselves as reviewer — expected on
+              // solo-maintainer repos. Swallow the error so the job stays green.
+              core.info('requestReviewers no-op: ' + e.message);
+            }
+
   phase-b-rls-test-discipline:
     name: Phase B RLS test-discipline (no naked audit queries)
     runs-on: ubuntu-latest

--- a/backend/src/main/java/org/fabt/auth/api/AuthController.java
+++ b/backend/src/main/java/org/fabt/auth/api/AuthController.java
@@ -57,12 +57,14 @@ public class AuthController {
     private final ApplicationEventPublisher eventPublisher;
 
     // mfaToken attempt tracking: jti → attempt count (Caffeine cache, 5-min TTL)
+    @org.fabt.shared.security.TenantUnscopedCache("MFA JTI is a UUID generated per mfaToken issuance — globally unique across all tenants; attempt counter per-JTI tracks brute-force attempts on that specific token, not tenant-bearing data")
     private final Cache<String, Integer> mfaAttempts = Caffeine.newBuilder()
             .expireAfterWrite(Duration.ofMinutes(5))
             .maximumSize(10000)
             .build();
 
     // mfaToken single-use blocklist: jti → true (Caffeine cache, 5-min TTL)
+    @org.fabt.shared.security.TenantUnscopedCache("MFA JTI single-use blocklist; JTI is globally unique; blocklist entry prevents token replay across all tenants")
     private final Cache<String, Boolean> mfaBlocklist = Caffeine.newBuilder()
             .expireAfterWrite(Duration.ofMinutes(5))
             .maximumSize(10000)

--- a/backend/src/main/java/org/fabt/auth/service/DynamicClientRegistrationSource.java
+++ b/backend/src/main/java/org/fabt/auth/service/DynamicClientRegistrationSource.java
@@ -35,6 +35,7 @@ public class DynamicClientRegistrationSource implements ClientRegistrationReposi
     private final TenantService tenantService;
     private final SecretEncryptionService encryptionService;
 
+    @org.fabt.shared.security.TenantUnscopedCache("pre-authentication OAuth2 provider lookup keyed by {slug}-{provider}; tenant slug is structurally part of the key so cross-tenant collision is impossible; cache is read by Spring Security filter chain before any JWT is validated")
     private final Cache<String, ClientRegistration> cache = Caffeine.newBuilder()
             .expireAfterWrite(5, TimeUnit.MINUTES)
             .maximumSize(100)

--- a/backend/src/main/java/org/fabt/auth/service/JwtService.java
+++ b/backend/src/main/java/org/fabt/auth/service/JwtService.java
@@ -82,6 +82,7 @@ public class JwtService {
     private final long refreshTokenExpiryDays;
     private final ObjectMapper objectMapper;
     private final Environment environment;
+    @org.fabt.shared.security.TenantUnscopedCache("JWT claims by SHA-256 of signature part; token signature is globally unique across all tenants and signing keys, so no cross-tenant collision is possible")
     private final Cache<String, JwtClaims> claimsCache;
 
     // Phase A4 dependencies. Optional (null in pre-A4 unit tests) so the

--- a/backend/src/main/java/org/fabt/notification/service/EscalationPolicyService.java
+++ b/backend/src/main/java/org/fabt/notification/service/EscalationPolicyService.java
@@ -19,7 +19,9 @@ import io.micrometer.core.instrument.MeterRegistry;
 import org.fabt.shared.audit.AuditEventRecord;
 import org.fabt.shared.audit.AuditEventTypes;
 import org.fabt.shared.audit.DetachedAuditPersister;
+import org.fabt.shared.security.TenantScopedByConstruction;
 import org.fabt.shared.security.TenantUnscoped;
+import org.fabt.shared.security.TenantUnscopedCache;
 import io.micrometer.core.instrument.binder.cache.CaffeineCacheMetrics;
 
 import org.fabt.notification.domain.EscalationPolicy;
@@ -112,6 +114,7 @@ public class EscalationPolicyService {
      * {@code EscalationPolicyServiceCacheMetricsTest} pins this against
      * regression (T-53, Alex Chen review 2026-04-12).</p>
      */
+    @TenantUnscopedCache("batch-job cross-tenant snapshot resolution; paired with @TenantUnscoped method guard on findByIdForBatch + EscalationPolicyBatchOnlyArchitectureTest package-restriction rule")
     private final Cache<UUID, EscalationPolicy> policyById = Caffeine.newBuilder()
             .maximumSize(500)
             .expireAfterAccess(Duration.ofMinutes(10))
@@ -124,6 +127,7 @@ public class EscalationPolicyService {
      *
      * <p><b>.recordStats() is REQUIRED</b> — see {@link #policyById} comment.</p>
      */
+    @TenantUnscopedCache("key is composite CurrentKey(tenantId, eventType) — tenantId is structurally embedded in the key; `update()` invalidates the specific (tenantId, eventType) entry so cross-tenant reads cannot observe another tenant's current policy")
     private final Cache<CurrentKey, EscalationPolicy> currentPolicyByTenant = Caffeine.newBuilder()
             .maximumSize(200)
             .expireAfterWrite(Duration.ofMinutes(5))
@@ -163,6 +167,7 @@ public class EscalationPolicyService {
      * discipline before the first real caller. When task 4.b migrates a
      * caller, remove this TODO note.</p>
      */
+    @TenantScopedByConstruction("composite PolicyKey(tenantId, policyId) + on-read tenant verification at EscalationPolicyService.findByTenantAndId; mismatch returns empty and emits CROSS_TENANT_POLICY_READ audit via DetachedAuditPersister; Phase C task 4.4")
     private final Cache<PolicyKey, EscalationPolicy> policyByTenantAndId = Caffeine.newBuilder()
             .maximumSize(500)
             .expireAfterAccess(Duration.ofMinutes(10))

--- a/backend/src/main/java/org/fabt/shared/security/ApiKeyAuthenticationFilter.java
+++ b/backend/src/main/java/org/fabt/shared/security/ApiKeyAuthenticationFilter.java
@@ -51,6 +51,7 @@ public class ApiKeyAuthenticationFilter extends OncePerRequestFilter {
     private final Duration rateWindow = Duration.ofMinutes(1);
 
     // Caffeine cache: bounded size + TTL eviction to prevent memory DoS from IP rotation
+    @TenantUnscopedCache("pre-authentication rate-limit buckets keyed by client IP; the filter runs BEFORE any API key is validated so the caller's tenant is unknown at cache-site; platform-admin API keys may legitimately cross tenants and share IP space — bucket isolation is per-IP not per-tenant by design")
     private final Cache<String, Bucket> rateLimitBuckets = Caffeine.newBuilder()
             .maximumSize(10_000)
             .expireAfterAccess(Duration.ofMinutes(10))

--- a/backend/src/main/java/org/fabt/shared/security/KidRegistryService.java
+++ b/backend/src/main/java/org/fabt/shared/security/KidRegistryService.java
@@ -56,6 +56,7 @@ public class KidRegistryService {
      * the rotation flow must {@link Cache#invalidate} the affected
      * tenant's entry in this cache.
      */
+    @TenantUnscopedCache("key IS tenantId (not a composite); cache stores per-tenant active kid lookup — structurally tenant-scoped by key shape; used by JwtService.sign to pick the signing key before a request is tenant-bound")
     private final Cache<UUID, UUID> tenantToActiveKidCache = Caffeine.newBuilder()
             .maximumSize(10_000)
             .expireAfterWrite(Duration.ofMinutes(5))
@@ -70,6 +71,7 @@ public class KidRegistryService {
      * registered, it never re-points. Cache eviction only on tenant
      * hard-delete (Phase F crypto-shred).
      */
+    @TenantUnscopedCache("kid is a globally-unique opaque UUID assigned once at kid_to_tenant_key insert; resolution (kid → tenant, generation) is immutable by design; JWT validate path reads this cache BEFORE TenantContext is bound — cache-site tenant-scoping is impossible at this stage")
     private final Cache<UUID, KidResolution> kidToResolutionCache = Caffeine.newBuilder()
             .maximumSize(100_000)
             .expireAfterWrite(Duration.ofHours(1))

--- a/backend/src/main/java/org/fabt/shared/security/RevokedKidCache.java
+++ b/backend/src/main/java/org/fabt/shared/security/RevokedKidCache.java
@@ -38,6 +38,7 @@ public class RevokedKidCache {
 
     private final JdbcTemplate jdbc;
 
+    @TenantUnscopedCache("kid is a globally-unique opaque UUID; revocation list is platform-wide (any tenant's revoked kid must be rejected by any validator regardless of calling tenant context); read path is in Spring Security filter chain BEFORE TenantContext is bound")
     private final Cache<UUID, Boolean> cache = Caffeine.newBuilder()
             .maximumSize(100_000)
             .expireAfterWrite(Duration.ofMinutes(1))

--- a/backend/src/main/java/org/fabt/shared/security/TenantScopedByConstruction.java
+++ b/backend/src/main/java/org/fabt/shared/security/TenantScopedByConstruction.java
@@ -1,0 +1,72 @@
+package org.fabt.shared.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a cache field whose key structurally includes the tenant id and
+ * whose on-read code path verifies the tenant match — tenant-scoped by
+ * construction, but NOT via the {@code TenantScopedCacheService} wrapper.
+ *
+ * <p>Distinct from {@link TenantUnscopedCache} (which marks caches whose
+ * key space is structurally platform-wide). Reviewers see these two
+ * annotations and ask different questions:
+ *
+ * <ul>
+ *   <li>{@code @TenantUnscopedCache("kid is platform-unique")} — "confirm
+ *       the key space is truly global; no tenant data could leak."</li>
+ *   <li>{@code @TenantScopedByConstruction("composite PolicyKey(tenantId, policyId) + on-read verify at X.Y")}
+ *       — "confirm the composite key includes tenantId AND the read path
+ *       verifies the stored tenant matches the caller's."</li>
+ * </ul>
+ *
+ * <p>{@code FamilyCArchitectureTest} accepts either annotation on
+ * Caffeine fields in {@code *.service}, {@code *.api}, {@code *.security},
+ * {@code *.auth.*}. Unannotated Caffeine fields in those packages fail the
+ * build.
+ *
+ * <h2>Canonical example</h2>
+ *
+ * <pre>{@code
+ * @TenantScopedByConstruction("tenant-scoped by composite PolicyKey + on-read verification; Phase C task 4.4")
+ * private final Cache<PolicyKey, EscalationPolicy> policyByTenantAndId = Caffeine.newBuilder()
+ *         .maximumSize(500)
+ *         .expireAfterAccess(Duration.ofMinutes(10))
+ *         .recordStats()
+ *         .build();
+ * }</pre>
+ *
+ * <h2>Review gate</h2>
+ *
+ * Like {@link TenantUnscopedCache}, new introductions trigger
+ * {@code @ccradle} review via the CI grep job. Reviewer MUST verify both
+ * (a) the composite key includes tenantId, and (b) the read path has an
+ * explicit tenantId-match check.
+ *
+ * <h2>Design-c reference</h2>
+ *
+ * Per Phase C task 4.2+4.3+4.5 warroom (D-4.23-1 resolution): splitting
+ * {@code @TenantUnscopedCache} vs {@code @TenantScopedByConstruction} was
+ * chosen over a single overloaded annotation because the two categories
+ * answer different review questions with different failure modes.
+ * Conflating them under one name is the kind of thing Casey flags as
+ * legal-adjacent misleading documentation.
+ */
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TenantScopedByConstruction {
+
+    /**
+     * Human-readable explanation of how the cache is tenant-scoped by
+     * construction: (a) what the composite key shape is, and (b) where
+     * the on-read tenant verification happens. Must be non-empty at build
+     * time (enforced by {@code FamilyCArchitectureTest}).
+     *
+     * @return the justification string
+     */
+    String value();
+}

--- a/backend/src/main/java/org/fabt/shared/security/TenantUnscopedCache.java
+++ b/backend/src/main/java/org/fabt/shared/security/TenantUnscopedCache.java
@@ -1,0 +1,82 @@
+package org.fabt.shared.security;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a cache field or cache-access method as an intentional exception to
+ * the Phase C Family C rule that requires every application-layer cache to
+ * route through {@code TenantScopedCacheService}. Used ONLY for caches whose
+ * key space is structurally platform-wide or pre-authentication — e.g., JWT
+ * claims by globally-unique token hash, MFA JTI blocklist, kid-to-tenant
+ * resolution.
+ *
+ * <p>The justification string is required and must be non-empty. It becomes
+ * the reviewer's future-self documentation: why this cache is safe to
+ * bypass tenant scoping. {@code FamilyCArchitectureTest} enforces presence
+ * of the annotation on every Caffeine field in {@code org.fabt.*.service},
+ * {@code *.api}, {@code *.security}, {@code *.auth.*} and on every method
+ * that makes a raw {@code CacheService.get/put/evict} call from those
+ * packages.
+ *
+ * <h2>When to use</h2>
+ *
+ * Use {@code @TenantUnscopedCache} when ALL of the following hold:
+ * <ul>
+ *   <li>The cache key is globally unique by construction (e.g., SHA-256
+ *       token hash, opaque kid UUID, JTI UUID).</li>
+ *   <li>The cached values are keyed lookups only — tenant-bearing payloads
+ *       are not stored, or the payload itself carries the tenant discriminator
+ *       (resolved at use-site, not at cache-site).</li>
+ *   <li>A reviewer reading the justification can independently verify the
+ *       key-space claim without reading the surrounding code.</li>
+ * </ul>
+ *
+ * <p>Use {@link TenantScopedByConstruction} instead when the cache key is
+ * composite (e.g., {@code (tenantId, resourceId)}) and the cache IS
+ * tenant-scoped — just not via the {@code TenantScopedCacheService} wrapper
+ * because it uses a stronger typed key than a raw string.
+ *
+ * <h2>Example</h2>
+ * <pre>{@code
+ * @TenantUnscopedCache("JWT claims by token hash; token hash is globally unique")
+ * private final Cache<String, Claims> claimsCache = Caffeine.newBuilder()
+ *         .maximumSize(1000)
+ *         .expireAfterWrite(Duration.ofMinutes(5))
+ *         .build();
+ * }</pre>
+ *
+ * <h2>Review gate</h2>
+ *
+ * New {@code @TenantUnscopedCache} introductions trigger {@code @ccradle}
+ * review via a CI grep job on every PR diff. The author must defend the
+ * justification in review; the reviewer must confirm the key-space claim.
+ * See {@code .github/workflows/ci.yml} and {@code .github/CODEOWNERS} for
+ * the gate configuration.
+ *
+ * <h2>Non-goals</h2>
+ *
+ * This annotation does NOT disable tenant isolation for the annotated
+ * cache at runtime — it is a review-time documentation marker plus an
+ * ArchUnit-rule escape hatch. The annotated cache is still subject to all
+ * other platform controls (auth filters, RLS on underlying DB queries,
+ * etc.).
+ */
+@Target({ElementType.METHOD, ElementType.FIELD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+public @interface TenantUnscopedCache {
+
+    /**
+     * Human-readable explanation of why this cache is structurally safe to
+     * bypass tenant scoping. Must be non-empty at build time (enforced by
+     * {@code FamilyCArchitectureTest}). Named {@code value} so callers can
+     * use the positional shorthand {@code @TenantUnscopedCache("...")}.
+     *
+     * @return the justification string
+     */
+    String value();
+}

--- a/backend/src/test/java/org/fabt/architecture/FamilyCArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/architecture/FamilyCArchitectureTest.java
@@ -1,0 +1,348 @@
+package org.fabt.architecture;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaField;
+import com.tngtech.archunit.core.domain.JavaMethod;
+import com.tngtech.archunit.core.domain.JavaMethodCall;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.fabt.shared.security.TenantScopedByConstruction;
+import org.fabt.shared.security.TenantUnscopedCache;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.fields;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noMethods;
+
+/**
+ * ArchUnit Family C — cache-isolation guard. Introduced by Phase C tasks 4.2
+ * + 4.3 (basic rule + extended scope to all application-layer Caffeine
+ * fields). Per design-c D-C-3 + D-C-4 + D-4.23 warroom resolutions.
+ *
+ * <h2>Three rules</h2>
+ *
+ * <ol>
+ *   <li><b>C1 — Raw CacheService call-site guard.</b> Direct calls to
+ *       {@code CacheService.get/put/evict/evictAll/evictAllByPrefix} or
+ *       {@code TieredCacheService.get/put/evict/evictAll/evictAllByPrefix}
+ *       from classes in {@code *.service}, {@code *.api}, {@code *.security},
+ *       {@code *.auth.*} packages MUST originate from a method annotated
+ *       {@link TenantUnscopedCache} OR {@link TenantScopedByConstruction},
+ *       OR from the {@code TenantScopedCacheService} wrapper itself (exempt).
+ *       Routes all tenant-bearing cache traffic through the wrapper.</li>
+ *   <li><b>C2 — Spring cache-abstraction blocked outright.</b>
+ *       {@code @Cacheable}, {@code @CacheEvict}, {@code @CachePut} forbidden
+ *       in all {@code org.fabt} application classes. FABT uses zero today
+ *       (verified at Phase C kickoff); blocking them proactively prevents a
+ *       parallel caching pattern with its own CacheManager + CacheResolver
+ *       seams that would need a separate tenant-scoping story.</li>
+ *   <li><b>C3 — Caffeine field-type guard.</b> Every field typed
+ *       {@code com.github.benmanes.caffeine.cache.Cache} declared in classes
+ *       residing in {@code *.service}, {@code *.api}, {@code *.security},
+ *       {@code *.auth.*} MUST carry {@link TenantUnscopedCache} with a
+ *       non-empty justification OR {@link TenantScopedByConstruction} with
+ *       a non-empty justification. Exempt classes: {@code CaffeineCacheService}
+ *       and {@code TieredCacheService} (internal to the wrapper).</li>
+ * </ol>
+ *
+ * <h2>Rule C4 (deferred to task 4.6)</h2>
+ *
+ * The warroom flagged a gap: a developer who wants to skip Caffeine entirely
+ * and use {@code ConcurrentHashMap}/{@code Map}/{@code Set} as a cache could
+ * dodge Rule C3. Per D-4.23-4 that guard is deferred to task 4.6 as a
+ * separate heuristic rule (field name matches {@code .*[Cc]ache.*} or
+ * {@code .*[Bb]ucket.*} + typed {@code Map}/{@code Set}/{@code ConcurrentHashMap}
+ * in the scope packages). Not in this PR.
+ *
+ * <h2>Scope packages</h2>
+ *
+ * {@code *.service}, {@code *.api}, {@code *.security}, {@code *.auth.*}
+ * per design-c D-C-3. Expansion beyond the original spec's {@code *.service}
+ * captured 7 additional Caffeine fields outside that package (the full
+ * 10-field inventory + Phase C task 4.4's policyByTenantAndId = 11).
+ *
+ * @see TenantUnscopedCache
+ * @see TenantScopedByConstruction
+ */
+@DisplayName("ArchUnit Family C — cache-isolation guard")
+class FamilyCArchitectureTest {
+
+    private static final String CACHE_SERVICE_CLASS =
+            "org.fabt.shared.cache.CacheService";
+    private static final String TIERED_CACHE_SERVICE_CLASS =
+            "org.fabt.shared.cache.TieredCacheService";
+    private static final Set<String> CACHE_SERVICE_METHODS = Set.of(
+            "get", "put", "evict", "evictAll", "evictAllByPrefix");
+
+    /**
+     * Classes exempt from Rules C1 and C3 — wrapper implementations that
+     * legitimately access the cache abstraction directly.
+     */
+    private static final Set<String> EXEMPT_CLASSES = Set.of(
+            "org.fabt.shared.cache.TenantScopedCacheService",
+            "org.fabt.shared.cache.CaffeineCacheService",
+            "org.fabt.shared.cache.TieredCacheService");
+
+    /**
+     * <b>Pending-migration allowlist for Rule C1.</b> Each entry is
+     * {@code SimpleClassName.methodName} of a pre-Phase-C call site that
+     * manually embeds {@code tenantId} in its cache key (per design-c D-C-1:
+     * "existing 7 call sites already manually embed tenantId in the cache key").
+     * These sites are tenant-safe TODAY — they just aren't routed through
+     * {@code TenantScopedCacheService} yet.
+     *
+     * <p><b>Task 4.b migration contract:</b> each migration MUST remove the
+     * corresponding entry from this set. The rule will go red if a new site
+     * is added without an annotation OR the allowlist entry isn't removed
+     * when the site migrates. Zero-entry state at task 4.b completion is
+     * the visible signal that 4.b is done.
+     *
+     * <p>Format: {@code SimpleClassName.methodName}. Per-method granularity —
+     * a method may contain multiple {@code get/put/evict} calls; the entry
+     * exempts the whole method.
+     */
+    private static final Set<String> PENDING_MIGRATION_SITES = Set.of(
+            // AnalyticsService — 6 methods, each with get/put per event-type
+            // composite-keyed lookup. Task 4.b migrates these to
+            // tenantScopedCacheService.get/put with the caller stripping the
+            // leading tenantId from the key.
+            "AnalyticsService.getUtilization",
+            "AnalyticsService.getDemand",
+            "AnalyticsService.getCapacity",
+            "AnalyticsService.getDvSummary",
+            "AnalyticsService.getGeographic",
+            "AnalyticsService.getHmisHealth",
+            // BedSearchService — 1 method with get/put. Key is
+            // tenantId.toString() (pure tenant cache); task 4.b migrates
+            // with caller stripping the leading tenantId so the wrapper's
+            // prefix isn't double-applied.
+            "BedSearchService.doSearch",
+            // AvailabilityService — 3 evict calls. Two by tenantId
+            // (SHELTER_AVAILABILITY + SHELTER_LIST), one by shelterId
+            // (SHELTER_PROFILE). Migration note (design-c D-C-1, D-4.1-5):
+            // the shelterId-keyed evict is safe under wrapper because the
+            // caller's TenantContext is the shelter's own tenant.
+            "AvailabilityService.createSnapshot",
+            // ShelterService — 2 evict calls in evictTenantShelterCaches,
+            // called from the tenant-lifecycle cleanup path. Task 4.b
+            // candidate: consider replacing with
+            // tenantScopedCacheService.invalidateTenant(UUID).
+            "ShelterService.evictTenantShelterCaches"
+    );
+
+    private static final String SCOPE_PKG_SERVICE = "..service..";
+    private static final String SCOPE_PKG_API = "..api..";
+    private static final String SCOPE_PKG_SECURITY = "..security..";
+    private static final String SCOPE_PKG_AUTH = "..auth..";
+
+    private static com.tngtech.archunit.core.domain.JavaClasses importMain() {
+        return new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("org.fabt..");
+    }
+
+    // -------------------------------------------------------------------
+    // Rule C1 — Raw CacheService call sites require justification
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("C1: CacheService.{get,put,evict,*} call sites require @TenantUnscopedCache/@TenantScopedByConstruction or wrapper")
+    void c1_cacheServiceCallSite_requiresJustification() {
+        ArchRule rule = methods()
+                .that().areDeclaredInClassesThat().resideInAnyPackage(
+                        SCOPE_PKG_SERVICE, SCOPE_PKG_API, SCOPE_PKG_SECURITY, SCOPE_PKG_AUTH)
+                .and().areNotAnnotatedWith(TenantUnscopedCache.class)
+                .and().areNotAnnotatedWith(TenantScopedByConstruction.class)
+                .should(notCallRawCacheService());
+
+        rule.check(importMain());
+    }
+
+    private static ArchCondition<JavaMethod> notCallRawCacheService() {
+        return new ArchCondition<>("not call CacheService.{get,put,evict,evictAll,evictAllByPrefix} without @TenantUnscopedCache or @TenantScopedByConstruction justification") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                String ownerFqn = method.getOwner().getName();
+                if (EXEMPT_CLASSES.contains(ownerFqn)) {
+                    return;
+                }
+                String siteKey = method.getOwner().getSimpleName() + "." + method.getName();
+                if (PENDING_MIGRATION_SITES.contains(siteKey)) {
+                    return;
+                }
+                for (JavaMethodCall call : method.getMethodCallsFromSelf()) {
+                    if (!CACHE_SERVICE_METHODS.contains(call.getName())) continue;
+                    JavaClass callTargetOwner = call.getTarget().getOwner();
+                    if (!isCacheServiceType(callTargetOwner)) continue;
+                    events.add(SimpleConditionEvent.violated(method,
+                            method.getFullName() + " calls " + callTargetOwner.getSimpleName()
+                                    + "." + call.getName() + "() at "
+                                    + call.getSourceCodeLocation()
+                                    + " — annotate the method with "
+                                    + "@TenantUnscopedCache(\"justification\") or "
+                                    + "@TenantScopedByConstruction(\"justification\"), "
+                                    + "route through TenantScopedCacheService, OR "
+                                    + "add the method name to "
+                                    + "FamilyCArchitectureTest.PENDING_MIGRATION_SITES "
+                                    + "if this is a known pre-Phase-C site awaiting "
+                                    + "task 4.b migration"));
+                }
+            }
+        };
+    }
+
+    private static boolean isCacheServiceType(JavaClass cls) {
+        if (cls.getName().equals(CACHE_SERVICE_CLASS)) return true;
+        if (cls.getName().equals(TIERED_CACHE_SERVICE_CLASS)) return true;
+        // Any subtype/impl of CacheService (e.g. CaffeineCacheService) also counts.
+        for (JavaClass supertype : cls.getAllRawInterfaces()) {
+            if (supertype.getName().equals(CACHE_SERVICE_CLASS)) return true;
+        }
+        return false;
+    }
+
+    // -------------------------------------------------------------------
+    // Rule C2 — Spring @Cacheable/@CacheEvict/@CachePut blocked outright
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("C2: Spring @Cacheable / @CacheEvict / @CachePut blocked in all org.fabt classes")
+    void c2_springCacheAnnotations_blocked() {
+        ArchRule rule = noMethods()
+                .that().areDeclaredInClassesThat().resideInAPackage("org.fabt..")
+                .should().beAnnotatedWith("org.springframework.cache.annotation.Cacheable")
+                .orShould().beAnnotatedWith("org.springframework.cache.annotation.CacheEvict")
+                .orShould().beAnnotatedWith("org.springframework.cache.annotation.CachePut")
+                .because("FABT uses zero Spring cache-abstraction annotations today — "
+                        + "introducing them would create a parallel caching pattern with "
+                        + "its own CacheManager + CacheResolver seams that would need a "
+                        + "separate tenant-scoping story. Use TenantScopedCacheService "
+                        + "(preferred) or directly-annotated Caffeine fields with "
+                        + "@TenantUnscopedCache / @TenantScopedByConstruction justification. "
+                        + "Design-c D-C-4.");
+
+        rule.check(importMain());
+    }
+
+    // -------------------------------------------------------------------
+    // Rule C3 — Caffeine field-type guard
+    // -------------------------------------------------------------------
+
+    @Test
+    @DisplayName("C3: Caffeine Cache fields in *.service/*.api/*.security/*.auth.* must be annotated @TenantUnscopedCache or @TenantScopedByConstruction")
+    void c3_caffeineFields_requireJustification() {
+        ArchRule rule = fields()
+                .that().haveRawType(Cache.class)
+                .and().areDeclaredInClassesThat().resideInAnyPackage(
+                        SCOPE_PKG_SERVICE, SCOPE_PKG_API, SCOPE_PKG_SECURITY, SCOPE_PKG_AUTH)
+                .should(beAnnotatedWithNonEmptyCacheJustification());
+
+        rule.check(importMain());
+    }
+
+    // -------------------------------------------------------------------
+    // Negative tests — fixtures in org.fabt.architecture.fixtures.cache
+    // assert each rule fires on the intentional violation pattern.
+    // Warroom Riley add: 3 fixtures covering C1 bypass (not needed — C1
+    // already has live positive via the SAFE_SITES), C2 (@Cacheable),
+    // C3 unannotated + C3 empty-justification.
+    // -------------------------------------------------------------------
+
+    private static com.tngtech.archunit.core.domain.JavaClasses importFixtures() {
+        return new ClassFileImporter()
+                .importPackages("org.fabt.architecture.fixtures.cache");
+    }
+
+    @Test
+    @DisplayName("C2 negative: @Cacheable on fixture method triggers violation")
+    void c2_negative_springCacheableFiresRule() {
+        ArchRule rule = noMethods()
+                .that().areDeclaredInClassesThat().resideInAPackage("org.fabt..")
+                .should().beAnnotatedWith("org.springframework.cache.annotation.Cacheable")
+                .orShould().beAnnotatedWith("org.springframework.cache.annotation.CacheEvict")
+                .orShould().beAnnotatedWith("org.springframework.cache.annotation.CachePut");
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> rule.check(importFixtures()))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("SpringCacheableFixture");
+    }
+
+    @Test
+    @DisplayName("C3 negative: unannotated Caffeine field triggers violation")
+    void c3_negative_unannotatedCaffeineFiresRule() {
+        ArchRule rule = fields()
+                .that().haveRawType(Cache.class)
+                .and().areDeclaredInClassesThat().resideInAPackage("org.fabt.architecture.fixtures.cache..")
+                .should(beAnnotatedWithNonEmptyCacheJustification());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> rule.check(importFixtures()))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("UnannotatedCaffeineFixture");
+    }
+
+    @Test
+    @DisplayName("C3 negative: empty-justification @TenantUnscopedCache triggers violation")
+    void c3_negative_emptyJustificationFiresRule() {
+        ArchRule rule = fields()
+                .that().haveRawType(Cache.class)
+                .and().areDeclaredInClassesThat().resideInAPackage("org.fabt.architecture.fixtures.cache..")
+                .should(beAnnotatedWithNonEmptyCacheJustification());
+
+        org.assertj.core.api.Assertions.assertThatThrownBy(() -> rule.check(importFixtures()))
+                .isInstanceOf(AssertionError.class)
+                .hasMessageContaining("EmptyJustificationFixture");
+    }
+
+    // -------------------------------------------------------------------
+    // Shared condition used by Rule C3 + negative tests above
+    // -------------------------------------------------------------------
+
+    private static ArchCondition<JavaField> beAnnotatedWithNonEmptyCacheJustification() {
+        return new ArchCondition<>("be annotated with @TenantUnscopedCache or @TenantScopedByConstruction carrying a non-empty justification") {
+            @Override
+            public void check(JavaField field, ConditionEvents events) {
+                String ownerFqn = field.getOwner().getName();
+                if (EXEMPT_CLASSES.contains(ownerFqn)) {
+                    return;
+                }
+                boolean annotated = false;
+                String value = null;
+                if (field.isAnnotatedWith(TenantUnscopedCache.class)) {
+                    annotated = true;
+                    value = field.getAnnotationOfType(TenantUnscopedCache.class).value();
+                } else if (field.isAnnotatedWith(TenantScopedByConstruction.class)) {
+                    annotated = true;
+                    value = field.getAnnotationOfType(TenantScopedByConstruction.class).value();
+                }
+                if (!annotated) {
+                    events.add(SimpleConditionEvent.violated(field,
+                            "Caffeine Cache field " + ownerFqn + "." + field.getName()
+                                    + " at " + field.getSourceCodeLocation()
+                                    + " is NOT annotated with @TenantUnscopedCache or "
+                                    + "@TenantScopedByConstruction — add one with a non-empty "
+                                    + "justification string explaining why tenant scoping would "
+                                    + "be incorrect for this cache, OR route through "
+                                    + "TenantScopedCacheService"));
+                    return;
+                }
+                if (value == null || value.isBlank()) {
+                    events.add(SimpleConditionEvent.violated(field,
+                            "Caffeine Cache field " + ownerFqn + "." + field.getName()
+                                    + " at " + field.getSourceCodeLocation()
+                                    + " has an EMPTY justification string — the annotation "
+                                    + "value must explain why tenant scoping would be incorrect "
+                                    + "for this cache (reviewer needs to verify the key-space "
+                                    + "claim)"));
+                }
+            }
+        };
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/FamilyCArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/architecture/FamilyCArchitectureTest.java
@@ -92,11 +92,13 @@ class FamilyCArchitectureTest {
             "org.fabt.shared.cache.TieredCacheService");
 
     /**
-     * <b>Pending-migration allowlist for Rule C1.</b> Each entry is
-     * {@code SimpleClassName.methodName} of a pre-Phase-C call site that
-     * manually embeds {@code tenantId} in its cache key (per design-c D-C-1:
-     * "existing 7 call sites already manually embed tenantId in the cache key").
-     * These sites are tenant-safe TODAY — they just aren't routed through
+     * <b>Pending-migration allowlist for Rule C1.</b> Each entry is the
+     * fully-qualified {@code <package>.<ClassName>.<methodName>} of a
+     * pre-Phase-C call site that manually embeds {@code tenantId} in its
+     * cache key (per design-c D-C-1: "existing 7 call sites already manually
+     * embed tenantId in the cache key" — actual inventory is 10 methods,
+     * spec-drift noted in warroom 2026-04-19 PM). These sites are
+     * tenant-safe TODAY — they just aren't routed through
      * {@code TenantScopedCacheService} yet.
      *
      * <p><b>Task 4.b migration contract:</b> each migration MUST remove the
@@ -105,37 +107,40 @@ class FamilyCArchitectureTest {
      * when the site migrates. Zero-entry state at task 4.b completion is
      * the visible signal that 4.b is done.
      *
-     * <p>Format: {@code SimpleClassName.methodName}. Per-method granularity —
-     * a method may contain multiple {@code get/put/evict} calls; the entry
-     * exempts the whole method.
+     * <p><b>FQN format</b> (not SimpleClassName) per warroom PR #137
+     * post-commit review (Marcus hardening): prevents cross-package
+     * class-name collisions from silently leaking an exemption between
+     * two classes that happen to share a simple name. Per-method
+     * granularity — a method may contain multiple {@code get/put/evict}
+     * calls; the entry exempts the whole method.
      */
     private static final Set<String> PENDING_MIGRATION_SITES = Set.of(
             // AnalyticsService — 6 methods, each with get/put per event-type
             // composite-keyed lookup. Task 4.b migrates these to
             // tenantScopedCacheService.get/put with the caller stripping the
             // leading tenantId from the key.
-            "AnalyticsService.getUtilization",
-            "AnalyticsService.getDemand",
-            "AnalyticsService.getCapacity",
-            "AnalyticsService.getDvSummary",
-            "AnalyticsService.getGeographic",
-            "AnalyticsService.getHmisHealth",
+            "org.fabt.analytics.service.AnalyticsService.getUtilization",
+            "org.fabt.analytics.service.AnalyticsService.getDemand",
+            "org.fabt.analytics.service.AnalyticsService.getCapacity",
+            "org.fabt.analytics.service.AnalyticsService.getDvSummary",
+            "org.fabt.analytics.service.AnalyticsService.getGeographic",
+            "org.fabt.analytics.service.AnalyticsService.getHmisHealth",
             // BedSearchService — 1 method with get/put. Key is
             // tenantId.toString() (pure tenant cache); task 4.b migrates
             // with caller stripping the leading tenantId so the wrapper's
             // prefix isn't double-applied.
-            "BedSearchService.doSearch",
+            "org.fabt.availability.service.BedSearchService.doSearch",
             // AvailabilityService — 3 evict calls. Two by tenantId
             // (SHELTER_AVAILABILITY + SHELTER_LIST), one by shelterId
             // (SHELTER_PROFILE). Migration note (design-c D-C-1, D-4.1-5):
             // the shelterId-keyed evict is safe under wrapper because the
             // caller's TenantContext is the shelter's own tenant.
-            "AvailabilityService.createSnapshot",
+            "org.fabt.availability.service.AvailabilityService.createSnapshot",
             // ShelterService — 2 evict calls in evictTenantShelterCaches,
             // called from the tenant-lifecycle cleanup path. Task 4.b
             // candidate: consider replacing with
             // tenantScopedCacheService.invalidateTenant(UUID).
-            "ShelterService.evictTenantShelterCaches"
+            "org.fabt.shelter.service.ShelterService.evictTenantShelterCaches"
     );
 
     private static final String SCOPE_PKG_SERVICE = "..service..";
@@ -174,7 +179,10 @@ class FamilyCArchitectureTest {
                 if (EXEMPT_CLASSES.contains(ownerFqn)) {
                     return;
                 }
-                String siteKey = method.getOwner().getSimpleName() + "." + method.getName();
+                // FQN format per warroom PR #137 hardening (Marcus):
+                // <fully.qualified.ClassName>.<methodName>. Prevents cross-
+                // package simple-name collisions.
+                String siteKey = method.getOwner().getName() + "." + method.getName();
                 if (PENDING_MIGRATION_SITES.contains(siteKey)) {
                     return;
                 }

--- a/backend/src/test/java/org/fabt/architecture/fixtures/cache/EmptyJustificationFixture.java
+++ b/backend/src/test/java/org/fabt/architecture/fixtures/cache/EmptyJustificationFixture.java
@@ -1,0 +1,31 @@
+package org.fabt.architecture.fixtures.cache;
+
+import java.time.Duration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.fabt.shared.security.TenantUnscopedCache;
+
+/**
+ * Negative-test fixture for {@code FamilyCArchitectureTest} Rule C3.
+ *
+ * <p>This fixture annotates its Caffeine field with
+ * {@code @TenantUnscopedCache("")} — empty string justification. Rule C3
+ * MUST fire on empty-or-blank justification strings because the annotation
+ * is the reviewer's documentation: an empty string provides zero defense
+ * at review time.
+ *
+ * <p>DO NOT fill in the justification. That would defeat the fixture.
+ */
+public class EmptyJustificationFixture {
+
+    // Intentionally empty justification — the negative test asserts Rule C3 fires.
+    @TenantUnscopedCache("")
+    private final Cache<String, String> cache = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .build();
+
+    public String get(String key) {
+        return cache.getIfPresent(key);
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/fixtures/cache/SpringCacheableFixture.java
+++ b/backend/src/test/java/org/fabt/architecture/fixtures/cache/SpringCacheableFixture.java
@@ -1,0 +1,24 @@
+package org.fabt.architecture.fixtures.cache;
+
+import org.springframework.cache.annotation.Cacheable;
+
+/**
+ * Negative-test fixture for {@code FamilyCArchitectureTest} Rule C2.
+ *
+ * <p>Placed in {@code org.fabt.architecture.fixtures.cache} (outside the
+ * production scan scope of Rule C2 which scans {@code org.fabt..}, except
+ * the test fixtures should not be picked up because the production scan
+ * uses {@code ImportOption.DoNotIncludeTests}). The negative test invokes
+ * Rule C2 against an explicit ClassFileImporter that DOES include this
+ * test-tree sub-package and asserts the rule fires.
+ *
+ * <p>DO NOT remove the {@code @Cacheable} annotation from this method.
+ */
+public class SpringCacheableFixture {
+
+    // Intentionally annotated @Cacheable — the negative test asserts Rule C2 fires.
+    @Cacheable("fixture-cache")
+    public String lookup(String key) {
+        return "value:" + key;
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/fixtures/cache/UnannotatedCaffeineFixture.java
+++ b/backend/src/test/java/org/fabt/architecture/fixtures/cache/UnannotatedCaffeineFixture.java
@@ -1,0 +1,35 @@
+package org.fabt.architecture.fixtures.cache;
+
+import java.time.Duration;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+/**
+ * Negative-test fixture for {@code FamilyCArchitectureTest} Rule C3.
+ *
+ * <p>This class is intentionally placed in {@code org.fabt.architecture.fixtures.cache}
+ * (NOT in any of the Family C scope packages: {@code *.service}, {@code *.api},
+ * {@code *.security}, {@code *.auth.*}) so the production Rule C3 does NOT scan
+ * it and the build stays green. The negative test imports this package
+ * explicitly and runs Rule C3 against it, asserting the rule fires as
+ * expected.
+ *
+ * <p>This fixture has an UNANNOTATED Caffeine cache field — Rule C3 must
+ * produce a violation when scoped to this package.
+ *
+ * <p>DO NOT add {@code @TenantUnscopedCache} or
+ * {@code @TenantScopedByConstruction} to this field; that would defeat the
+ * fixture's purpose.
+ */
+public class UnannotatedCaffeineFixture {
+
+    // Intentionally unannotated — the negative test asserts Rule C3 fires.
+    private final Cache<String, String> cache = Caffeine.newBuilder()
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .build();
+
+    public String get(String key) {
+        return cache.getIfPresent(key);
+    }
+}


### PR DESCRIPTION
## Summary

Phase C Family C cache-isolation guard. Three rules, two annotations, 11 field annotations, CODEOWNERS, PR template, and CI review-auto-request job — landed atomically per D-4.23-5 warroom.

- **`@TenantUnscopedCache`** (10 fields) — caches with structurally platform-wide key space (JWT token hash, MFA JTI, opaque kid, pre-auth slug).
- **`@TenantScopedByConstruction`** (1 field: `policyByTenantAndId` from 4.4) — composite `(tenantId, policyId)` key + on-read verify with `CROSS_TENANT_POLICY_READ` audit.
- **Rule C1** — raw `CacheService.get/put/evict` call sites require one of the annotations, the `TenantScopedCacheService` wrapper, or an explicit `PENDING_MIGRATION_SITES` allowlist entry. 10 pre-Phase-C sites pre-populated (task 4.b migrates these; removing each entry is the visible signal that 4.b is done).
- **Rule C2** — Spring `@Cacheable`/`@CacheEvict`/`@CachePut` blocked outright (FABT uses zero today).
- **Rule C3** — Caffeine `Cache<*>` field-type guard (Sam's perf note: field-scan by type, not `newBuilder()` call-site).
- **3 negative-test fixtures** (Riley warroom add) in `org.fabt.architecture.fixtures.cache` proving each rule fires on the intentional violation.
- **CI grep job** `family-c-annotation-review-gate` — detects new `@TenantUnscopedCache` / `@TenantScopedByConstruction` usages in the PR diff (excluding annotation-definition files), posts PR comment, auto-requests `@ccradle` review (D-4.23-2: CODEOWNERS is path-based, this is the diff-content-based complement).

## Warroom plan review

Plan went through warroom (D-4.23-1 through D-4.23-5). All 5 resolutions folded in:
- Split `@TenantUnscopedCache` + `@TenantScopedByConstruction` (D-4.23-1 pick-alternative)
- CI grep job + keep CODEOWNERS line (D-4.23-2 pick-alternative)
- Rule C3 scans fields by type, not `newBuilder()` call sites (Sam)
- 3 negative-test fixtures (Riley)
- Rule C4 (ConcurrentHashMap-as-cache heuristic, Marcus gap) deferred to task 4.6 (filed as #182)

## Test plan

- [x] `FamilyCArchitectureTest` — 6 tests (3 positive + 3 negative), all green
- [x] Full architecture suite `*Architecture*` — 35/35 green
- [x] `EscalationPolicyServiceTest` — 28/28 green (no regression from 4.4)
- [x] `AuditEventTypesTest` — 12/12 green
- [x] **Combined local run: 78/78 green, 0 failures**
- [x] Local compile clean, no unused imports

## Not in this PR

- **Task 4.6** — Rule C4 (ConcurrentHashMap/Map/Set-as-cache heuristic). Filed as task #182.
- **Task 4.7** — negative-cache guardrail (ArchUnit rule on `put(..., null, ...)`). Independent small slice.
- **Task 4.6 (reflection-driven bleed test)** — next Phase C item after 4.7.
- **Task 4.b** — migrate the 10 `PENDING_MIGRATION_SITES` entries. **This is the load-bearing piece** — when 4.b lands, each migrated call site routes through `TenantScopedCacheService`, the allowlist entry is removed, and cache isolation becomes a live defence in production.

## Ship unit

Atomic single commit (D-4.23-5). 16 files, 751 insertions. Annotation + rule + field annotations + CODEOWNERS + PR template + CI job all land at the same SHA — CI runs once against the combined state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)