### PR TITLE
test(cache): CacheIsolationDiscoveryTest — Phase C task 4.6

### DIFF
--- a/backend/src/test/java/org/fabt/architecture/CacheIsolationDiscoveryTest.java
+++ b/backend/src/test/java/org/fabt/architecture/CacheIsolationDiscoveryTest.java
@@ -1,0 +1,254 @@
+package org.fabt.architecture;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Stream;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.syntax.ArchRuleDefinition;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.shared.cache.CacheNames;
+import org.fabt.shared.cache.TenantScopedCacheService;
+import org.fabt.shared.web.TenantContext;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Phase C task 4.6 — automated discovery of every cache name in the FABT
+ * inventory plus a legitimate-isolation round-trip per cache.
+ *
+ * <h2>What this test exists to catch</h2>
+ *
+ * Task 4.b drained {@code PENDING_MIGRATION_SITES} by hand-migrating 9
+ * call sites. The next regression is NOT another forgotten migration — it
+ * is a <em>new</em> cache name added to {@link CacheNames} without
+ * wrapper wiring OR without a matching isolation contract. That regression
+ * would slip past {@code FamilyCArchitectureTest}'s rules (which check
+ * call-site annotations, not per-cache-name isolation) and past the
+ * hand-written matrices in {@code Task4bCacheHitRateTest} and
+ * {@code Tenant4bMigrationCrossTenantAttackTest} (which enumerate 7 and
+ * 8 specific cache names respectively).
+ *
+ * <p>This test discovers every {@code CacheNames} constant via reflection
+ * and, for each, asserts the legitimate-isolation triple:
+ * <ol>
+ *   <li>{@code tenantA.put(k, v)}</li>
+ *   <li>{@code tenantA.get(k)} → HIT (precondition — wrapper actually stored it)</li>
+ *   <li>{@code tenantB.get(k)} → MISS (isolation — tenantB's prefix slot is empty)</li>
+ * </ol>
+ *
+ * <p>A new {@code CacheNames} constant added without a matching
+ * wrapper-write path will pass row-3 (empty MISS on both sides) but fail
+ * row-2 (nothing stored) — the test surfaces the gap loudly.
+ *
+ * <h2>Why "reflection" = ArchUnit, not {@code org.reflections}</h2>
+ *
+ * The task spec says "reflection-driven discovery" to mean "automated
+ * discovery that adapts to future additions." Java's
+ * {@code java.lang.reflect.*} API covers field/method/annotation
+ * discovery but not bytecode-level call-site graphs. ArchUnit's
+ * {@code JavaMethodCall} primitives do that — and the project already
+ * depends on ArchUnit (see {@code FamilyCArchitectureTest}). This test
+ * uses plain {@code Class.getFields()} for {@code CacheNames} constant
+ * discovery (sufficient — it's field discovery, not call-site) and
+ * ArchUnit for the zero-{@code @Cacheable} companion assertion (the
+ * positive-discovery mirror of Family C rule C2).
+ *
+ * <h2>Silent-empty guard</h2>
+ *
+ * Per {@code feedback_never_skip_silently.md} + design-c D-C-7: a
+ * classloader misconfiguration can cause discovery to silently return
+ * an empty set, which a naive "iterate and assert each" test passes
+ * vacuously. The {@link #discoverySatisfiesFloor()} test asserts a
+ * minimum count (8) below which we are confident the discovery itself
+ * broke. The "exactly the expected count" pin is at 11 (the
+ * {@code CacheNames} inventory at Phase C kickoff); the floor is 8 so
+ * a partial-discovery failure mode is loud without being brittle to
+ * legitimate future additions.
+ *
+ * <h2>Warroom authority</h2>
+ *
+ * Plan warroom 2026-04-19 night (Alex + Marcus + Sam + Riley + Jordan +
+ * Casey + Elena): 5 GREEN / 2 YELLOW verdicts; implementation picks —
+ * ArchUnit over {@code org.reflections}, count = {@code CacheNames}
+ * constants (not caller methods — legitimate refactors would churn that
+ * number), {@code @ParameterizedTest + @MethodSource} over
+ * {@code @TestFactory} (which silent-passes on empty iterables).
+ */
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DisplayName("Phase C task 4.6 — cache-isolation discovery across every CacheNames constant")
+class CacheIsolationDiscoveryTest extends BaseIntegrationTest {
+
+    /**
+     * Silent-empty floor per design-c D-C-7. Below this the discovery
+     * itself is suspect — 11 constants in {@link CacheNames} today,
+     * 8 floor accommodates a legitimate removal-of-one while still
+     * detecting a half-scan classloader misconfig.
+     */
+    private static final int DISCOVERY_FLOOR = 8;
+
+    /**
+     * Exact count at Phase C kickoff (post-4.b). Any change — add or
+     * remove — requires bumping this pin AND updating per-cache tests
+     * in {@code Task4bCacheHitRateTest} +
+     * {@code Tenant4bMigrationCrossTenantAttackTest}. Exact equality
+     * (not {@code >=}) is deliberate: the JavaDoc on
+     * {@link #discoveryMatchesExpectedMinimum} promises the pin fires as
+     * a reminder on additions; a {@code >=} assertion silently accepts
+     * new constants and defeats that promise.
+     */
+    private static final int EXPECTED_SITES = 11;
+
+    private static final UUID TENANT_A = UUID.fromString("4c000000-a000-0000-0000-000000000001");
+    private static final UUID TENANT_B = UUID.fromString("4c000000-b000-0000-0000-000000000002");
+
+    private static List<String> discoveredCacheNames;
+
+    @Autowired
+    private TenantScopedCacheService wrapper;
+
+    @BeforeAll
+    void discoverCacheNames() throws IllegalAccessException {
+        List<String> names = new ArrayList<>();
+        for (Field f : CacheNames.class.getFields()) {
+            if (Modifier.isStatic(f.getModifiers())
+                    && Modifier.isPublic(f.getModifiers())
+                    && String.class.equals(f.getType())) {
+                names.add((String) f.get(null));
+            }
+        }
+        discoveredCacheNames = List.copyOf(names);
+    }
+
+    static Stream<String> cacheNameRows() {
+        // Belt-and-suspenders: if @BeforeAll hasn't run (classloader skew) or
+        // the list is empty, JUnit throws PreconditionViolationException when
+        // @MethodSource returns an empty stream — loud failure. The explicit
+        // guard test below catches partial-discovery (e.g. half the fields
+        // loaded).
+        return discoveredCacheNames == null ? Stream.empty() : discoveredCacheNames.stream();
+    }
+
+    @Test
+    @DisplayName("Discovery floor — at least 8 CacheNames constants found (silent-empty guard)")
+    void discoverySatisfiesFloor() {
+        assertThat(discoveredCacheNames)
+                .as("CacheNames reflection discovery must find at least %d constants. "
+                        + "Fewer means either (a) the reflection mechanism broke "
+                        + "(classloader misconfig, Reflections library skew) OR "
+                        + "(b) someone removed half the cache-name inventory without "
+                        + "updating DISCOVERY_FLOOR. Either way, fail loud — "
+                        + "feedback_never_skip_silently.md.",
+                        DISCOVERY_FLOOR)
+                .hasSizeGreaterThanOrEqualTo(DISCOVERY_FLOOR);
+    }
+
+    @Test
+    @DisplayName("Expected-count pin — CacheNames inventory matches Phase C kickoff exactly")
+    void discoveryMatchesExpectedCount() {
+        // Exact equality, NOT >=, per Riley post-commit warroom. The pin
+        // fires BOTH directions: a reduction needs design-c doc update; an
+        // addition requires bumping EXPECTED_SITES + adding per-cache tests
+        // to Task4bCacheHitRateTest + Tenant4bMigrationCrossTenantAttackTest.
+        // A >= assertion would silently accept new constants without the
+        // reminder, defeating the promise in the class-level Javadoc.
+        assertThat(discoveredCacheNames)
+                .as("CacheNames inventory must match Phase C kickoff pin of %d "
+                        + "exactly. If the count changed: (a) verify intent with "
+                        + "the team, (b) update EXPECTED_SITES to the new value, "
+                        + "(c) add a matching row to Task4bCacheHitRateTest and "
+                        + "Tenant4bMigrationCrossTenantAttackTest for each new "
+                        + "constant (or remove rows for removed constants).",
+                        EXPECTED_SITES)
+                .hasSize(EXPECTED_SITES);
+    }
+
+    @Test
+    @DisplayName("Positive mirror of C2 — zero @Cacheable methods in org.fabt")
+    void zeroSpringCacheableMethodsInOrgFabt() {
+        // Positive-discovery companion to FamilyCArchitectureTest rule C2
+        // (which is a `noMethods().should().beAnnotatedWith(...)` block — a
+        // negative rule). This runs the affirmative scan: actively enumerate
+        // any @Cacheable method and count them. Zero today; the C2 rule
+        // keeps it at zero, and this test pins the count from the positive
+        // side so an ArchUnit rule-regression (e.g., scope package typo)
+        // doesn't silently re-admit @Cacheable.
+        JavaClasses classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("org.fabt");
+
+        // If import returned empty, something is badly wrong.
+        assertThat(classes.size())
+                .as("ArchUnit import of org.fabt returned zero classes — "
+                        + "classpath / classloader misconfig.")
+                .isGreaterThan(50);
+
+        ArchRuleDefinition.noMethods()
+                .that().areDeclaredInClassesThat().resideInAPackage("org.fabt..")
+                .should().beAnnotatedWith("org.springframework.cache.annotation.Cacheable")
+                .because("Family C rule C2 forbids Spring @Cacheable; this test "
+                        + "is the positive-discovery mirror so a rule-scope typo "
+                        + "(e.g., resideInAPackage with a bad glob) cannot silently "
+                        + "re-admit @Cacheable without tripping a second test.")
+                .check(classes);
+    }
+
+    @ParameterizedTest(name = "Cache isolation on {0}: A writes → A hits → B misses")
+    @MethodSource("cacheNameRows")
+    void cacheIsolationRoundTrip(String cacheName) {
+        // Per-cache isolation contract:
+        //   1. Tenant A put
+        //   2. Tenant A get → HIT (precondition — wrapper actually stored it)
+        //   3. Tenant B get (same logical key) → MISS (isolation — B's prefix slot empty)
+        //
+        // A new CacheNames constant added without wrapper-compatible behaviour
+        // fails step 2 (empty Optional when the test expected .isPresent()).
+        // A wrapper isolation regression fails step 3 (B unexpectedly sees A's
+        // entry).
+        String key = "isolation-probe-" + cacheName;
+        String payload = "probe-value-for-" + cacheName;
+
+        // Step 1 + 2: tenant A round-trip.
+        TenantContext.runWithContext(TENANT_A, true, () -> {
+            wrapper.put(cacheName, key, payload, Duration.ofSeconds(60));
+
+            var hit = wrapper.get(cacheName, key, String.class);
+            assertThat(hit)
+                    .as("%s: tenant A's own read after put must be a HIT. "
+                            + "Miss = wrapper key-stability regression (put-key vs "
+                            + "get-key drift) OR wrapper short-circuit that skipped "
+                            + "the put.", cacheName)
+                    .isPresent()
+                    .hasValue(payload);
+        });
+
+        // Step 3: tenant B under same logical key.
+        TenantContext.runWithContext(TENANT_B, true, () -> {
+            var miss = wrapper.get(cacheName, key, String.class);
+            assertThat(miss)
+                    .as("%s: tenant B reading the SAME logical key must be a MISS. "
+                            + "Hit = cross-tenant leak — wrapper's prefix is no longer "
+                            + "per-tenant. Load-bearing 4.b isolation invariant.",
+                            cacheName)
+                    .isEmpty();
+        });
+
+        // Cleanup — evict tenant A's entry so parametrized rows don't interfere.
+        TenantContext.runWithContext(TENANT_A, true, () ->
+                wrapper.evict(cacheName, key));
+    }
+}

--- a/deploy/prometheus/phase-c-cache-isolation.rules.yml
+++ b/deploy/prometheus/phase-c-cache-isolation.rules.yml
@@ -173,3 +173,45 @@ groups:
             wrapper emits `fabt.cache.put` at the same cache-name
             rate — a put-counter that stayed flat while get-misses
             rose means the put path itself broke.
+
+      # ---- WARN — DetachedAuditPersister persist failure --------------
+      # Added 2026-04-19 night per pre-release warroom Marcus #4.
+      # DetachedAuditPersister wraps security-evidence audit writes in
+      # PROPAGATION_REQUIRES_NEW so the row survives the caller's
+      # rollback (the leading attack vector: trigger cross-tenant read
+      # inside a @Transactional endpoint + rely on rollback to erase
+      # the audit trail). The persister catches any persistence
+      # exception and logs loudly rather than re-throwing (re-throwing
+      # would mask the original IllegalStateException). The counter
+      # below fires when that swallow happens — we lose a
+      # security-evidence audit row. Triage urgency parallels
+      # fabt.audit.rls_rejected.count: both represent lost audit data.
+      - alert: FabtPhaseCDetachedAuditPersistFailure
+        expr: |
+          sum by (action) (
+            rate(fabt_audit_detached_failed_count_total{env="prod"}[15m])
+          ) > 0
+        for: 15m
+        labels:
+          severity: warning
+          surface: phase-c-cache
+          runbook: docs/security/phase-c-cache-isolation-runbook.md
+        annotations:
+          summary: "Phase C: detached audit row failed to persist (action={{ $labels.action }})"
+          description: |
+            DetachedAuditPersister.persistDetached swallowed a
+            persistence exception while writing a
+            {{ $labels.action }} audit row (rate
+            {{ $value | humanize }}/s over 15 minutes). The backing
+            cross-tenant-read or policy-read event already fired;
+            the AUDIT record of it is lost. Investigate loudly — this
+            is the same posture as Phase B's audit-loss signal
+            (fabt.audit.rls_rejected.count).
+
+            Triage: grep `docker logs fabt-backend` for
+            "DetachedAuditPersister failed for action=" in the last
+            hour; stack trace + SQLState reveal whether this is
+            (a) RLS rejection (42501 — connection bind broke),
+            (b) FK constraint (actor_user_id → app_user — seed gap),
+            or (c) DB connectivity. Per-action tag isolates the
+            specific security-evidence surface losing rows.

--- a/docs/security/phase-c-cache-isolation-runbook.md
+++ b/docs/security/phase-c-cache-isolation-runbook.md
@@ -1,0 +1,240 @@
+# Runbook: Phase C cache-isolation alert triage
+
+**Applies to:** v0.47.0 and later (Phase C — `TenantScopedCacheService` wrapper live across all application call sites)
+**Owner:** SRE on-call + application security (escalate CRITICAL)
+**Last reviewed:** 2026-04-19
+
+## Alerts covered
+
+| Alert | Severity | Rule file | Meaning |
+|---|---|---|---|
+| `FabtPhaseCCrossTenantCacheRead` | **CRITICAL** | `deploy/prometheus/phase-c-cache-isolation.rules.yml` | Wrapper rejected a cache read because the stored envelope's tenant UUID did not match the reader's |
+| `FabtPhaseCMalformedCacheEntry` | WARN | same | Wrapper fetched a non-envelope payload from a cache — a caller wrote through `CacheService` bypassing the wrapper |
+| `FabtPhaseCCacheHitRateCollapse` | WARN | same | Per-cache hit rate dropped more than 50% below its 7-day average |
+| `FabtPhaseCDetachedAuditPersistFailure` | WARN | same | `DetachedAuditPersister` swallowed a persistence exception writing a security-evidence audit row (cross-tenant-read or cross-tenant-policy-read evidence lost) |
+
+## Why these alerts exist
+
+Phase C installs a `TenantScopedCacheService` wrapper that prefixes every cache key with the caller's tenant UUID AND stamps every stored value with a `TenantScopedValue(UUID tenantId, T value)` envelope. On read, the wrapper verifies both the prefix (caller can't read another tenant's slot) and the envelope's tenant (caller can't consume a value stamped by a different tenant, even if they reach the same underlying cache slot by some bug or attack).
+
+- **Prefix alone** catches honest reader mistakes (tenant B trying tenant A's key).
+- **Envelope alone** catches writer mistakes (tenant A's code path runs with stale `TenantContext` and writes into a slot that another tenant's reader later reaches).
+
+Both have to fail in the same direction for a leak. The three alerts page when the wrapper says either check fired.
+
+---
+
+## Alert 1 — `FabtPhaseCCrossTenantCacheRead` (CRITICAL)
+
+**PromQL**: `sum by (tenant, cache) (rate(fabt_cache_get_total{result="cross_tenant_reject",env="prod"}[5m])) > 0`
+**For**: 0m (immediate page)
+
+### What just happened
+
+Someone's read path hit `TenantScopedCacheService.get(cacheName, key, ...)`. The wrapper fetched a value from the underlying cache; the value was a `TenantScopedValue` envelope; the envelope's `tenantId` did NOT match `TenantContext.getTenantId()` at read time. Wrapper threw `IllegalStateException("CROSS_TENANT_CACHE_READ")`, incremented the counter that triggered this alert, and persisted an `audit_events` row with `action='CROSS_TENANT_CACHE_READ'` via `DetachedAuditPersister` REQUIRES_NEW (survives caller rollback).
+
+This counter fires only on the wrapper's envelope-verify path. It should physically never fire in correct production operation.
+
+### Possible causes
+
+1. **Async continuation context drift** — code crossed a thread boundary (virtual thread hand-off, `CompletableFuture`, SSE loop) without re-binding `TenantContext.runWithContext(...)`. New thread carries a stale or null context; wrapper reads a value stamped by the prior tenant on the old thread.
+2. **Scheduled-job-forgot-to-bind** — a new `@Scheduled` method that accesses a cache skipped the `TenantContext.runWithContext` wrap. ArchUnit `EscalationPolicyBatchOnlyArchitectureTest` covers the known batch path; a novel scheduled caller won't be on that allowlist.
+3. **Attacker-triggered** — an HTTP endpoint that races a tenant-switch or manipulates session state to read a cached value stamped by a different tenant. Rare — the wrapper's prefix would need to match AND the envelope tenant would need to mismatch, which requires a very specific pattern.
+
+### Triage — within 5 minutes
+
+1. **Confirm the alert labels**:
+   ```bash
+   # Alertmanager UI or:
+   curl -s 'http://prometheus:9090/api/v1/alerts' | jq '.data.alerts[] | select(.labels.alertname=="FabtPhaseCCrossTenantCacheRead")'
+   ```
+   Note the `tenant` and `cache` labels — these are the READER's tenant and the cache name.
+
+2. **Read the audit row** — it has actor + observed vs expected tenant:
+   ```sql
+   -- Connect as fabt owner (NOT fabt_app) to bypass RLS during diagnosis.
+   -- Wrap count query in TenantContext of the reader's tenant if connecting as fabt_app.
+   SELECT id, timestamp, actor_user_id, details
+   FROM audit_events
+   WHERE action = 'CROSS_TENANT_CACHE_READ'
+     AND timestamp > NOW() - INTERVAL '15 minutes'
+   ORDER BY timestamp DESC
+   LIMIT 20;
+   ```
+   `details` is JSONB with `{cache_name, reader_tenant, stamped_tenant, caller_key}`. The `caller_key` (logical key, no tenant prefix) is the most useful triage signal.
+
+3. **Cross-reference with application logs**:
+   ```bash
+   docker logs --since 15m fabt-backend 2>&1 | \
+       grep -E "CROSS_TENANT_CACHE_READ|TenantContext.runWithContext" | tail -100
+   ```
+   Look for the stack trace at the throw site. The caller method is the suspect.
+
+4. **Decide blast radius**:
+   - If the `caller_key` suggests a specific resource (e.g., `shelter-UUID-abc`) AND the reader's tenant is NOT the owner of that UUID → **scope a per-tenant cache invalidation** as a precaution:
+     ```bash
+     # Platform-admin API call
+     curl -X POST -H "Authorization: Bearer $PLATFORM_ADMIN_TOKEN" \
+         "https://findabed.org/api/v1/admin/cache/invalidate?tenantId=${READER_TENANT}"
+     ```
+   - If multiple audit rows with different `caller_key` but same `reader_tenant` → the reader's context was broken across multiple reads. Full tenant-invalidate.
+   - If multiple `reader_tenant` values in the 15-min window → a systemic bug or active attack. **Escalate to security lead; do NOT attempt resolution alone**.
+
+### Rollback criterion
+
+If the alert fires on a release day within 2 hours of deploy AND the suspect code path is in the release, ROLL BACK. Phase C's value-stamp-and-verify is correctness-critical; false positives at this level do not exist by design.
+
+---
+
+## Alert 2 — `FabtPhaseCMalformedCacheEntry` (WARN)
+
+**PromQL**: `sum by (cache) (rate(fabt_cache_get_total{result="malformed_entry",env="prod"}[15m])) > 0`
+**For**: 15m
+
+### What happened
+
+Wrapper `get()` fetched an entry from the underlying cache that was NOT a `TenantScopedValue` envelope OR whose inner value's runtime type did not match the caller's requested type. Wrapper threw `IllegalStateException("MALFORMED_CACHE_ENTRY")`.
+
+This means someone put a raw non-envelope value into the cache via `CacheService.put(...)` directly, bypassing the wrapper's stamp step. After the v0.47.0 release + Task 4.b drain, this counter should be zero — every production put goes through the wrapper.
+
+### Possible causes
+
+1. **Wrapper-bypass on write** — a new `CacheService.put(...)` call site landed without the Family C ArchUnit rule catching it (scope-package typo, new package not in the rule's scope list). ArchUnit rules C1+C3 should catch this at build time; a non-zero rate means one slipped through.
+2. **Test-path leakage** — an integration test that directly writes via raw `CacheService` polluted a shared cache instance. Shouldn't be possible with Testcontainers but has happened historically.
+3. **Deserialization skew** — Caffeine's `asMap()` held a value from a prior release before the envelope existed; envelope shape changed without a cache invalidation on deploy. v0.47.0 deploy on a fresh JVM eliminates this; subsequent hot deploys need cache flush.
+
+### Triage — within 15 minutes
+
+1. **Identify the cache name** from the alert `cache` label.
+2. **Grep for raw put sites** on that cache name:
+   ```bash
+   cd finding-a-bed-tonight
+   grep -rn "cacheService.put.*${CACHE_NAME}\|cacheService.put(.*\"${CACHE_NAME}\"" backend/src/main/java/
+   ```
+   Every hit must be either through `TenantScopedCacheService` OR annotated `@TenantUnscopedCache`.
+3. **Confirm via Family C**: run `mvn -Dtest=FamilyCArchitectureTest test` locally against the current main. If it passes but the alert still fires, there's a bypass the rule doesn't catch — open an issue and add a negative-test fixture mirroring `UnannotatedCaffeineFixture.java`.
+4. **Flush the cache** to stop the bleed while you find the bypass:
+   ```bash
+   curl -X POST -H "Authorization: Bearer $PLATFORM_ADMIN_TOKEN" \
+       "https://findabed.org/api/v1/admin/cache/invalidate?tenantId=${AFFECTED_TENANT}"
+   ```
+   Repeat per affected tenant. If multiple tenants or all — restart backend (cache is in-memory Caffeine; restart clears it).
+
+### When to rollback
+
+Not immediate. Malformed entries don't corrupt data — they throw on read and fail the individual request. Investigate in-hours; rollback only if the bypass is active on every write and users see sustained 500s.
+
+---
+
+## Alert 3 — `FabtPhaseCCacheHitRateCollapse` (WARN)
+
+**PromQL**: compares current-1h hit-rate against 7-day moving avg; fires if current < avg × 0.5
+**For**: 30m
+
+### What happened
+
+Cache is being hit (`put` and `get` counters both incrementing) but hit-rate dropped by more than half vs. the 7-day baseline for 30+ minutes. The wrapper is running; callers are reaching it; but the `get` keys don't match the `put` keys — so every read is a miss, every miss goes to DB, every DB result is re-put, cycle repeats with no hits.
+
+### Possible causes
+
+1. **Migration drift** — a recent PR changed a caller's cache-key computation (composite-key `toString()` reordering, accidentally stripped a caller-side prefix on one side only). `Task4bCacheHitRateTest` is the first line of defence here; if it didn't cover the changed caller, this alert is the fallback.
+2. **TTL too short** — a TTL was shortened to less than the typical re-fetch interval; entries expire before they're re-read. Check recent commits to `CACHE_TTL` constants.
+3. **Cache eviction under pressure** — Caffeine's bounded size (`maximumSize`) is exceeding capacity and LRU-evicting before re-read. Check JVM heap + the specific cache's `.maximumSize(...)` builder call.
+
+### Triage — within 30 minutes
+
+1. **Identify the cache name** from the alert `cache` label.
+2. **Compare put counter to get-miss counter rates**:
+   ```
+   rate(fabt_cache_put_total{cache="${CACHE_NAME}",env="prod"}[10m])
+   rate(fabt_cache_get_total{cache="${CACHE_NAME}",result="miss",env="prod"}[10m])
+   ```
+   Similar rates = normal (cache warming). Miss rate >> put rate = the put path stopped working. Miss rate >> get-hit rate + put rate similar to pre-regression = key-drift.
+3. **Check recent commits** to the caller class of that cache name:
+   ```bash
+   git log --since="7 days ago" --name-only | \
+       grep -iE "$(echo $CACHE_NAME | tr '_-' ' ')" | head -10
+   ```
+4. **Run hit-rate test locally** against main:
+   ```bash
+   cd backend && mvn -Dtest=Task4bCacheHitRateTest test
+   ```
+   If it passes and the alert still fires, the caller-to-wrapper path is OK; investigate TTL + eviction.
+
+### When to rollback
+
+Not immediate. Hit-rate collapse degrades performance but doesn't corrupt data or leak across tenants. Fix forward; rollback only if p95 regresses more than 30% vs. pre-deploy baseline.
+
+---
+
+## Alert 4 — `FabtPhaseCDetachedAuditPersistFailure` (WARN)
+
+**PromQL**: `sum by (action) (rate(fabt_audit_detached_failed_count_total{env="prod"}[15m])) > 0`
+**For**: 15m
+
+### What happened
+
+`DetachedAuditPersister.persistDetached(...)` caught a persistence exception while writing a security-evidence audit row and swallowed it (correct posture — re-throwing would mask the original `IllegalStateException` that fired the detached persist in the first place; the caller's user would see a 500 for the WRONG reason). The counter fires so the swallow is observable. Each counter increment = one lost audit row; the `action` tag identifies which kind of security event was being logged.
+
+### Why we care
+
+`DetachedAuditPersister` exists because the Phase C wrapper throws on cross-tenant reads inside `@Transactional` endpoints, and the classic attacker pattern is: trigger the cross-tenant read, let the `@Transactional` rollback, hope the audit row rolls back too. `REQUIRES_NEW` propagation keeps the audit row committed even if the caller's transaction rolls back. When the wrapping fails for ANY reason — DB down, RLS rejection, FK constraint, constraint violation — we lose the very audit row that proves the attack happened.
+
+This alert's severity is WARN (not CRITICAL) because the underlying security event — the `CROSS_TENANT_CACHE_READ` or `CROSS_TENANT_POLICY_READ` exception — already fired at its own CRITICAL level (Alert 1). This alert is the signal that we LOST the evidence; the event itself was surfaced elsewhere.
+
+### Possible causes
+
+1. **RLS rejection (SQLState 42501)** — the connection's `app.tenant_id` GUC wasn't bound at persist time. `REQUIRES_NEW` opens a fresh connection; if `AuditEventPersister` (the chained persister inside `DetachedAuditPersister`) doesn't re-bind the tenant, FORCE RLS on `audit_events` blocks the INSERT. Phase B guard territory.
+2. **FK constraint violation** — `actor_user_id` references `app_user`; if the acting user was deleted between the event and the persist, the INSERT fails. Rare but happens in tenant-lifecycle paths.
+3. **DB connectivity drop** — Hikari connection timeout, long-running txn exhausted pool. Correlated with `hikari_pool_connections_pending` spikes.
+
+### Triage — within 30 minutes
+
+1. **Check which `action` tag is firing**:
+   ```bash
+   # In Grafana or:
+   curl -sf http://localhost:9091/actuator/prometheus | \
+       grep '^fabt_audit_detached_failed_count_total'
+   ```
+   `action=CROSS_TENANT_CACHE_READ` vs `CROSS_TENANT_POLICY_READ` localizes which security surface is affected.
+2. **Find the swallow stack trace**:
+   ```bash
+   docker logs --since 1h fabt-backend 2>&1 | \
+       grep -A 20 "DetachedAuditPersister failed for action=" | tail -100
+   ```
+   Root cause is in the stack trace; SQLState is printed with the exception.
+3. **Cross-check Alert 1** — if `FabtPhaseCCrossTenantCacheRead` is firing at the same rate, the security events are happening AND being unlogged; this is a dual-incident (page on-call security + SRE).
+4. **Count actual audit rows** to compare with fired-but-unpersisted signal:
+   ```sql
+   SELECT action, COUNT(*) FROM audit_events
+   WHERE timestamp > NOW() - INTERVAL '1 hour'
+     AND action IN ('CROSS_TENANT_CACHE_READ','CROSS_TENANT_POLICY_READ')
+   GROUP BY action;
+   ```
+   Compare against `fabt_cache_get_total{result="cross_tenant_reject"}` aggregate. Delta = lost rows.
+
+### When to rollback
+
+Not usually. This alert is a signal that something else is broken (DB, RLS, connection pool). Fix the root cause; audit rows persist once it's resolved. Rollback v0.47.0 only if a NEW code path in v0.47.0 is provably the cause of the persist failure AND on-call can't mitigate via the obvious paths (DB restart, connection pool recycle).
+
+---
+
+## Cross-cutting signals
+
+### `fabt_cache_registered_cache_names` gauge
+
+Expected steady-state value: **11** (one per `CacheNames` constant). Deviation means the wrapper's eager-seed `@PostConstruct` found a different number of constants — almost certainly a broken deploy (classloader skew, partial JAR). Paired with the CI check `CacheIsolationDiscoveryTest.discoveryMatchesExpectedCount` which enforces exact-equals 11 at build time.
+
+### `fabt.cache.get{result=hit|miss|cross_tenant_reject|malformed_entry}`
+
+All four result values should be observable. A flat-line `hit=0` at steady-state traffic (no new deploys) is a silent-wrapper signal (wrapper is running but every op is a miss — handled by Alert 3).
+
+---
+
+## Escalation
+
+- **CRITICAL unresolved 15 min → security lead.**
+- **Multiple tenants in cross-tenant-reject audit rows → all-hands security bridge.**
+- **Alert on post-deploy window → consider rollback before continuing triage**.
+
+Refer to `docs/oracle-update-notes-v0.47.0.md` for the v0.47.0 deploy + rollback commands.

--- a/prometheus.yml
+++ b/prometheus.yml
@@ -17,6 +17,15 @@
 global:
   scrape_interval: 15s
   evaluation_interval: 15s
+  # env=prod label is attached to EVERY scraped time-series. The Phase C
+  # alert rules in deploy/prometheus/phase-c-cache-isolation.rules.yml
+  # filter on env="prod" so CI / dev / staging scrapes (which use
+  # prometheus.dev.yml without this label, see the companion file) do not
+  # false-page the production on-call when the Tenant4bMigrationCrossTenantAttackTest
+  # harness intentionally fires cross_tenant_reject counters. Added 2026-04-19
+  # per pre-release warroom Jordan blocker #1 — PR #140.
+  external_labels:
+    env: prod
 
 scrape_configs:
   - job_name: 'fabt-backend'


### PR DESCRIPTION
## Summary

- **Final Phase C code task.** Adds `CacheIsolationDiscoveryTest` — an ArchUnit + `java.lang.reflect` test that automatically discovers every `CacheNames` constant and runs the legitimate-isolation triple per cache (`tenantA.put → tenantA.get HIT → tenantB.get MISS`).
- **Orthogonal to existing tests.** `Task4bCacheHitRateTest` covers 7 specific caller methods (key stability); `Tenant4bMigrationCrossTenantAttackTest` covers poisoning rejection × 8 names; `TenantScopedCacheServiceUnitTest` covers the wrapper contract under bound/unbound context. 4.6 is the only test that picks up a future `CacheNames` constant added without a matching wrapper-write path (step-2 failure) or a wrapper isolation regression (step-3 failure).
- **14/14 green** (3 guards + 11 parametrized rows). **949/949 full backend suite green** post-addition (+14 exactly, zero collateral damage).

## Implementation picks (plan warroom 2026-04-19 night)

| Question | Pick | Rationale |
|---|---|---|
| Discovery mechanism | ArchUnit + `Class.getFields()` | ArchUnit's `JavaMethodCall` primitives already in-tree (`FamilyCArchitectureTest:168`); `org.reflections` cannot do call-site graphs; no new dep |
| `EXPECTED_SITES` pin | **11, exact** | Counts `CacheNames` constants — spec's unit-of-isolation. `.hasSize(11)` not `>=` so additions fire the reminder-to-update-per-cache-tests promise from the Javadoc |
| Silent-empty floor | 8 | Accommodates 3-constant removal headroom while still detecting a half-scan classloader misconfig |
| Parametrization | `@ParameterizedTest + @MethodSource` | `@TestFactory` silent-passes on empty iterables — violates `feedback_never_skip_silently.md` |

## Post-commit warroom fold-in (Riley)

- Original draft used `.hasSizeGreaterThanOrEqualTo(EXPECTED_MIN_SITES)` — Riley caught that the class Javadoc promised "an increase is a reminder to update this pin + add per-cache tests" but `>=` silently accepted new constants, defeating the promise. Tightened to `.hasSize(EXPECTED_SITES)` exact-equals. Constant renamed `EXPECTED_MIN_SITES` → `EXPECTED_SITES` for consistency.

## Test plan

- [x] `mvn -Dtest=CacheIsolationDiscoveryTest test` → 14/14
- [x] `mvn test` → 949/949 (2:26 min)
- [x] Legal-scan sweep clean (zero trigger words in new file)
- [ ] CI `Backend (Java 25 + Maven)` green
- [ ] CI `Legal Language Scan` green
- [ ] CI `Family C annotation review gate` green (sanity — no Family C rule touched but rule execution covers the new file as part of the architecture test suite)

## Phase C completion state

After this PR merges + a companion release PR (CHANGELOG + pom 0.46.0 → 0.47.0 + oracle-update-notes-v0.47.0), Phase C closes. Three open follow-ups remain but are non-blocking for v0.47.0:

- Task #180 — `EscalationPolicyAuditRollbackIntegrationTest` follow-up for 4.4
- Task #182 — Rule C4 ConcurrentHashMap-as-cache heuristic
- Task #184 — `NEGATIVE_SENTINEL` enum-singleton promotion (before first `putNegative` caller)

🤖 Generated with [Claude Code](https://claude.com/claude-code)