### PR TITLE
docs(runbook): canonical template + memory index + v0.49 worked example

### DIFF
--- a/RELEASE-NOTES-STRATEGY.md
+++ b/RELEASE-NOTES-STRATEGY.md
@@ -1,0 +1,43 @@
+# Release Notes Strategy
+
+## Runbook files
+
+Every production release ships a `docs/oracle-update-notes-vX.Y.Z.md` file.
+**All runbooks from v0.50.0 onward MUST follow `docs/runbook-template.md`.**
+
+The template defines:
+
+- Mandatory section order (8 sections, fixed)
+- `consulted:` frontmatter block listing every reviewed memory file
+- Service-recreate matrix (prevents "forgot to recreate frontend" class of errors)
+- Pre-deploy gate checklist derived from the `feedback_*.md` corpus
+- Mandatory Playwright smoke gate as a numbered post-deploy step
+- Rollback matrix
+
+The worked example is `docs/oracle-update-notes-v0.49.0.md` (back-converted
+to the template format on 2026-04-22).
+
+## Authoring a new runbook
+
+1. Copy `docs/runbook-template.md` to `docs/oracle-update-notes-vX.Y.Z.md`
+2. Fill in version-specific content
+3. Scan `docs/runbook-memory-index.md` and populate the `consulted:` block
+4. Check off the service-recreate matrix rows that apply
+5. Verify every mandatory pre-deploy gate is present
+6. Self-review: all 8 mandatory section headers present, in order
+
+The `opsx-runbook-draft-skill` change (when shipped) automates steps 1–3.
+The `ci-runbook-consulted-check` change (when shipped) validates the
+`consulted:` block in CI.
+
+## CHANGELOG entries
+
+`CHANGELOG.md` follows the Keep A Changelog convention. `[Unreleased]` items
+move to `[vX.Y.Z]` at release-prep time. The release-prep commit is tagged;
+the GitHub release is created only after CI scans are green
+(`feedback_release_after_scans.md`).
+
+## Older runbooks
+
+`docs/oracle-update-notes-v0.25.0.md` through `docs/oracle-update-notes-v0.48.1.md`
+are frozen historical artifacts. They are not migrated to the new template.

--- a/docs/oracle-update-notes-v0.49.0.md
+++ b/docs/oracle-update-notes-v0.49.0.md
@@ -174,7 +174,7 @@ docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc "
 
 ### 1. Confirm 8 operator env vars present in `~/fabt-secrets/.env.prod`
 
-Per `~/OneDrive/Documents/Ark Public Technology LLC/alertmanager-operator-setup.md`:
+Per the alertmanager operator setup guide (operator local docs, not in repo):
 
 ```bash
 grep -c "^FABT_ALERT_" ~/fabt-secrets/.env.prod
@@ -409,8 +409,8 @@ docker ps | grep alertmanager
 curl -s http://localhost:9093/api/v2/status | python3 -m json.tool | head -30
 # expect: versionInfo with "v0.27.0", no configError
 
-# Rendered config loaded (no ${} placeholders visible)
-docker exec <alertmanager-container-name> cat /etc/alertmanager/alertmanager.yml | grep -c '\${FABT_'
+# Rendered config: zero unresolved placeholders (structural check only — do NOT cat the file)
+docker exec <alertmanager-container-name> grep -c '\${FABT_' /etc/alertmanager/alertmanager.yml
 # expect: 0
 ```
 
@@ -500,7 +500,7 @@ regressed:
 # From laptop — Blue Ridge
 T=$(curl -s -X POST https://findabed.org/api/v1/auth/login \
   -H "Content-Type: application/json" \
-  -d '{"tenantSlug":"dev-coc-west","email":"dv-coordinator@blueridge.fabt.org","password":"admin123"}' \
+  -d '{"tenantSlug":"dev-coc-west","email":"dv-coordinator@blueridge.fabt.org","password":"<seed-password>"}' \
   | python -c "import sys,json; print(json.load(sys.stdin).get('accessToken',''))")
 curl -s -H "Authorization: Bearer $T" https://findabed.org/api/v1/dv-referrals/pending/count
 # Expected: {"count":N, "firstPending":...}  — count may be 0 if no pending

--- a/docs/oracle-update-notes-v0.49.0.md
+++ b/docs/oracle-update-notes-v0.49.0.md
@@ -1,5 +1,36 @@
 # Oracle Deploy Notes — v0.49.0 (Alertmanager routing: Prometheus → email + ntfy push)
 
+> **Template version:** runbook-template-v1 (back-converted 2026-04-22 as worked example)
+> This is the canonical worked example for the deploy runbook template. See `docs/runbook-template.md`.
+
+---
+
+## 1. Consulted Memories
+
+```yaml
+consulted:
+  - file: feedback_prod_docker_build_pattern.md
+    # why-cited: explicit docker build + --force-recreate required; three no-op traps
+  - file: feedback_bind_mount_inode_pitfall.md
+    # why-cited: prometheus.yml git-checkout on VM → --force-recreate, not /-/reload
+  - file: feedback_deploy_old_jars.md
+    # why-cited: mvn clean required before docker build to avoid stale JAR
+  - file: project_live_deployment_status.md
+    # why-cited: confirmed prod was on v0.48.0 (not v0.48.1), compose chain, Flyway HWM
+  - file: feedback_release_after_scans.md
+    # why-cited: GitHub release created only after CI green
+  - file: feedback_never_print_rendered_secrets.md
+    not-applicable: created mid-deploy (SMTP password leaked during v0.49 — this memory did not exist at author time; now back-cited as the lesson)
+  - file: feedback_verify_doc_facts_against_source.md
+    not-applicable: created mid-deploy (fabricated rule names + tenant slugs in triage runbook — this memory did not exist at author time; now back-cited as the lesson)
+  - file: feedback_smoke_spec_default_target.md
+    not-applicable: smoke gate was skipped entirely in this runbook (v0.49 issue; now a mandatory gate in the template)
+```
+
+---
+
+## 2. Scope & Non-Scope
+
 **From:** v0.48.0 live at `findabed.org` (NOTE: v0.48.1 was tagged
 2026-04-20 but **never shipped to prod** as a separate deploy — its
 content rolls forward into v0.49.0). Current prod state: 3 tenants, 9
@@ -103,7 +134,19 @@ now deliver through the pipeline. No new rules added in this release.
 
 ---
 
-## Pre-deploy sanity
+## 3. Service-Recreate Matrix
+
+| Service | What triggers recreate | Changed? | Recreate required? |
+|---|---|---|---|
+| `backend` + `frontend` | Any backend image rebuild — recreating backend without frontend leaves docker-network stale; host nginx serves 502s until both recreated. **This row is the v0.49 issue #3 lesson; deploy step 5 was originally missing `frontend` here, fixed in commit `def9ea7`.** | ☑ | ☑ |
+| `prometheus` | `prometheus.yml` replaced via `git checkout` / `git pull` — inode changes, `/-/reload` insufficient | ☑ (alerting block added) | ☑ via `curl -XPOST /-/reload` (acceptable here because `prometheus.yml` was edited in-place on VM — no git checkout; inode unchanged) |
+| `alertmanager` | New container — first deploy; rendered `~/fabt-secrets/alertmanager.yml` bind-mounted | ☑ (new container) | ☑ |
+| `postgres` | No pgaudit.conf change in this release | ☐ | ☐ |
+| Host `nginx` | No nginx config change in this release | ☐ | ☐ |
+
+---
+
+## 4. Pre-Deploy Gates
 
 ### 1a. Confirm v0.48.1 hot-patch is still intact on prod
 
@@ -205,7 +248,7 @@ test -f /tmp/v0.48-config.rendered.yml && \
 
 ---
 
-## Deploy steps
+## 5. Deploy Steps
 
 ### 1. Preserve last-good backend image
 
@@ -353,7 +396,7 @@ curl -s -XPOST http://localhost:9090/-/reload
 
 ---
 
-## Post-deploy sanity
+## 6. Post-Deploy Gates
 
 ### 1. Alertmanager is up + config accepted
 
@@ -476,7 +519,7 @@ curl -s http://localhost:9090/api/v1/rules | python3 -c \
 
 ---
 
-## Rollback
+## 7. Rollback Matrix
 
 V0.49 adds capability but doesn't change existing behavior. If
 Alertmanager causes any issue:
@@ -506,7 +549,7 @@ Backend is unchanged; no backend rollback needed.
 
 ---
 
-## After deploy succeeds
+## 8. Post-Deploy Housekeeping
 
 1. **Delete the v0.49 test alert** from the Alertmanager UI (the firing
    `FabtV049DeployTest` alert will self-resolve after ~5 min; speed it
@@ -547,6 +590,28 @@ Backend is unchanged; no backend rollback needed.
    - Demo-tier (no BAA, ntfy public topic with long-random shared-secret
      name). Regulated-tier escalation path documented in
      `docs/security/compliance-posture-matrix.md` — Phase F territory
+
+---
+
+### Lessons Surfaced (v0.49 deploy — 10 issues)
+
+The following issues hit during the v0.49 live deploy on 2026-04-20. Each entry
+records whether the lesson was already in a memory file (missed) or is new.
+
+| # | Issue | Pre-existing memory? | Outcome |
+|---|---|---|---|
+| 1 | Env-var trailing-space (`FABT_ALERT_NTFY_TOPIC= xyz`) breaks `source <(grep ...)` | No — new lesson | New pre-deploy gate added to `docs/runbook-template.md` |
+| 2 | `chmod 644` needed (not 600) — alertmanager container runs as UID 65534 (`nobody`) | No — new lesson | New pre-deploy gate added to template |
+| 3 | `--force-recreate` must include `frontend` — backend-only recreate leaves docker-network stale | Yes — `feedback_prod_docker_build_pattern.md` (MISSED) | Service-recreate matrix row (a) explicitly calls this out |
+| 4 | Wait-loop must use `http://localhost:9091/actuator/health`, not public URL | Yes — `project_live_deployment_status.md` Lesson 3 (MISSED) | Now in template § Deploy Steps wait loop with callout |
+| 5 | Prometheus `external_labels` invisible to local PromQL — use `scrape_configs.labels` | Yes — `feedback_prometheus_external_labels_gotcha.md` (MISSED) | Not a deploy step, but cited in memory index |
+| 6 | Docker bind-mount `prometheus.yml` inode pitfall — `git checkout` = new inode, `/-/reload` fails | Yes — `feedback_bind_mount_inode_pitfall.md` (MISSED) | Service-recreate matrix row (b) + pre-deploy gate |
+| 7 | Playwright smoke gate omitted entirely — no end-to-end verification ran | Yes — implied by `feedback_smoke_spec_default_target.md` (MISSED) | Now a mandatory numbered post-deploy gate in template |
+| 8 | Alertmanager template `default` (Sprig) not available in v0.27.0 — `function "default" not defined` | No — new lesson | `feedback_alertmanager_template_funcs.md` created; deploy fixed in commit `47d348d` |
+| 9 | SMTP password leaked to transcript via `grep ~/fabt-secrets/alertmanager.yml` | No — new lesson | `feedback_never_print_rendered_secrets.md` created; Gmail app password rotated |
+| 10 | Fabricated rule names + tenant slugs in `alertmanager-triage-runbook.md` | No — new lesson | `feedback_verify_doc_facts_against_source.md` created; triage runbook rewritten against source |
+
+**Pattern:** issues 3–7 all had pre-existing memory entries that the runbook author did not consult. The `consulted:` frontmatter block above lists what SHOULD have been reviewed; the `not-applicable:` entries flag the two memories that didn't exist yet.
 
 ---
 

--- a/docs/runbook-memory-index.md
+++ b/docs/runbook-memory-index.md
@@ -1,0 +1,57 @@
+# Deploy Runbook Memory Index
+
+Scannable index of every memory file relevant to deploy operations.
+Scan this before authoring a new `docs/oracle-update-notes-vX.Y.Z.md` to
+populate the `consulted:` block.
+
+**Editorial note:** Add a new entry here whenever a `feedback_*.md` or
+`project_*.md` file is created that encodes a deploy, ops, or runbook
+lesson. The test: "would a future runbook author need to know this?"
+
+**Index discipline:** each entry is one line, ≤150 chars. Topic then implication.
+
+---
+
+## Deploy execution
+
+- `feedback_prod_docker_build_pattern.md` — `up --build` is NO-OP; use `docker build --no-cache` + `--force-recreate`. Three v0.48 traps.
+- `feedback_bind_mount_inode_pitfall.md` — single-file bind-mount holds inode; `git checkout` = new inode → `--force-recreate` needed, not reload.
+- `feedback_deploy_old_jars.md` — always `mvn clean package`; stale JARs in `target/` cause `COPY *.jar` to pick up the wrong version.
+- `feedback_stale_sw_on_deploy.md` — old service worker serves cached JS post-deploy; test in incognito or clear site data.
+- `feedback_deploy_checklist_v031.md` — post-deploy checklist: verify JAR version, actuator :9091, class verification, image prune.
+- `feedback_cleanup_old_artifacts.md` — remove stale JARs and Docker images after each Oracle deploy.
+
+## Pre-deploy safety
+
+- `feedback_never_print_rendered_secrets.md` — **CRITICAL**: never cat/grep `.env.prod` or `alertmanager.yml`; placeholder-count + wc-l checks only.
+- `feedback_release_after_scans.md` — GitHub release only after CI scans green; tag first, `gh release create` second.
+- `feedback_flyway_immutable_after_apply.md` — **CRITICAL**: never edit applied Flyway migration (even comments); mismatch → backend won't start.
+- `feedback_never_guess_deployment.md` — **HIGHEST PRIORITY**: read deployment docs before acting; never guess on Oracle VM.
+- `feedback_no_ip_in_repo.md` — VM IP must not appear in git-tracked files; fine in memory only.
+
+## Post-deploy verification
+
+- `feedback_smoke_spec_default_target.md` — smoke specs need `BASE_URL=https://findabed.org` override; default is localhost, CI will hit prod WAF.
+- `feedback_check_ports_before_assuming.md` — **CRITICAL**: Playwright uses `BASE_URL=http://localhost:8081` (nginx), never bare Vite port.
+- `feedback_deploy_verify_isolation.md` — post-deploy smoke specs live in `deploy/` dir, NOT `tests/`; wrong dir corrupts seed passwords.
+- `project_oracle_deployment_lessons.md` — 10 gotchas from first Oracle deploy: fabt_app password, port 9091, CORS, iptables, container names.
+
+## Infrastructure & config
+
+- `project_live_deployment_status.md` — current prod: version, containers, compose chain, HWM, tenants, Alertmanager, rollback image.
+- `feedback_prometheus_external_labels_gotcha.md` — `external_labels` invisible to local PromQL/rule eval; use `scrape_configs` labels.
+- `feedback_alertmanager_template_funcs.md` — Alertmanager v0.27.0 has 9 template funcs, NO Sprig; use Go `with`/`else` not `default`.
+- `feedback_pgaudit_include_dir_existing_volume.md` — pgaudit `include_dir` fresh pgdata only; existing volumes need direct `postgresql.conf` edit.
+
+## Documentation accuracy
+
+- `feedback_verify_doc_facts_against_source.md` — grep source before naming rules/slugs/metrics; v0.49 had 7/9 wrong rule names + invented slugs.
+- `feedback_no_ssh_tunnels.md` — share SSH tunnel commands, don't execute them; confirm operator SSH session before starting deploy.
+
+## Process & tooling
+
+- `feedback_devstart_pid_desync.md` — `.pid-backend` stale → port 8080 collision; use `./dev-start.sh stop` (script handles PID cleanup).
+- `feedback_use_dev_start_script.md` — always use `./dev-start.sh` for local stack; never raw `docker compose`.
+- `feedback_maven_not_gradle.md` — build tool is Maven (`pom.xml`); never use gradle/gradlew.
+- `feedback_build_before_commit.md` — **CRITICAL**: run `npm run build` (tsc + vite) before committing any frontend change.
+- `feedback_no_brute_force.md` — fix the script itself, don't hack around broken scripts.

--- a/docs/runbook-template.md
+++ b/docs/runbook-template.md
@@ -1,0 +1,223 @@
+# Deploy Runbook Template
+
+Every `docs/oracle-update-notes-vX.Y.Z.md` file MUST follow this template.
+Copy it, fill in the version-specific content, and check off each mandatory
+element before tagging a release.
+
+**Template version:** v1 (2026-04-22)
+**Related changes:** `opsx-runbook-draft-skill` (auto-populates this template),
+`ci-runbook-consulted-check` (lints the `consulted:` block in CI)
+
+---
+
+## Mandatory section order
+
+Every runbook must have these 8 sections in this order:
+
+1. Consulted Memories
+2. Scope & Non-Scope
+3. Service-Recreate Matrix
+4. Pre-Deploy Gates
+5. Deploy Steps
+6. Post-Deploy Gates
+7. Rollback Matrix
+8. Post-Deploy Housekeeping
+
+Additional sections (e.g. detailed sub-steps, "What's New", release-specific
+notes) may appear between any two mandatory sections or nested within them.
+Do not reorder the 8 mandatory sections.
+
+---
+
+## 1. Consulted Memories
+
+Each runbook author MUST review deploy-relevant memory files before authoring
+the runbook and list them here. See `docs/runbook-memory-index.md` for the
+full scannable list.
+
+```yaml
+consulted:
+  - file: feedback_prod_docker_build_pattern.md
+    # why-cited: explicit docker build + --force-recreate required; three no-op traps documented
+  - file: feedback_bind_mount_inode_pitfall.md
+    # why-cited: any prometheus.yml git-checkout on VM requires --force-recreate, not just /-/reload
+  - file: feedback_deploy_old_jars.md
+    # why-cited: mvn clean is mandatory before docker build to avoid stale JAR in image
+  - file: feedback_never_print_rendered_secrets.md
+    # why-cited: never cat/grep .env.prod or alertmanager.yml — structural checks only
+  - file: feedback_smoke_spec_default_target.md
+    # why-cited: post-deploy Playwright smoke must use BASE_URL override against findabed.org
+  - file: project_live_deployment_status.md
+    # why-cited: current prod state (version, containers, compose chain, Flyway HWM, lessons)
+  - file: feedback_release_after_scans.md
+    not-applicable: omit if this is a docs-only commit with no release tag
+  - file: feedback_verify_doc_facts_against_source.md
+    # why-cited: before naming rule names / slugs / table lists, grep the source file
+```
+
+> **How to fill in this block:** scan `docs/runbook-memory-index.md` for
+> entries marked `[deploy]` or `[security]`. Add any that are relevant. Use
+> `not-applicable: <reason>` for entries you explicitly reviewed and dismissed.
+> Do NOT omit the block — an empty `consulted:` with a reason is better than
+> a missing block.
+
+---
+
+## 2. Scope & Non-Scope
+
+**Deploying:** vX.Y.Z — one-line description of the user-visible change
+
+**From:** `vA.B.C` live at `findabed.org` (confirm current version via
+`curl -s https://findabed.org/api/v1/version`)
+
+**To:** `vX.Y.Z` (describe what ships)
+
+**What does NOT change in this deploy** (explicit list reduces cognitive load
+during a stressful deploy):
+
+- Backend Java code — no change / changed
+- Frontend — no change / rebuilt (if rebuilt, docker build step required)
+- Postgres / pgaudit — no restart / restart required
+- Flyway schema — no new migrations / migrations VNN–VMM
+- FORCE RLS posture — unchanged
+
+---
+
+## 3. Service-Recreate Matrix
+
+Check each row before writing deploy steps. "Changed?" refers to whether the
+service's config or image changed in this release. "Recreate required?" is
+the action consequence.
+
+| Service | What triggers recreate | Changed? | Recreate required? |
+|---|---|---|---|
+| `backend` + `frontend` | Any backend image rebuild — recreating backend without frontend leaves docker-network stale (v0.49 issue #3); host nginx serves 502s | ☐ | ☐ |
+| `prometheus` | `prometheus.yml` replaced via `git checkout` / `git pull` — inode changes, `/-/reload` insufficient (`feedback_bind_mount_inode_pitfall.md`) | ☐ | ☐ |
+| `alertmanager` | Rendered `~/fabt-secrets/alertmanager.yml` re-rendered (new inode on `envsubst` output) | ☐ | ☐ |
+| `postgres` | `pgaudit.conf` edited in place (`sed -i` / `vim` OK; `cp` / `git checkout` requires recreate) | ☐ | ☐ |
+| Host `nginx` | `/etc/nginx/sites-available/fabt` edited — `nginx -s reload` sufficient (no bind-mount, in-place edit) | ☐ | ☐ |
+
+> **Rule:** if a row is checked "Changed? ☑" you MUST also check "Recreate
+> required? ☑" and include an explicit `--force-recreate <service>` in the
+> Deploy Steps.
+
+---
+
+## 4. Pre-Deploy Gates
+
+Check each gate before starting any deploy action. Every gate has a pass/fail
+criterion — do not proceed if a gate fails.
+
+- [ ] **Env-var trailing-space lint** — `grep -nE "^FABT_[A-Z_]*= " ~/fabt-secrets/.env.prod` must return NO output. A trailing space after `=` breaks `source <(grep ...)` at render time. (v0.49 issue #1)
+- [ ] **mvn clean** — run `mvn -B -DskipTests clean package -q`; verify exactly 1 JAR in `backend/target/` before `docker build`. (`feedback_deploy_old_jars.md`)
+- [ ] **Container UID vs perms** — any config file bind-mounted into a container must be readable by the container's UID. Alertmanager runs as UID 65534 (`nobody`): needs `chmod 644`. Backend runs as UID 1000. (`project_live_deployment_status.md` v0.49 issue #2)
+- [ ] **pg_dump backup** — `docker exec finding-a-bed-tonight-postgres-1 pg_dump -U fabt -d fabt -Fc > ~/fabt-backups/fabt-pre-vX.Y.Z-$(date -u +%Y%m%d-%H%M%S).dump`
+- [ ] **CI green** — `gh run list --branch main --limit 3` — all runs green. (`feedback_release_after_scans.md`)
+- [ ] **SSH access confirmed** — open an SSH session to the VM before starting. Do not assume it will be reachable mid-deploy. (`feedback_no_ssh_tunnels.md`)
+- [ ] **Compose dry-render** — `docker compose -f docker-compose.yml -f ~/fabt-secrets/docker-compose.prod.yml ... config > /tmp/vX.Y.Z-config.rendered.yml` — inspect for expected changes; diff against prior render if available.
+
+---
+
+## 5. Deploy Steps
+
+Number every step. The first step is always "preserve last-good image tags."
+
+### 1. Preserve last-good image tags
+
+```bash
+docker tag fabt-backend:latest fabt-backend:vPREV-lastgood
+docker tag fabt-frontend:latest fabt-frontend:vPREV-lastgood
+docker images | grep -E "fabt-(backend|frontend)"
+# Confirm: latest + vPREV-lastgood both present; IMAGE IDs will match (same image, two tags)
+```
+
+### 2. [Release-specific steps]
+
+Use `feedback_prod_docker_build_pattern.md` for the canonical build sequence:
+1. `mvn clean package -DskipTests -q`
+2. `docker build --no-cache -f infra/docker/Dockerfile.backend -t fabt-backend:vNEW -t fabt-backend:latest .`
+3. `docker build --no-cache -f infra/docker/Dockerfile.frontend -t fabt-frontend:vNEW -t fabt-frontend:latest .` (skip if no frontend change)
+4. `docker compose -f docker-compose.yml -f ... up -d --force-recreate backend frontend`
+
+### N. Wait for backend readiness
+
+```bash
+# Use internal management port — NOT the public URL (returns 404; v0.49 issue #4)
+until curl -fsS http://localhost:9091/actuator/health 2>/dev/null | grep -q '"status":"UP"'; do
+    echo "waiting for backend..."; sleep 3
+done
+echo "backend is UP"
+```
+
+---
+
+## 6. Post-Deploy Gates
+
+Run every gate; record the actual value alongside the expected.
+
+### Mandatory smoke gate
+
+```bash
+# Must use BASE_URL override — smoke specs default to localhost (feedback_smoke_spec_default_target.md)
+cd e2e/playwright && BASE_URL=https://findabed.org npx playwright test \
+    --config=deploy/playwright.config.ts --reporter=list --trace on \
+    2>&1 | tee ../../logs/post-deploy-smoke-vX.Y.Z.log
+```
+
+> **Do NOT skip this gate.** The smoke is the only test that exercises the full
+> Cloudflare → host nginx → frontend → backend chain. It is a numbered gate,
+> not an "if time permits" footnote.
+
+### Version check
+
+```bash
+curl -s https://findabed.org/api/v1/version
+# expect: {"version":"X.Y.Z", ...}
+```
+
+### Flyway HWM
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc \
+  "SELECT version, description, success FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 3;"
+# expect: top row = newest migration, success=t
+```
+
+### [Release-specific gates]
+
+Add any gates specific to this release (new container health, config acceptance,
+end-to-end smoke for new feature, etc.)
+
+---
+
+## 7. Rollback Matrix
+
+| Symptom | Action |
+|---|---|
+| Backend won't start (Flyway validate error) | Never modify applied migrations. Revert the file to exact pre-deploy byte content, then `docker compose up -d --force-recreate backend`. |
+| Frontend serving stale JS after deploy | Old service worker cached. Use incognito or clear site data. (`feedback_stale_sw_on_deploy.md`) |
+| Host nginx 502 after backend recreate | Frontend docker-network is stale — recreate frontend too: `docker compose ... up -d --force-recreate frontend`. |
+| Prometheus shows stale config after `prometheus.yml` update | `git checkout` changed the inode — `/-/reload` insufficient. Run `docker compose ... up -d --force-recreate prometheus`. (`feedback_bind_mount_inode_pitfall.md`) |
+| Alertmanager config error (`function "X" not defined`) | Sprig helper used in template. Replace with Go `with`/`else`. (`feedback_alertmanager_template_funcs.md`) |
+| Full rollback needed | `docker tag fabt-backend:vPREV-lastgood fabt-backend:latest` then `docker compose ... up -d --force-recreate backend frontend`. |
+
+---
+
+## 8. Post-Deploy Housekeeping
+
+- [ ] Update `project_live_deployment_status.md` memory — version, Flyway HWM, container list, any new lessons
+- [ ] Delete/expire any test alerts fired during deploy verification
+- [ ] Update `CHANGELOG.md` `[Unreleased]` section to move items under `[vX.Y.Z]`
+- [ ] Archive any spent OpenSpec changes (`/opsx:archive`)
+- [ ] Per `feedback_periodic_resume_save.md`: update relevant `project_*_resume_point.md` memory files
+
+---
+
+## Related changes
+
+- `opsx-runbook-draft-skill` — skill that seeds a new `docs/oracle-update-notes-vX.Y.Z.md` from this template, auto-populates the `consulted:` block from `docs/runbook-memory-index.md`
+- `ci-runbook-consulted-check` — CI check that lints the `consulted:` block (presence, non-empty entries, valid file names against the memory index)
+
+---
+
+*FABT Deploy Runbook Template v1 — applies to all `docs/oracle-update-notes-vX.Y.Z.md` files from v0.50.0 onward*


### PR DESCRIPTION
## Summary

- Adds `docs/runbook-template.md` — canonical 8-section deploy runbook template (Consulted Memories → Scope → Service-Recreate Matrix → Pre-Deploy Gates → Deploy Steps → Post-Deploy Gates → Rollback Matrix → Post-Deploy Housekeeping); applies to all `docs/oracle-update-notes-vX.Y.Z.md` from v0.50.0 onward
- Adds `docs/runbook-memory-index.md` — 22-entry flat index of every deploy-relevant memory file; authors scan this to populate the `consulted:` block before each release
- Converts `docs/oracle-update-notes-v0.49.0.md` to the template format as the canonical worked example — adds `consulted:` frontmatter, numbered section headers, Service-Recreate Matrix with v0.49 actual state, and a 10-row Lessons Surfaced table
- Updates `RELEASE-NOTES-STRATEGY.md` to reference the template as the authoritative shape for all future runbooks

## Security review (warroom — Marcus / Jordan)

Three issues found and fixed before this PR was opened:

| # | Issue | Fix |
|---|---|---|
| 1 | `~/OneDrive/Documents/Ark Public Technology LLC/alertmanager-operator-setup.md` in v0.49 runbook — leaks company legal name and local filesystem path into public repo | Replaced with `the alertmanager operator setup guide (operator local docs, not in repo)` |
| 2 | `docker exec ... cat /etc/alertmanager/alertmanager.yml \| grep -c` — `cat`-ing a rendered secrets file contradicts `feedback_never_print_rendered_secrets.md`; SMTP password visible in scroll-back | Rewrote as direct `docker exec ... grep -c '\${FABT_' /etc/alertmanager/alertmanager.yml` (structural count only) |
| 3 | Hardcoded `"password":"admin123"` seed credential in the banner smoke-check curl command | Replaced with `"password":"<seed-password>"` placeholder |

No IP addresses, no API keys, no real credentials remain in any of the three files.

## Test plan

- [ ] Open `docs/runbook-template.md` in GitHub preview — confirm `consulted:` YAML block renders, section headers display, matrices are readable
- [ ] Open `docs/oracle-update-notes-v0.49.0.md` in GitHub preview — confirm `consulted:` block, 8 section headers in order, Service-Recreate Matrix, Lessons Surfaced table all render correctly
- [ ] Confirm no IP addresses, no credentials, no company-specific filesystem paths in any of the three new/modified files
- [ ] Per `feedback_release_after_scans.md` — wait for CI green before merge (docs-only, no version bump, no deploy, no release tag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)