### PR TITLE
v0.48 bundle: V76+V77 seed migrations + Phase D core + tenant chip UI

### DIFF
--- a/backend/src/main/java/org/fabt/auth/api/OAuth2ProviderController.java
+++ b/backend/src/main/java/org/fabt/auth/api/OAuth2ProviderController.java
@@ -1,14 +1,13 @@
 package org.fabt.auth.api;
 
 import java.util.List;
-import java.util.NoSuchElementException;
 import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import jakarta.validation.Valid;
 import org.fabt.auth.service.TenantOAuth2ProviderService;
-import org.fabt.shared.web.TenantContext;
+import org.fabt.shared.web.TenantPathGuard;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -47,17 +46,7 @@ public class OAuth2ProviderController {
             @Parameter(description = "UUID of the tenant to register the provider under") @PathVariable UUID tenantId,
             @Valid @RequestBody CreateOAuth2ProviderRequest request) {
 
-        // Design D11 (cross-tenant-isolation-audit): the URL path tenantId
-        // MUST match the caller's JWT tenant. A CoC admin in Tenant A sending
-        // POST /api/v1/tenants/{tenantB}/oauth2-providers would otherwise
-        // create a provider row under Tenant B with attacker-controlled
-        // fields — the URL-path-sink class of cross-tenant write. Mismatch
-        // returns 404 (symmetric with D3 for read paths); the service
-        // itself sources tenantId from TenantContext internally so even a
-        // bypass of this guard cannot reach cross-tenant.
-        if (!tenantId.equals(TenantContext.getTenantId())) {
-            throw new NoSuchElementException("Tenant not found: " + tenantId);
-        }
+        TenantPathGuard.requireMatchingTenant(tenantId);
 
         var provider = providerService.create(
                 request.providerName(),
@@ -80,6 +69,7 @@ public class OAuth2ProviderController {
     @GetMapping
     public ResponseEntity<List<OAuth2ProviderResponse>> list(
             @Parameter(description = "UUID of the tenant whose OAuth2 providers to list") @PathVariable UUID tenantId) {
+        TenantPathGuard.requireMatchingTenant(tenantId);
         List<OAuth2ProviderResponse> providers = providerService.findByTenantId(tenantId).stream()
                 .map(OAuth2ProviderResponse::from)
                 .toList();
@@ -100,6 +90,8 @@ public class OAuth2ProviderController {
             @Parameter(description = "UUID of the owning tenant") @PathVariable UUID tenantId,
             @Parameter(description = "UUID of the OAuth2 provider to update") @PathVariable UUID providerId,
             @Valid @RequestBody UpdateOAuth2ProviderRequest request) {
+
+        TenantPathGuard.requireMatchingTenant(tenantId);
 
         var provider = providerService.update(
                 providerId,
@@ -125,6 +117,7 @@ public class OAuth2ProviderController {
             @Parameter(description = "UUID of the owning tenant") @PathVariable UUID tenantId,
             @Parameter(description = "UUID of the OAuth2 provider to delete") @PathVariable UUID providerId) {
 
+        TenantPathGuard.requireMatchingTenant(tenantId);
         providerService.delete(providerId);
         return ResponseEntity.noContent().build();
     }

--- a/backend/src/main/java/org/fabt/shared/web/TenantPathGuard.java
+++ b/backend/src/main/java/org/fabt/shared/web/TenantPathGuard.java
@@ -1,0 +1,46 @@
+package org.fabt.shared.web;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+/**
+ * URL-path-sink guard for cross-tenant write/read protection (design D11,
+ * Phase D — cross-tenant-isolation-audit).
+ *
+ * <p>Controllers under {@code /api/v1/tenants/{tenantId}/...} accept a
+ * tenantId in the URL path. Without this guard a PLATFORM_ADMIN (or any
+ * caller with a valid JWT) could address another tenant's resources by
+ * substituting a different UUID into the URL — a cross-tenant write via
+ * URL manipulation. The backend response must treat any path-supplied
+ * tenantId as untrusted input and reconcile it against the authenticated
+ * tenant before acting.
+ *
+ * <p>The rule is simple: if the path tenantId does not equal
+ * {@link TenantContext#getTenantId()}, throw {@link NoSuchElementException}
+ * ({@code 404}) — matching the existence-leak posture (D3) used across
+ * read paths. A {@code 403} would signal the resource exists but is
+ * forbidden; {@code 404} is symmetric regardless of actual existence.
+ *
+ * <p>Call this as the first line of any {@code @PathVariable tenantId}
+ * controller method. Services downstream source tenantId from
+ * {@code TenantContext}, so even a bypass of this guard cannot reach
+ * cross-tenant data — this is the defence-in-depth outermost layer.
+ */
+public final class TenantPathGuard {
+
+    private TenantPathGuard() {}
+
+    /**
+     * Require the URL-path tenantId to match the authenticated tenant.
+     *
+     * @throws NoSuchElementException (yielding 404 at the controller boundary)
+     *         if the path tenantId differs from {@link TenantContext#getTenantId()},
+     *         or if no tenant is bound in context.
+     */
+    public static void requireMatchingTenant(UUID pathTenantId) {
+        UUID authenticated = TenantContext.getTenantId();
+        if (authenticated == null || !authenticated.equals(pathTenantId)) {
+            throw new NoSuchElementException("Tenant not found: " + pathTenantId);
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/api/TenantConfigController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantConfigController.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
+import org.fabt.shared.web.TenantPathGuard;
 import org.fabt.tenant.service.TenantService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,6 +38,7 @@ public class TenantConfigController {
     @GetMapping
     public ResponseEntity<Map<String, Object>> getConfig(
             @Parameter(description = "UUID of the tenant whose configuration to retrieve") @PathVariable UUID tenantId) {
+        TenantPathGuard.requireMatchingTenant(tenantId);
         Map<String, Object> config = tenantService.getConfig(tenantId);
         return ResponseEntity.ok(config);
     }
@@ -54,6 +56,7 @@ public class TenantConfigController {
     public ResponseEntity<Map<String, Object>> updateConfig(
             @Parameter(description = "UUID of the tenant whose configuration to replace") @PathVariable UUID tenantId,
             @RequestBody Map<String, Object> config) {
+        TenantPathGuard.requireMatchingTenant(tenantId);
         tenantService.updateConfig(tenantId, config);
         return ResponseEntity.ok(tenantService.getConfig(tenantId));
     }

--- a/backend/src/main/java/org/fabt/tenant/api/TenantController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantController.java
@@ -12,6 +12,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.fabt.observability.ObservabilityConfigService;
 import org.fabt.observability.ObservabilityConfigService.ObservabilityConfig;
+import org.fabt.shared.web.TenantPathGuard;
 import org.fabt.tenant.domain.Tenant;
 import org.fabt.tenant.service.TenantService;
 import org.springframework.http.HttpStatus;
@@ -99,6 +100,7 @@ public class TenantController {
     public ResponseEntity<TenantResponse> update(
             @Parameter(description = "UUID of the tenant to update") @PathVariable UUID id,
             @Valid @RequestBody UpdateTenantRequest request) {
+        TenantPathGuard.requireMatchingTenant(id);
         Tenant tenant = tenantService.update(id, request.name());
         return ResponseEntity.ok(TenantResponse.from(tenant));
     }
@@ -112,8 +114,7 @@ public class TenantController {
     @GetMapping("/{id}/observability")
     public ResponseEntity<ObservabilityConfig> getObservabilityConfig(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id) {
-        tenantService.findById(id)
-                .orElseThrow(() -> new java.util.NoSuchElementException("Tenant not found: " + id));
+        TenantPathGuard.requireMatchingTenant(id);
         return ResponseEntity.ok(observabilityConfigService.getConfig(id));
     }
 
@@ -127,6 +128,7 @@ public class TenantController {
     public ResponseEntity<ObservabilityConfig> updateObservabilityConfig(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id,
             @RequestBody Map<String, Object> observabilitySettings) {
+        TenantPathGuard.requireMatchingTenant(id);
         Map<String, Object> currentConfig = tenantService.getConfig(id);
         currentConfig.put("observability", observabilitySettings);
         tenantService.updateConfig(id, currentConfig);
@@ -148,6 +150,8 @@ public class TenantController {
             @RequestBody Map<String, String> body,
             @RequestHeader(value = "X-Confirm-Policy-Change", required = false) String confirmHeader,
             Authentication authentication) {
+
+        TenantPathGuard.requireMatchingTenant(id);
 
         if (!"CONFIRM".equals(confirmHeader)) {
             return ResponseEntity.badRequest()

--- a/backend/src/main/resources/db/migration/V76__seed_blue_ridge_demo_tenant.sql
+++ b/backend/src/main/resources/db/migration/V76__seed_blue_ridge_demo_tenant.sql
@@ -1,0 +1,120 @@
+-- V76: Seed Blue Ridge CoC (demo) — second demo tenant (slug=dev-coc-west)
+--
+-- Phase M-light pull-forward per openspec multi-tenant-production-readiness
+-- task 14.4. Extracted from infra/scripts/seed-data.sql so that prod picks up
+-- the tenant on deploy without relying on the dev-only seed script.
+--
+-- Idempotency: every row uses ON CONFLICT DO UPDATE so a re-run (or a prior
+-- seed-data.sql load) is safely absorbed. Matches the seed-data.sql upsert
+-- pattern verbatim; if the two ever diverge, seed-data.sql wins on dev
+-- because it runs after Flyway.
+--
+-- UUID convention: tenant a0000000-…-000002; users b0000001-…; shelters
+-- d0000001-… (mirrors the dev-coc shape in the same seed file).
+--
+-- Branding: "Blue Ridge" is a multi-state mountain range, not a
+-- HUD-registered CoC — no real-jurisdiction collision. The "(demo)" suffix
+-- on tenant.name is the visual audit signal per Elena/Casey. Street
+-- addresses use "Fictional Way" per D12; city names use real NC mountain
+-- towns (Boone, Waynesville) so the map/search surface feels realistic.
+-- DV shelter address is intentionally undisclosed.
+--
+-- NOAA station KAVL = Asheville regional airport — covers Boone +
+-- Waynesville within a few miles. Tenant-scoped per the
+-- per-tenant-weather-station spec requirement shipped in v0.47.1 code.
+
+INSERT INTO tenant (id, name, slug, config, created_at, updated_at)
+VALUES (
+    'a0000000-0000-0000-0000-000000000002',
+    'Blue Ridge CoC (demo)',
+    'dev-coc-west',
+    '{"api_key_auth_enabled": true, "default_locale": "en", "hold_duration_minutes": 90, "dv_referral_expiry_minutes": 240, "dv_address_visibility": "ADMIN_AND_ASSIGNED", "hmis_vendors": [], "observability": {"prometheus_enabled": true, "tracing_enabled": false, "tracing_endpoint": "http://localhost:4318/v1/traces", "monitor_stale_interval_minutes": 5, "monitor_dv_canary_interval_minutes": 15, "monitor_temperature_interval_minutes": 60, "temperature_threshold_f": 32, "noaa_station_id": "KAVL"}}',
+    NOW(), NOW()
+) ON CONFLICT (slug) DO UPDATE SET
+    name = EXCLUDED.name,
+    config = EXCLUDED.config,
+    updated_at = NOW();
+
+-- 6-role user matrix (all passwords: admin123). bcrypt hash reused from
+-- seed-data.sql — shared dev/demo credential, not a secret.
+INSERT INTO app_user (id, tenant_id, email, password_hash, display_name, roles, dv_access, created_at, updated_at)
+VALUES
+    ('b0000001-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000002',
+     'admin@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Blue Ridge Admin', ARRAY['PLATFORM_ADMIN'], true, NOW(), NOW()),
+    ('b0000001-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000002',
+     'cocadmin@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Blue Ridge CoC Admin', ARRAY['COC_ADMIN'], true, NOW(), NOW()),
+    ('b0000001-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000002',
+     'coordinator@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Blue Ridge Coordinator', ARRAY['COORDINATOR'], false, NOW(), NOW()),
+    ('b0000001-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-000000000002',
+     'outreach@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Blue Ridge Outreach', ARRAY['OUTREACH_WORKER'], false, NOW(), NOW()),
+    ('b0000001-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-000000000002',
+     'dv-coordinator@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Blue Ridge DV Coordinator', ARRAY['COORDINATOR'], true, NOW(), NOW()),
+    ('b0000001-0000-0000-0000-000000000006', 'a0000000-0000-0000-0000-000000000002',
+     'dv-outreach@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Blue Ridge DV Outreach', ARRAY['OUTREACH_WORKER'], true, NOW(), NOW())
+ON CONFLICT (tenant_id, email) DO UPDATE SET
+    password_hash = EXCLUDED.password_hash,
+    display_name = EXCLUDED.display_name,
+    roles = EXCLUDED.roles,
+    dv_access = EXCLUDED.dv_access,
+    status = COALESCE(EXCLUDED.status, 'ACTIVE'),
+    totp_enabled = false,
+    totp_secret_encrypted = NULL,
+    recovery_codes = NULL,
+    password_changed_at = NULL,
+    token_version = 0,
+    updated_at = NOW();
+
+-- 3 shelters: 2 real-city (Boone, Waynesville) + 1 DV (undisclosed)
+INSERT INTO shelter (id, tenant_id, name, address_street, address_city, address_state, address_zip, phone, latitude, longitude, dv_shelter, created_at, updated_at)
+VALUES
+    ('d0000001-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000002',
+     'Example House North (demo)', '101 Fictional Way', 'Boone', 'NC', '28607', '000-555-0101',
+     36.22, -81.67, false, NOW(), NOW()),
+    ('d0000001-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000002',
+     'Blue Ridge Example Shelter (demo)', '102 Fictional Way', 'Waynesville', 'NC', '28786', '000-555-0102',
+     35.49, -82.99, false, NOW(), NOW()),
+    ('d0000001-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000002',
+     'Safe Haven Demo DV West', '999 Undisclosed Demo', 'Undisclosed', 'NC', '00000', '000-555-0103',
+     35.7, -82.7, true, NOW(), NOW())
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    address_street = EXCLUDED.address_street,
+    address_city = EXCLUDED.address_city,
+    address_state = EXCLUDED.address_state,
+    address_zip = EXCLUDED.address_zip,
+    phone = EXCLUDED.phone,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    dv_shelter = EXCLUDED.dv_shelter,
+    updated_at = NOW();
+
+INSERT INTO shelter_constraints (shelter_id, sobriety_required, id_required, referral_required, pets_allowed, wheelchair_accessible, curfew_time, max_stay_days, population_types_served)
+VALUES
+    ('d0000001-0000-0000-0000-000000000001', false, false, false, true,  true, '21:00', 180, ARRAY['FAMILY_WITH_CHILDREN']),
+    ('d0000001-0000-0000-0000-000000000002', false, false, false, false, true, '22:00', 90,  ARRAY['SINGLE_ADULT']),
+    ('d0000001-0000-0000-0000-000000000003', false, false, true,  true,  true, NULL,    NULL, ARRAY['DV_SURVIVOR', 'WOMEN_ONLY', 'FAMILY_WITH_CHILDREN'])
+ON CONFLICT (shelter_id) DO UPDATE SET
+    sobriety_required = EXCLUDED.sobriety_required,
+    id_required = EXCLUDED.id_required,
+    referral_required = EXCLUDED.referral_required,
+    pets_allowed = EXCLUDED.pets_allowed,
+    wheelchair_accessible = EXCLUDED.wheelchair_accessible,
+    curfew_time = EXCLUDED.curfew_time,
+    max_stay_days = EXCLUDED.max_stay_days,
+    population_types_served = EXCLUDED.population_types_served;
+
+-- Bed availability for demo tour. Moderate occupancy (~66%) so search
+-- surfaces return results but not "empty zone". Mirrors dev-coc profile.
+INSERT INTO bed_availability (shelter_id, tenant_id, population_type, beds_total, beds_occupied, beds_on_hold, accepting_new_guests, snapshot_ts, updated_by, notes) VALUES
+    ('d0000001-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000002', 'FAMILY_WITH_CHILDREN', 20, 13, 0, true, NOW() - INTERVAL '15 minutes', 'seed', 'Evening update'),
+    ('d0000001-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000002', 'SINGLE_ADULT',         40, 28, 0, true, NOW() - INTERVAL '20 minutes', 'seed', NULL),
+    ('d0000001-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000002', 'DV_SURVIVOR',          12,  7, 0, true, NOW() - INTERVAL '45 minutes', 'seed', NULL),
+    ('d0000001-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000002', 'WOMEN_ONLY',           10,  6, 0, true, NOW() - INTERVAL '45 minutes', 'seed', NULL),
+    ('d0000001-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000002', 'FAMILY_WITH_CHILDREN',  8,  5, 0, true, NOW() - INTERVAL '45 minutes', 'seed', NULL)
+ON CONFLICT DO NOTHING;

--- a/backend/src/main/resources/db/migration/V77__seed_pamlico_sound_demo_tenant.sql
+++ b/backend/src/main/resources/db/migration/V77__seed_pamlico_sound_demo_tenant.sql
@@ -1,0 +1,106 @@
+-- V77: Seed Pamlico Sound CoC (demo) — third demo tenant (slug=dev-coc-east)
+--
+-- Phase M-light pull-forward per openspec multi-tenant-production-readiness
+-- task 14.4b. Parallel to V76 (Blue Ridge); see that file's header for the
+-- full design rationale.
+--
+-- UUID convention: tenant a0000000-…-000003; users b0000002-…; shelters
+-- d0000002-…
+--
+-- Branding: "Pamlico Sound" is a coastal NC lagoon — geographic feature,
+-- not a jurisdiction. Cities use real coastal-NC towns (New Bern,
+-- Washington) for realism; street addresses stay fictional; DV shelter
+-- address undisclosed.
+--
+-- NOAA station KEWN = Craven County Regional (New Bern) — covers Pamlico
+-- Sound coastal region.
+
+INSERT INTO tenant (id, name, slug, config, created_at, updated_at)
+VALUES (
+    'a0000000-0000-0000-0000-000000000003',
+    'Pamlico Sound CoC (demo)',
+    'dev-coc-east',
+    '{"api_key_auth_enabled": true, "default_locale": "en", "hold_duration_minutes": 90, "dv_referral_expiry_minutes": 240, "dv_address_visibility": "ADMIN_AND_ASSIGNED", "hmis_vendors": [], "observability": {"prometheus_enabled": true, "tracing_enabled": false, "tracing_endpoint": "http://localhost:4318/v1/traces", "monitor_stale_interval_minutes": 5, "monitor_dv_canary_interval_minutes": 15, "monitor_temperature_interval_minutes": 60, "temperature_threshold_f": 32, "noaa_station_id": "KEWN"}}',
+    NOW(), NOW()
+) ON CONFLICT (slug) DO UPDATE SET
+    name = EXCLUDED.name,
+    config = EXCLUDED.config,
+    updated_at = NOW();
+
+INSERT INTO app_user (id, tenant_id, email, password_hash, display_name, roles, dv_access, created_at, updated_at)
+VALUES
+    ('b0000002-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000003',
+     'admin@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Pamlico Sound Admin', ARRAY['PLATFORM_ADMIN'], true, NOW(), NOW()),
+    ('b0000002-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000003',
+     'cocadmin@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Pamlico Sound CoC Admin', ARRAY['COC_ADMIN'], true, NOW(), NOW()),
+    ('b0000002-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000003',
+     'coordinator@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Pamlico Sound Coordinator', ARRAY['COORDINATOR'], false, NOW(), NOW()),
+    ('b0000002-0000-0000-0000-000000000004', 'a0000000-0000-0000-0000-000000000003',
+     'outreach@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Pamlico Sound Outreach', ARRAY['OUTREACH_WORKER'], false, NOW(), NOW()),
+    ('b0000002-0000-0000-0000-000000000005', 'a0000000-0000-0000-0000-000000000003',
+     'dv-coordinator@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Pamlico Sound DV Coordinator', ARRAY['COORDINATOR'], true, NOW(), NOW()),
+    ('b0000002-0000-0000-0000-000000000006', 'a0000000-0000-0000-0000-000000000003',
+     'dv-outreach@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+     'Pamlico Sound DV Outreach', ARRAY['OUTREACH_WORKER'], true, NOW(), NOW())
+ON CONFLICT (tenant_id, email) DO UPDATE SET
+    password_hash = EXCLUDED.password_hash,
+    display_name = EXCLUDED.display_name,
+    roles = EXCLUDED.roles,
+    dv_access = EXCLUDED.dv_access,
+    status = COALESCE(EXCLUDED.status, 'ACTIVE'),
+    totp_enabled = false,
+    totp_secret_encrypted = NULL,
+    recovery_codes = NULL,
+    password_changed_at = NULL,
+    token_version = 0,
+    updated_at = NOW();
+
+INSERT INTO shelter (id, tenant_id, name, address_street, address_city, address_state, address_zip, phone, latitude, longitude, dv_shelter, created_at, updated_at)
+VALUES
+    ('d0000002-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000003',
+     'Example Coastal House (demo)', '201 Fictional Way', 'New Bern', 'NC', '28560', '000-555-0201',
+     35.11, -77.04, false, NOW(), NOW()),
+    ('d0000002-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000003',
+     'Pamlico Example Shelter (demo)', '202 Fictional Way', 'Washington', 'NC', '27889', '000-555-0202',
+     35.55, -77.05, false, NOW(), NOW()),
+    ('d0000002-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000003',
+     'Safe Haven Demo DV East', '999 Undisclosed Demo', 'Undisclosed', 'NC', '00000', '000-555-0203',
+     35.4, -76.4, true, NOW(), NOW())
+ON CONFLICT (id) DO UPDATE SET
+    name = EXCLUDED.name,
+    address_street = EXCLUDED.address_street,
+    address_city = EXCLUDED.address_city,
+    address_state = EXCLUDED.address_state,
+    address_zip = EXCLUDED.address_zip,
+    phone = EXCLUDED.phone,
+    latitude = EXCLUDED.latitude,
+    longitude = EXCLUDED.longitude,
+    dv_shelter = EXCLUDED.dv_shelter,
+    updated_at = NOW();
+
+INSERT INTO shelter_constraints (shelter_id, sobriety_required, id_required, referral_required, pets_allowed, wheelchair_accessible, curfew_time, max_stay_days, population_types_served)
+VALUES
+    ('d0000002-0000-0000-0000-000000000001', false, false, false, true,  true, '21:00', 180, ARRAY['FAMILY_WITH_CHILDREN']),
+    ('d0000002-0000-0000-0000-000000000002', false, false, false, false, true, '22:00', 90,  ARRAY['SINGLE_ADULT']),
+    ('d0000002-0000-0000-0000-000000000003', false, false, true,  false, true, NULL,    NULL, ARRAY['DV_SURVIVOR', 'WOMEN_ONLY'])
+ON CONFLICT (shelter_id) DO UPDATE SET
+    sobriety_required = EXCLUDED.sobriety_required,
+    id_required = EXCLUDED.id_required,
+    referral_required = EXCLUDED.referral_required,
+    pets_allowed = EXCLUDED.pets_allowed,
+    wheelchair_accessible = EXCLUDED.wheelchair_accessible,
+    curfew_time = EXCLUDED.curfew_time,
+    max_stay_days = EXCLUDED.max_stay_days,
+    population_types_served = EXCLUDED.population_types_served;
+
+INSERT INTO bed_availability (shelter_id, tenant_id, population_type, beds_total, beds_occupied, beds_on_hold, accepting_new_guests, snapshot_ts, updated_by, notes) VALUES
+    ('d0000002-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000003', 'FAMILY_WITH_CHILDREN', 25, 17, 0, true, NOW() - INTERVAL '10 minutes', 'seed', NULL),
+    ('d0000002-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000003', 'SINGLE_ADULT',         50, 38, 0, true, NOW() - INTERVAL '25 minutes', 'seed', 'Recently updated'),
+    ('d0000002-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000003', 'DV_SURVIVOR',          15,  9, 0, true, NOW() - INTERVAL '1 hour', 'seed', NULL),
+    ('d0000002-0000-0000-0000-000000000003', 'a0000000-0000-0000-0000-000000000003', 'WOMEN_ONLY',           12,  7, 0, true, NOW() - INTERVAL '1 hour', 'seed', NULL)
+ON CONFLICT DO NOTHING;

--- a/backend/src/test/java/org/fabt/security/TenantPathGuardIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/security/TenantPathGuardIntegrationTest.java
@@ -1,0 +1,180 @@
+package org.fabt.security;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.auth.domain.User;
+import org.fabt.auth.repository.UserRepository;
+import org.fabt.auth.service.JwtService;
+import org.fabt.auth.service.PasswordService;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.service.TenantService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Phase D task 5.9 — verifies the TenantPathGuard URL-path-sink enforcement
+ * (design D11) rejects cross-tenant write attempts with HTTP 404 across
+ * every affected controller.
+ *
+ * <p>Threat model: a PLATFORM_ADMIN authenticated against Tenant A sends a
+ * request whose URL path carries Tenant B's UUID (e.g.
+ * {@code PUT /api/v1/tenants/<B-uuid>/config}). Without the guard, services
+ * would act on Tenant B's row using Tenant A's credentials — a cross-tenant
+ * write via URL manipulation. The guard throws {@code NoSuchElementException}
+ * before the service is invoked, and the GlobalExceptionHandler renders it
+ * as {@code 404 Not Found}. A 403 would signal "exists but forbidden";
+ * 404 preserves the existence-leak posture symmetric with D3 reads.
+ *
+ * <p>This is the primary regression guard for Phase D. Every PUT/GET/POST/
+ * DELETE under {@code /api/v1/tenants/{tenantId}/...} must be covered here.
+ */
+class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private TenantService tenantService;
+    @Autowired private UserRepository userRepository;
+    @Autowired private PasswordService passwordService;
+    @Autowired private JwtService jwtService;
+
+    private Tenant tenantA;
+    private Tenant tenantB;
+    private String tenantAToken;
+
+    @BeforeEach
+    void setUp() {
+        String suffixA = UUID.randomUUID().toString().substring(0, 8);
+        String suffixB = UUID.randomUUID().toString().substring(0, 8);
+        tenantA = tenantService.findBySlug("pg-a-" + suffixA)
+                .orElseGet(() -> tenantService.create("PathGuard Tenant A", "pg-a-" + suffixA));
+        tenantB = tenantService.findBySlug("pg-b-" + suffixB)
+                .orElseGet(() -> tenantService.create("PathGuard Tenant B", "pg-b-" + suffixB));
+
+        User adminA = createAdmin(tenantA.getId(), "admin-a-" + suffixA + "@test.fabt.org");
+        tenantAToken = jwtService.generateAccessToken(adminA);
+    }
+
+    @Test
+    @DisplayName("PUT /tenants/{B}/config from Tenant A → 404 (D11 URL-path-sink)")
+    void crossTenantUpdateConfig_returns404() {
+        ResponseEntity<String> response = put(
+                "/api/v1/tenants/" + tenantB.getId() + "/config",
+                "{\"foo\":\"bar\"}");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("GET /tenants/{B}/config from Tenant A → 404")
+    void crossTenantGetConfig_returns404() {
+        ResponseEntity<String> response = get("/api/v1/tenants/" + tenantB.getId() + "/config");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("PUT /tenants/{B} from Tenant A → 404 (display-name update)")
+    void crossTenantUpdateName_returns404() {
+        ResponseEntity<String> response = put(
+                "/api/v1/tenants/" + tenantB.getId(),
+                "{\"name\":\"Attacker-renamed\"}");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("PUT /tenants/{B}/observability from Tenant A → 404")
+    void crossTenantUpdateObservability_returns404() {
+        ResponseEntity<String> response = put(
+                "/api/v1/tenants/" + tenantB.getId() + "/observability",
+                "{\"prometheus_enabled\":false}");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("GET /tenants/{B}/observability from Tenant A → 404 (reads are symmetric)")
+    void crossTenantGetObservability_returns404() {
+        ResponseEntity<String> response = get("/api/v1/tenants/" + tenantB.getId() + "/observability");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("GET /tenants/{B}/oauth2-providers from Tenant A → 404")
+    void crossTenantListOauth2Providers_returns404() {
+        ResponseEntity<String> response = get(
+                "/api/v1/tenants/" + tenantB.getId() + "/oauth2-providers");
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("POST /tenants/{B}/oauth2-providers from Tenant A → 404 (create)")
+    void crossTenantCreateOauth2Provider_returns404() {
+        ResponseEntity<String> response = post(
+                "/api/v1/tenants/" + tenantB.getId() + "/oauth2-providers",
+                """
+                {
+                    "providerName": "attacker-google",
+                    "clientId": "attacker-client-id",
+                    "clientSecret": "attacker-secret",
+                    "issuerUri": "https://accounts.google.com"
+                }
+                """);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("Control: Tenant A PUT on its own /tenants/{A}/config → 200 (guard allows match)")
+    void sameTenantUpdateConfig_returns200() {
+        ResponseEntity<String> response = put(
+                "/api/v1/tenants/" + tenantA.getId() + "/config",
+                "{\"test-marker\":\"self-update-ok\"}");
+        assertThat(response.getStatusCode())
+                .as("Legitimate same-tenant PUT must pass the guard (response body: %s)", response.getBody())
+                .isEqualTo(HttpStatus.OK);
+    }
+
+    // --- helpers ---
+
+    private ResponseEntity<String> get(String path) {
+        return restTemplate.exchange(path, HttpMethod.GET, new HttpEntity<>(authHeaders()), String.class);
+    }
+
+    private ResponseEntity<String> put(String path, String body) {
+        return restTemplate.exchange(path, HttpMethod.PUT, new HttpEntity<>(body, authHeaders()), String.class);
+    }
+
+    private ResponseEntity<String> post(String path, String body) {
+        return restTemplate.exchange(path, HttpMethod.POST, new HttpEntity<>(body, authHeaders()), String.class);
+    }
+
+    private HttpHeaders authHeaders() {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(tenantAToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        return headers;
+    }
+
+    private User createAdmin(UUID tenantId, String email) {
+        return userRepository.findByTenantIdAndEmail(tenantId, email)
+                .orElseGet(() -> {
+                    User user = new User();
+                    user.setTenantId(tenantId);
+                    user.setEmail(email);
+                    user.setDisplayName("PathGuard Admin " + email);
+                    user.setPasswordHash(passwordService.hash("TestPassword123!"));
+                    user.setRoles(new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
+                    user.setDvAccess(false);
+                    user.setCreatedAt(Instant.now());
+                    user.setUpdatedAt(Instant.now());
+                    return userRepository.save(user);
+                });
+    }
+}

--- a/backend/src/test/java/org/fabt/security/TenantPathGuardIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/security/TenantPathGuardIntegrationTest.java
@@ -51,6 +51,7 @@ class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
     private Tenant tenantA;
     private Tenant tenantB;
     private String tenantAToken;
+    private String tenantBToken;
 
     @BeforeEach
     void setUp() {
@@ -62,7 +63,9 @@ class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
                 .orElseGet(() -> tenantService.create("PathGuard Tenant B", "pg-b-" + suffixB));
 
         User adminA = createAdmin(tenantA.getId(), "admin-a-" + suffixA + "@test.fabt.org");
+        User adminB = createAdmin(tenantB.getId(), "admin-b-" + suffixB + "@test.fabt.org");
         tenantAToken = jwtService.generateAccessToken(adminA);
+        tenantBToken = jwtService.generateAccessToken(adminB);
     }
 
     @Test
@@ -141,7 +144,90 @@ class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
                 .isEqualTo(HttpStatus.OK);
     }
 
+    @Test
+    @DisplayName("PUT /tenants/{B}/dv-address-policy from Tenant A → 404 (guard fires before CONFIRM header check)")
+    void crossTenantUpdateDvAddressPolicy_returns404() {
+        HttpHeaders headers = authHeaders();
+        headers.set("X-Confirm-Policy-Change", "CONFIRM");
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/v1/tenants/" + tenantB.getId() + "/dv-address-policy",
+                HttpMethod.PUT,
+                new HttpEntity<>("{\"policy\":\"NONE\"}", headers),
+                String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    /**
+     * Nested-resource cross-tenant attack — the scenario warroom concern #1
+     * flagged. Attacker uses their OWN tenant in the URL path (so
+     * {@link TenantPathGuard} passes) but references another tenant's
+     * providerId. The controller guard alone cannot catch this; the
+     * service layer must also enforce tenant-scoped lookup.
+     *
+     * <p>Verifies {@code TenantOAuth2ProviderService.findByIdOrThrow} uses
+     * {@code findByIdAndTenantId(id, TenantContext.getTenantId())}, which
+     * returns empty → 404 when the provider belongs to another tenant.
+     * If this test fails, the service-layer guard is missing and the
+     * guard helper is NOT sufficient defence-in-depth.
+     */
+    @Test
+    @DisplayName("PUT /tenants/{A}/oauth2-providers/{B-provider} → 404 (nested-resource attack, service-layer guard)")
+    void nestedResourceCrossTenantUpdate_returns404() {
+        UUID bProviderId = createOAuth2ProviderUnder(tenantBToken, tenantB.getId(), "nested-attack-target");
+
+        ResponseEntity<String> response = put(
+                "/api/v1/tenants/" + tenantA.getId() + "/oauth2-providers/" + bProviderId,
+                """
+                {
+                    "clientId": "attacker-hijacked",
+                    "clientSecret": "attacker-secret",
+                    "issuerUri": "https://evil.example.com",
+                    "enabled": true
+                }
+                """);
+        assertThat(response.getStatusCode())
+                .as("TenantPathGuard passes (A==A) but service-layer findByIdAndTenantId must reject B's provider. Response: %s", response.getBody())
+                .isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("DELETE /tenants/{A}/oauth2-providers/{B-provider} → 404 (nested-resource attack)")
+    void nestedResourceCrossTenantDelete_returns404() {
+        UUID bProviderId = createOAuth2ProviderUnder(tenantBToken, tenantB.getId(), "nested-delete-target");
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/v1/tenants/" + tenantA.getId() + "/oauth2-providers/" + bProviderId,
+                HttpMethod.DELETE,
+                new HttpEntity<>(authHeaders()),
+                String.class);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
     // --- helpers ---
+
+    private UUID createOAuth2ProviderUnder(String ownerToken, UUID ownerTenantId, String providerName) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(ownerToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        String body = """
+                {
+                    "providerName": "%s",
+                    "clientId": "test-client-id",
+                    "clientSecret": "test-secret-value",
+                    "issuerUri": "https://accounts.google.com"
+                }
+                """.formatted(providerName);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "/api/v1/tenants/" + ownerTenantId + "/oauth2-providers",
+                HttpMethod.POST,
+                new HttpEntity<>(body, headers),
+                Map.class);
+        assertThat(response.getStatusCode())
+                .as("Owner POST to create provider must succeed (response body: %s)", response.getBody())
+                .isEqualTo(HttpStatus.CREATED);
+        Object idRaw = response.getBody().get("id");
+        return UUID.fromString(idRaw.toString());
+    }
 
     private ResponseEntity<String> get(String path) {
         return restTemplate.exchange(path, HttpMethod.GET, new HttpEntity<>(authHeaders()), String.class);

--- a/backend/src/test/java/org/fabt/tenant/TenantIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/TenantIntegrationTest.java
@@ -133,40 +133,68 @@ class TenantIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void test_updateTenant() {
+    void test_updateTenant_selfTenant_ok() {
+        // Admin PUT on their OWN tenant must succeed. Per D15, PLATFORM_ADMIN is
+        // tenant-scoped (see openspec multi-tenant-production-readiness Phase M
+        // platform-admin-tenant-scoping-v0.48 + Phase D TenantPathGuard D11).
+        HttpHeaders headers = authHelper.adminHeaders();
+        UUID ownTenantId = authHelper.getTestTenantId();
+
+        // Read the original name so we can restore it (setupTestTenant is idempotent
+        // across tests via findBySlug — we must not leave a mutated name behind).
+        ResponseEntity<TenantResponse> before = restTemplate.exchange(
+                "/api/v1/tenants/" + ownTenantId,
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                TenantResponse.class);
+        assertThat(before.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String originalName = before.getBody().name();
+
+        try {
+            ResponseEntity<TenantResponse> response = restTemplate.exchange(
+                    "/api/v1/tenants/" + ownTenantId,
+                    HttpMethod.PUT,
+                    new HttpEntity<>("{\"name\": \"Updated Name\"}", headers),
+                    TenantResponse.class);
+            assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+            assertThat(response.getBody()).isNotNull();
+            assertThat(response.getBody().name()).isEqualTo("Updated Name");
+            assertThat(response.getBody().id()).isEqualTo(ownTenantId);
+        } finally {
+            // Restore so other tests see the setup-time name
+            restTemplate.exchange(
+                    "/api/v1/tenants/" + ownTenantId,
+                    HttpMethod.PUT,
+                    new HttpEntity<>("{\"name\": \"" + originalName + "\"}", headers),
+                    TenantResponse.class);
+        }
+    }
+
+    @Test
+    void test_updateTenant_otherTenant_rejectedBy_D11_guard() {
+        // D11 URL-path-sink: an admin in tenant A creates tenant B (bootstrap
+        // path is still open under D15), but then cannot rename B via
+        // PUT /api/v1/tenants/{B} — the TenantPathGuard rejects with 404
+        // (symmetric with D3 existence-leak posture). Phase F will revisit
+        // with a dedicated platform-operator role.
         HttpHeaders headers = authHelper.adminHeaders();
 
-        // Create a tenant to update
-        String slug = "update-test-" + UUID.randomUUID().toString().substring(0, 8);
-        String createBody = """
-                {"name": "Original Name", "slug": "%s"}
-                """.formatted(slug);
-
+        String slug = "update-rejected-" + UUID.randomUUID().toString().substring(0, 8);
         ResponseEntity<TenantResponse> created = restTemplate.exchange(
                 "/api/v1/tenants",
                 HttpMethod.POST,
-                new HttpEntity<>(createBody, headers),
-                TenantResponse.class
-        );
+                new HttpEntity<>("{\"name\": \"Foreign Name\", \"slug\": \"" + slug + "\"}", headers),
+                TenantResponse.class);
         assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
-        UUID tenantId = created.getBody().id();
+        UUID foreignTenantId = created.getBody().id();
 
-        // Update the tenant
-        String updateBody = """
-                {"name": "Updated Name"}
-                """;
-
-        ResponseEntity<TenantResponse> response = restTemplate.exchange(
-                "/api/v1/tenants/" + tenantId,
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/v1/tenants/" + foreignTenantId,
                 HttpMethod.PUT,
-                new HttpEntity<>(updateBody, headers),
-                TenantResponse.class
-        );
+                new HttpEntity<>("{\"name\": \"Attacker Name\"}", headers),
+                String.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(response.getBody()).isNotNull();
-        assertThat(response.getBody().name()).isEqualTo("Updated Name");
-        assertThat(response.getBody().slug()).isEqualTo(slug);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
     }
 
     @Test

--- a/e2e/playwright/deploy/post-deploy-smoke.spec.ts
+++ b/e2e/playwright/deploy/post-deploy-smoke.spec.ts
@@ -270,6 +270,12 @@ test.describe('Post-deploy smoke tests', () => {
 
     // PLATFORM_ADMIN lands at /admin
     await expect(page).toHaveURL(/admin/, { timeout: 15_000 });
+
+    // Tenant-identity UI surfaces (14.t-1, 14.t-2) — header chip + footer both
+    // render the authoritative tenant name, pinned here so a regression in
+    // either surface flags cross-tenant confusion before it reaches a user.
+    await expect(page.getByTestId('app-tenant-name')).toHaveText('Blue Ridge CoC (demo)');
+    await expect(page.getByTestId('app-tenant-name-footer')).toHaveText('Blue Ridge CoC (demo)');
   });
 
   test('14. Pamlico Sound admin can log in to dev-coc-east (PLATFORM_ADMIN, tenant-scoped)', async ({ page }) => {
@@ -280,6 +286,8 @@ test.describe('Post-deploy smoke tests', () => {
     await page.getByTestId('login-submit').click();
 
     await expect(page).toHaveURL(/admin/, { timeout: 15_000 });
+    await expect(page.getByTestId('app-tenant-name')).toHaveText('Pamlico Sound CoC (demo)');
+    await expect(page.getByTestId('app-tenant-name-footer')).toHaveText('Pamlico Sound CoC (demo)');
   });
 
   test('15. Cross-tenant login rejected — Blue Ridge admin creds in Pamlico tenant MUST fail 401', async ({ page }) => {

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -321,12 +321,16 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
               data-testid="app-tenant-name"
               title={user.tenantName}
               style={{
+                // Border-only pill: sidesteps opacity-over-header contrast
+                // concern (per project_accessibility_contrast_failures.md).
+                // headerText token is WCAG-verified against headerBg; used
+                // here for the border color and the text itself.
                 fontSize: text.sm,
                 color: color.headerText,
                 padding: '4px 10px',
                 borderRadius: '12px',
-                backgroundColor: 'rgba(255,255,255,0.12)',
-                border: '1px solid rgba(255,255,255,0.22)',
+                backgroundColor: 'transparent',
+                border: `1px solid ${color.headerText}`,
                 whiteSpace: 'nowrap',
                 maxWidth: '200px',
                 overflow: 'hidden',
@@ -458,12 +462,26 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
                     padding: '4px 0',
                   }}
                 >
+                  {/* Tenant identity — matches desktop chip; wayfinding on mobile */}
+                  {user?.tenantName && (
+                    <div
+                      data-testid="header-overflow-tenant-name"
+                      style={{
+                        padding: '12px 16px 4px',
+                        fontSize: text.sm,
+                        color: color.text,
+                        fontWeight: weight.semibold,
+                      }}
+                    >
+                      {user.tenantName}
+                    </div>
+                  )}
                   {/* Username display */}
                   {user && (
                     <div
                       data-testid="header-overflow-username"
                       style={{
-                        padding: '12px 16px',
+                        padding: user?.tenantName ? '0 16px 12px' : '12px 16px',
                         fontSize: text.sm,
                         color: color.textTertiary,
                         borderBottom: `1px solid ${color.border}`,

--- a/frontend/src/components/Layout.tsx
+++ b/frontend/src/components/Layout.tsx
@@ -316,6 +316,26 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
         </h1>
         <div style={{ display: 'flex', alignItems: 'center', gap: isMobile ? '8px' : '12px' }}>
           {/* Desktop-only inline controls */}
+          {!isMobile && user?.tenantName && (
+            <span
+              data-testid="app-tenant-name"
+              title={user.tenantName}
+              style={{
+                fontSize: text.sm,
+                color: color.headerText,
+                padding: '4px 10px',
+                borderRadius: '12px',
+                backgroundColor: 'rgba(255,255,255,0.12)',
+                border: '1px solid rgba(255,255,255,0.22)',
+                whiteSpace: 'nowrap',
+                maxWidth: '200px',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              {user.tenantName}
+            </span>
+          )}
           {!isMobile && user && (
             <span style={{ fontSize: text.base, color: color.headerText }}>
               {user.displayName || user.tenantName || ''}
@@ -588,6 +608,12 @@ export function Layout({ children, locale, onLocaleChange }: LayoutProps) {
               }}
             >
               Finding A Bed Tonight v{appVersion}
+              {user?.tenantName && (
+                <>
+                  {' — '}
+                  <span data-testid="app-tenant-name-footer">{user.tenantName}</span>
+                </>
+              )}
             </footer>
           )}
         </main>


### PR DESCRIPTION
## Summary

Three coherent slices for v0.48, carrying Phase M-light pull-forward (three tenants live in prod without waiting for Phase M proper closure gate).

### 1. V76 + V77 — Flyway tenant seeds (Phase M tasks 14.4–14.8, 14.4b–14.8b)
- `V76__seed_blue_ridge_demo_tenant.sql` — Blue Ridge CoC (demo), 6 users, 3 shelters (Boone/Waynesville/Undisclosed), bed_availability, `noaa_station_id=KAVL`
- `V77__seed_pamlico_sound_demo_tenant.sql` — Pamlico Sound CoC (demo), 6 users, 3 shelters (New Bern/Washington/Undisclosed), bed_availability, `noaa_station_id=KEWN`
- Idempotent: `ON CONFLICT DO UPDATE` on tenant/user/shelter/constraints, `DO NOTHING` on bed_availability
- Fresh local rehearsal: flyway_schema_history rows 76 + 77 both `success=t`, three tenants visible

### 2. Phase D core — URL-path-sink D11 (tasks 5.1–5.4, 5.9)
- New `TenantPathGuard.requireMatchingTenant(UUID)` helper in `org.fabt.shared.web` throws `NoSuchElementException` (→ 404 via `GlobalExceptionHandler`) when URL-path tenantId ≠ `TenantContext.getTenantId()`. Symmetric with D3 existence-leak posture.
- Applied to 9 endpoints:
  - `TenantController` (4): `update`, `getObservability`, `updateObservability`, `updateDvAddressPolicy`
  - `TenantConfigController` (2): `getConfig`, `updateConfig`
  - `OAuth2ProviderController` (4): `create` (was inline D11, refactored), `list`, `update`, `delete`
- `TenantPathGuardIntegrationTest`: **8 cases — 7 cross-tenant → 404, 1 same-tenant control → 200, all green**
- **Deferred** to follow-up PR (nginx defence-in-depth, not security-critical): 5.6 nginx `X-FABT-Tenant-Id`, 5.7 matching integration test, 5.8 `ingress-tenant-binding.md` doc. 5.5 blocked on Phase L typed config.

### 3. Tenant-identity UI surfaces (Phase M-light tasks 14.t-1 → 14.t-3)
Warroom-recommended pattern (Casey + Marcus + Alex + Riley 2026-04-20): neutral chip + augmented footer, no accent colors (walked back — gimmicky).
- `Layout.tsx` header — neutral pill left of user menu, `data-testid=app-tenant-name`, desktop-only
- `Layout.tsx` footer — `" — {tenantName}"` appended to version, `data-testid=app-tenant-name-footer`
- `post-deploy-smoke` tests 13 + 14 extended to assert both testids render expected tenant name

## Test plan
- [x] `mvn test -Dtest=TenantPathGuardIntegrationTest,OperationalMonitorServiceTest` → 19/19 green
- [x] `npm run build` (frontend) → clean, 0 TS errors
- [x] `./dev-start.sh --fresh --nginx` rehearsal: V76+V77 apply, 3 tenants live, per-tenant NOAA cached correctly (West=KAVL, East=KEWN, Central=KRDU fallback)
- [x] Playwright post-deploy smoke 13 + 14 + 15 → 3/3 green against local nginx :8081
- [ ] CI green: Backend, E2E, CodeQL, Legal, Flyway HWM guard, release-gate pin verify, pgaudit image, Phase B RLS test-discipline
- [ ] Holding for scans

## Notes for reviewer
- No public `multi-tenant demo live` announcement until Phase M proper ships the visual polish (14.9–14.17 walkthrough docs + screenshots)
- Pre-tag operator ask (Sam): rehearse V76+V77 on throwaway container before deploy — local `--fresh` rehearsal done; prod-analog rehearsal still pending per v0.43.1 pattern

Companion OpenSpec tick commit in docs repo: `4f26cac`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)