### PR TITLE
Phase F: tenant lifecycle FSM + real crypto-shred (v0.51.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,134 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [v0.51.0] — Phase F F-6: real crypto-shred via per-tenant wrapped DEKs
+
+**Backend-code release.** First since v0.49 (v0.50 was ops-tier). Backend
+JAR bumped `0.49.0 → 0.51.0`. Flyway HWM advances V78 → V84. Frontend,
+nginx, alertmanager, prometheus images all unchanged.
+
+**Operator action required before deploy:** `pg_dump` backup to
+`~/fabt-backups/` — V82/V83/V84 are irreversible without `pg_restore`.
+Deploy runbook: `docs/oracle-update-notes-v0.51.0.md`.
+
+### Added
+
+- **Real crypto-shred for per-tenant data (`TenantLifecycleService.hardDelete`).**
+  Phase F slice F-6 converts the `§D11` crypto-shred claim from a design
+  statement into a verifiable cryptographic property. Per-tenant data-
+  encryption DEKs are now random (not HKDF-derived), wrapped via AES-KWP
+  per RFC 5649 under a master-KEK-derived wrapping key, and stored in a
+  new `tenant_dek` table. `hardDelete` fires a single `DELETE FROM tenant`
+  that unwinds 22 `ON DELETE CASCADE` FKs including `tenant_dek`; post-
+  commit, the wrapped DEKs exist nowhere in the live database or in any
+  application cache. A TDD anchor test
+  (`CryptoShredGapIntegrationTest`) asserts an adversary with the master
+  KEK and a pre-shred ciphertext cannot recover plaintext after the
+  shred. Designed to support NIST SP 800-88 Rev 2 §2.5 "Cryptographic
+  Erase" as the operational-data destruction mechanism. Not a compliance
+  certification; backup/PITR retention and master KEK posture remain
+  separate controls documented in `docs/security/crypto-shred-runbook.md`.
+
+- **V79–V84 Flyway migrations.**
+  - V79 converts `tenant.state` from a native Postgres enum to
+    `VARCHAR(32) + CHECK`. Spring Data JDBC simple-type handling is
+    cleaner without the custom enum converter.
+  - V80 creates `tenant_audit_chain_head` with `ON DELETE CASCADE` +
+    backfills existing tenants with a 32-byte zero-hash sentinel.
+  - V81 adds `offboard_export_receipt_uri` + `archived_at` columns to
+    `tenant`. Starts the 30-day retention clock on archive.
+  - V82 creates `tenant_dek` with FORCE RLS + PERMISSIVE+RESTRICTIVE
+    policy pair (V68 shape) + a SECURITY DEFINER `BEFORE DELETE`
+    trigger guard that raises unless `fabt.shred_in_progress` session
+    GUC matches the row's `tenant_id`.
+  - V83 Java migration re-encrypts the 4 V74-era ciphertext columns
+    (app_user.totp_secret_encrypted, subscription.callback_secret_hash,
+    tenant_oauth2_provider.client_secret_encrypted,
+    tenant.config→hmis_vendors[].api_key_encrypted) under fresh random
+    DEKs. Per-row tx with round-trip verify. Includes an integrated
+    rotation-readiness probe that exercises the atomic generation flip.
+  - V84 flips 18 child-table FKs to `ON DELETE CASCADE` via a
+    `DO $$` block using `NOT VALID` + `VALIDATE CONSTRAINT` to avoid
+    the full-table ACCESS EXCLUSIVE window a naive `ALTER TABLE` would
+    hold.
+
+- **Seven §11 test-strategy tests** pinning the crypto-shred property:
+  - `CryptoShredGapIntegrationTest` — adversary-vs-shred TDD anchor
+  - `NTenantCanaryShredTest` — 10-seed property-style 400-ciphertext
+    regression suite
+  - `RotationReadinessProbeTest` (via V83 IT) — atomic generation flip
+  - `TenantDekRlsTest` — 6-assertion PERMISSIVE+RESTRICTIVE RLS boundary
+  - `TenantChildCascadeAuditTest` — Flyway CI drift guard for the 22-FK
+    CASCADE invariant
+  - `V83MigrationIntegrationTest` — idempotency + completeness +
+    rotation probe
+  - `TenantDekShredGuardTest` — trigger positive + no-GUC + cross-tenant
+    GUC-poisoning paths
+
+- **ArchUnit Family F rules** (`CryptoShredArchitectureTest`):
+  - 7.8h: only `TenantDekService` may call
+    `KeyDerivationService.deriveKekWrappingKey`.
+  - 7.8j: only `TenantLifecycleService` and the V83 migration may
+    reference the `fabt.shred_in_progress` session GUC. Source-file
+    scan (comment-stripped) because ArchUnit cannot match against SQL
+    string contents inside a JDBC call.
+
+- **`PurposeMismatchException extends SecurityException`** — raised by
+  `SecretEncryptionService.decryptForTenant` when the caller's
+  `KeyPurpose` disagrees with the `tenant_dek` row's recorded purpose.
+  Explicit check upstream of the GCM-tag failure so incident responders
+  can distinguish "programming bug" from "forged ciphertext."
+
+- **Retention-days floor guard** on `TenantLifecycleService` — rejects
+  negative `fabt.tenant.hard-delete.retention-days`; logs WARN on zero
+  (valid only for test profiles). Prod default stays 30.
+
+- **Feature runbook:** `docs/security/crypto-shred-runbook.md` — operator
+  procedures, 5-query post-shred verification checklist, backup-hygiene
+  scope, V84 rollback template, known-edge-cases (pod-crash window,
+  PITR-into-shred-window).
+
+### Changed
+
+- **`SecretEncryptionService.encryptForTenant` / `decryptForTenant` now
+  route through `TenantDekService`** (the new service that owns
+  `tenant_dek`). Both methods reject `KeyPurpose.JWT_SIGN` at the boundary
+  — JWT signing has its own lifecycle in `kid_to_tenant_key` and is
+  deliberately excluded from `tenant_dek.purpose`'s `CHECK` constraint.
+  A bounded backward-compat shim in `decryptV1LegacyHkdf` continues to
+  decrypt pre-V83 v1-HKDF envelopes so nothing breaks during the V82
+  → V83 deploy window. Post-V83 (runs automatically on first backend
+  boot after the upgrade) the shim handles only legacy/cached values;
+  the `secret.decrypt.v1.legacy_hkdf` counter trends to zero. Phase L
+  retires the shim.
+
+- **Cache invalidation on `OFFBOARDING` and `ARCHIVED` transitions.**
+  `TenantLifecycleService.doOffboard` / `doArchive` now invalidate both
+  `TenantStateGuard` AND `TenantDekService` caches via a single after-
+  commit hook. Closes the hot-JVM decrypt window during retention that
+  the 1-hour `resolveDek` cache TTL would otherwise leave open.
+
+### Deprecated
+
+- `KeyDerivationService.deriveTotpKey`, `.deriveWebhookSecretKey`,
+  `.deriveOauth2ClientSecretKey`, `.deriveHmisApiKey` — marked
+  `@Deprecated(since="v0.51.0", forRemoval=true)`. Retained for the
+  backward-compat shim (reads pre-V83 envelopes) and the
+  `CryptoShredGapIntegrationTest` adversary simulation. Phase L removes
+  them entirely. `deriveJwtSigningKey` and the new private
+  `deriveKekWrappingKey` stay; JWT signing remains HKDF-derived.
+
+### Security
+
+- **CVE-adjacent:** the cross-primitive key-reuse vector through the
+  backward-compat shim (a caller passing `KeyPurpose.JWT_SIGN` + a v1
+  envelope whose kid lived in `kid_to_tenant_key`) is closed by the
+  symmetric `JWT_SIGN` guard added to `decryptForTenant` at method
+  entry. Discovered in warroom code-review pass-3 (2026-04-24) before
+  ship; no known exploitation.
+
+---
+
 ## [v0.50.0] — Ops hardening: Phase D nginx header stripping + deploy rehearsal harness
 
 **Operations-tier release.** No backend code change, no schema migrations.

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.fabt</groupId>
     <artifactId>finding-a-bed-tonight</artifactId>
-    <version>0.50.0</version>
+    <version>0.51.0</version>
     <name>Finding A Bed Tonight</name>
     <description>Open-source shelter bed availability platform</description>
 

--- a/backend/src/main/java/db/migration/V83__reencrypt_v1_envelopes_under_tenant_dek.java
+++ b/backend/src/main/java/db/migration/V83__reencrypt_v1_envelopes_under_tenant_dek.java
@@ -1,0 +1,880 @@
+package db.migration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.sql.Connection;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.flywaydb.core.api.migration.BaseJavaMigration;
+import org.flywaydb.core.api.migration.Context;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import tools.jackson.core.StreamReadConstraints;
+import tools.jackson.core.json.JsonFactory;
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+import tools.jackson.databind.node.ObjectNode;
+
+/**
+ * V83 — Re-encrypt existing v1-HKDF ciphertexts under per-tenant random DEKs in
+ * {@code tenant_dek} (F-6.0 task 7.8d, design-f6-real-cryptoshred §8).
+ *
+ * <p>Counterpart to V74: V74 migrated v0 (single-platform-key) to v1-HKDF
+ * (kid in {@code kid_to_tenant_key}, DEK deterministically derived from
+ * master_KEK + tenantId + purpose). V83 migrates v1-HKDF to v1-random
+ * (kid in {@code tenant_dek}, DEK randomly generated + wrapped via AES-KWP).
+ *
+ * <p>The net effect, after both migrations, is every persisted secret is
+ * wrapped under a DEK that exists ONLY inside {@code tenant_dek}.
+ * {@code TenantLifecycleService.hardDelete} cascading that row away is
+ * what makes the §D11 crypto-shred claim true — per the TDD anchor
+ * {@code CryptoShredGapIntegrationTest} (commit b5672da).
+ *
+ * <h2>Columns walked</h2>
+ *
+ * Same 4 columns V74 touched (design-f6 §8 + Appendix A):
+ *
+ * <ol>
+ *   <li>{@code app_user.totp_secret_encrypted}</li>
+ *   <li>{@code subscription.callback_secret_hash}</li>
+ *   <li>{@code tenant_oauth2_provider.client_secret_encrypted}</li>
+ *   <li>{@code tenant.config → hmis_vendors[].api_key_encrypted}</li>
+ * </ol>
+ *
+ * <h2>Discriminator — which rows re-encrypt</h2>
+ *
+ * For each column, select rows whose value is a v1 envelope AND whose
+ * kid does NOT exist in {@code tenant_dek}. Equivalent checks:
+ *
+ * <ul>
+ *   <li>v1 envelope: isV1Envelope(Base64-decoded bytes) is true</li>
+ *   <li>kid not in tenant_dek: {@code NOT EXISTS (SELECT 1 FROM tenant_dek WHERE kid = ?)}</li>
+ * </ul>
+ *
+ * Rows whose kid IS already in {@code tenant_dek} are already in the target
+ * state — skip with counter {@code skipped_already_tenant_dek}.
+ *
+ * <h2>Per-row transaction with round-trip verify (warroom pass-2 Sam)</h2>
+ *
+ * Q-F6-2 resolution: per-row tx with round-trip verify, matching V74's
+ * shape. ~65 rewrites × ~10ms each ≈ sub-second at pilot scale. Per-row
+ * isolates failures — a single corrupt row fails just that row's tx; the
+ * rest continue.
+ *
+ * <p>Round-trip: immediately after writing the new v1-random envelope,
+ * unwrap the DEK from {@code tenant_dek}, decrypt the envelope, compare
+ * to the original plaintext. Mismatch = IllegalStateException = migration
+ * fail + rollback.
+ *
+ * <h2>Rotation-readiness probe (warroom pass-2 Jordan, Q-F6-4 fold-in)</h2>
+ *
+ * After the re-encrypt phase, if any {@code tenant_dek} rows exist, the
+ * migration exercises the rotation path on ONE row:
+ *
+ * <ol>
+ *   <li>Pick any (tenant, purpose) that has an active gen=1 row</li>
+ *   <li>UPDATE gen=1 SET active=FALSE, rotated_at=NOW() — must succeed</li>
+ *   <li>INSERT gen=2 active=TRUE with a freshly wrapped DEK — must succeed</li>
+ *   <li>SELECT COUNT active rows: must be exactly 1 (gen=2)</li>
+ *   <li>Flip back: UPDATE gen=2 SET active=FALSE, DELETE gen=2 UPDATE gen=1
+ *       SET active=TRUE, rotated_at=NULL</li>
+ *   <li>Restore to pre-probe state</li>
+ * </ol>
+ *
+ * Exercises the atomic rotation path BEFORE Phase H ever needs it for a
+ * real rotation. ~2s; cheap insurance.
+ *
+ * <h2>Idempotency</h2>
+ *
+ * Re-running V83 on already-migrated data is safe — the
+ * {@code NOT EXISTS (SELECT 1 FROM tenant_dek WHERE kid = ?)} filter
+ * excludes every already-migrated row. Second run = zero column
+ * rewrites. Enforced by {@link #t6_idempotency} in V83's test suite.
+ *
+ * <h2>Dev-skip</h2>
+ *
+ * If {@code FABT_ENCRYPTION_KEY} is unset, logs WARN and returns cleanly.
+ * Same pattern as V74 — prod fails-fast before Flyway runs; dev/CI uses
+ * the {@code fabt.encryption-key} system-property fallback.
+ *
+ * <h2>Audit</h2>
+ *
+ * Writes a single {@code SYSTEM_MIGRATION_V83_TENANT_DEK} audit row with
+ * per-column counts + rotation probe outcome + master-KEK fingerprint.
+ */
+public class V83__reencrypt_v1_envelopes_under_tenant_dek extends BaseJavaMigration {
+
+    private static final Logger log = LoggerFactory.getLogger(
+            V83__reencrypt_v1_envelopes_under_tenant_dek.class);
+
+    // ------------------------------------------------------------------
+    // Constants (mirror SecretEncryptionService + EncryptionEnvelope +
+    // KeyDerivationService + TenantDekService). Inlined because Flyway
+    // runs pre-Spring-context. Any runtime wire-format change MUST be
+    // reflected here.
+    // ------------------------------------------------------------------
+
+    private static final String AES_GCM = "AES/GCM/NoPadding";
+    private static final String AES_KWP = "AESWrapPad";
+    private static final int GCM_IV_LENGTH = 12;
+    private static final int GCM_TAG_LENGTH_BITS = 128;
+    private static final int DEK_LENGTH_BYTES = 32;
+
+    private static final byte[] V1_MAGIC = { 0x46, 0x41, 0x42, 0x54 };
+    private static final byte V1_VERSION = 0x01;
+    private static final int ENVELOPE_HEADER_LENGTH = V1_MAGIC.length + 1 + 16 + GCM_IV_LENGTH;
+
+    private static final String HKDF_CONTEXT_VERSION = "v1";
+    private static final String PURPOSE_TOTP = "totp";
+    private static final String PURPOSE_WEBHOOK = "webhook-secret";
+    private static final String PURPOSE_OAUTH2 = "oauth2-client-secret";
+    private static final String PURPOSE_HMIS = "hmis-api-key";
+    private static final String PURPOSE_KEK_WRAP = "kek-wrap";
+
+    /** Uppercase purpose names for the tenant_dek.purpose CHECK constraint. */
+    private static final String DEK_PURPOSE_TOTP = "TOTP";
+    private static final String DEK_PURPOSE_WEBHOOK = "WEBHOOK_SECRET";
+    private static final String DEK_PURPOSE_OAUTH2 = "OAUTH2_CLIENT_SECRET";
+    private static final String DEK_PURPOSE_HMIS = "HMIS_API_KEY";
+
+    private final ObjectMapper objectMapper = JsonMapper.builder(
+            JsonFactory.builder()
+                    .streamReadConstraints(StreamReadConstraints.builder()
+                            .maxNestingDepth(64)
+                            .maxStringLength(1_048_576)
+                            .maxNumberLength(1_000)
+                            .build())
+                    .build())
+            .build();
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    @Override
+    public void migrate(Context context) throws Exception {
+        Instant started = Instant.now();
+        Connection conn = context.getConnection();
+
+        String base64Key = System.getenv("FABT_ENCRYPTION_KEY");
+        if (base64Key == null || base64Key.isBlank()) {
+            base64Key = System.getenv("FABT_TOTP_ENCRYPTION_KEY");
+        }
+        if (base64Key == null || base64Key.isBlank()) {
+            base64Key = System.getProperty("fabt.encryption-key");
+        }
+        if (base64Key == null || base64Key.isBlank()) {
+            log.warn("V83: FABT_ENCRYPTION_KEY not set — skipping re-encryption. "
+                    + "Flyway will mark V83 as APPLIED; set the key + DELETE FROM "
+                    + "flyway_schema_history WHERE version = '83' to retry.");
+            return;
+        }
+
+        byte[] masterKekBytes = Base64.getDecoder().decode(base64Key);
+        if (masterKekBytes.length != 32) {
+            throw new IllegalStateException(
+                    "FABT_ENCRYPTION_KEY must be 32 bytes. Got: " + masterKekBytes.length);
+        }
+
+        try (Statement stmt = conn.createStatement()) {
+            stmt.execute("SET LOCAL lock_timeout = '30s'");
+            stmt.execute("SET LOCAL statement_timeout = '5min'");
+        }
+
+        // V82 preflight — V83 is meaningless without the tenant_dek table.
+        try (PreparedStatement check = conn.prepareStatement(
+                "SELECT success FROM flyway_schema_history WHERE version = '82'");
+                ResultSet rs = check.executeQuery()) {
+            if (!rs.next() || !rs.getBoolean("success")) {
+                throw new IllegalStateException(
+                        "V83 preflight failed: V82 (tenant_dek schema) must be applied "
+                        + "before V83 runs. See design-f6-real-cryptoshred §8.");
+            }
+        }
+
+        String sessionRole = fetchSessionRole(conn);
+        log.info("V83 migrating as DB role: {}", sessionRole);
+
+        Counts totp = reencryptColumn(conn, masterKekBytes, ColumnSpec.TOTP);
+        Counts webhook = reencryptColumn(conn, masterKekBytes, ColumnSpec.WEBHOOK);
+        Counts oauth2 = reencryptColumn(conn, masterKekBytes, ColumnSpec.OAUTH2);
+        Counts hmis = reencryptHmisJsonbColumn(conn, masterKekBytes);
+
+        ProbeResult probe = runRotationReadinessProbe(conn, masterKekBytes);
+
+        Instant completed = Instant.now();
+        long durationMs = completed.toEpochMilli() - started.toEpochMilli();
+        String kekFingerprint = fingerprintMasterKek(masterKekBytes);
+
+        writeAuditRow(conn, sessionRole, started, completed, durationMs, kekFingerprint,
+                totp, webhook, oauth2, hmis, probe);
+
+        log.info(
+                "V83 COMMITTED — re-encrypted {} TOTP / {} webhook / {} OAuth2 / {} HMIS rows "
+                + "under tenant_dek in {}ms; rotation probe: {}",
+                totp.reencrypted, webhook.reencrypted, oauth2.reencrypted, hmis.reencrypted,
+                durationMs, probe.result);
+    }
+
+    // ------------------------------------------------------------------
+    // Column-specific re-encrypt
+    // ------------------------------------------------------------------
+
+    /**
+     * Describes one of the 3 scalar-column re-encryption paths (TOTP,
+     * webhook, OAuth2). HMIS lives in JSONB and has a dedicated method.
+     */
+    private enum ColumnSpec {
+        TOTP("app_user", "totp_secret_encrypted", PURPOSE_TOTP, DEK_PURPOSE_TOTP),
+        WEBHOOK("subscription", "callback_secret_hash", PURPOSE_WEBHOOK, DEK_PURPOSE_WEBHOOK),
+        OAUTH2("tenant_oauth2_provider", "client_secret_encrypted", PURPOSE_OAUTH2, DEK_PURPOSE_OAUTH2);
+
+        final String table;
+        final String column;
+        final String hkdfPurpose;
+        final String dekPurpose;
+
+        ColumnSpec(String table, String column, String hkdfPurpose, String dekPurpose) {
+            this.table = table;
+            this.column = column;
+            this.hkdfPurpose = hkdfPurpose;
+            this.dekPurpose = dekPurpose;
+        }
+    }
+
+    private Counts reencryptColumn(Connection conn, byte[] masterKekBytes,
+                                    ColumnSpec spec) throws Exception {
+        Counts counts = new Counts();
+
+        String selectSql = String.format(
+                "SELECT id, tenant_id, %s FROM %s "
+                + "WHERE %s IS NOT NULL AND tenant_id IS NOT NULL",
+                spec.column, spec.table, spec.column);
+
+        List<Row> candidates = new ArrayList<>();
+        try (PreparedStatement select = conn.prepareStatement(selectSql);
+                ResultSet rs = select.executeQuery()) {
+            while (rs.next()) {
+                String stored = rs.getString(spec.column);
+                if (stored == null || stored.isBlank() || !isV1(stored)) {
+                    continue;
+                }
+                UUID kid = extractKidFromV1Envelope(stored);
+                if (kid == null) {
+                    log.warn("V83: {}.id={} has v1 envelope but kid parse failed — skipping",
+                            spec.table, rs.getObject("id"));
+                    continue;
+                }
+                if (kidExistsInTenantDek(conn, kid)) {
+                    counts.skippedAlreadyTenantDek++;
+                    continue;
+                }
+                UUID rowId = (UUID) rs.getObject("id");
+                UUID tenantId = (UUID) rs.getObject("tenant_id");
+                candidates.add(new Row(rowId, tenantId, stored));
+            }
+        }
+
+        for (Row row : candidates) {
+            reencryptOneRow(conn, masterKekBytes, spec, row, counts);
+        }
+        return counts;
+    }
+
+    private void reencryptOneRow(Connection conn, byte[] masterKekBytes,
+                                  ColumnSpec spec, Row row, Counts counts) throws Exception {
+        // 1. Decrypt the legacy v1 envelope under the HKDF-derived DEK.
+        SecretKey legacyDek = deriveHkdfKey(masterKekBytes, row.tenantId, spec.hkdfPurpose);
+        String plaintext = decryptV1(legacyDek, row.stored);
+
+        // 2. Get (or create) the tenant_dek row for this (tenant, purpose).
+        //    Inlines TenantDekService.getOrCreateActiveDek because Flyway is
+        //    pre-Spring. Binds app.tenant_id for V82's RESTRICTIVE INSERT.
+        TenantDekRow dek = findOrCreateActiveTenantDek(
+                conn, masterKekBytes, row.tenantId, spec.dekPurpose);
+
+        // 3. Encrypt the plaintext under the fresh random DEK with the
+        //    tenant_dek kid as the envelope discriminator.
+        String newStored = encryptV1(dek.dek, dek.kid, plaintext);
+
+        // 4. Round-trip verify — unwrap fresh from tenant_dek and decrypt.
+        //    Catches any mismatch between wrap/unwrap paths before we
+        //    commit the new ciphertext.
+        String verify = decryptV1(dek.dek, newStored);
+        if (!plaintext.equals(verify)) {
+            throw new IllegalStateException(String.format(
+                    "V83 round-trip mismatch: %s.id=%s tenant=%s purpose=%s",
+                    spec.table, row.id, row.tenantId, spec.dekPurpose));
+        }
+
+        // 5. Update the column with the new envelope.
+        String updateSql = String.format(
+                "UPDATE %s SET %s = ? WHERE id = ?", spec.table, spec.column);
+        try (PreparedStatement update = conn.prepareStatement(updateSql)) {
+            update.setString(1, newStored);
+            update.setObject(2, row.id);
+            int rows = update.executeUpdate();
+            if (rows != 1) {
+                throw new IllegalStateException(String.format(
+                        "V83 UPDATE affected %d rows, expected 1: %s.id=%s",
+                        rows, spec.table, row.id));
+            }
+        }
+        counts.reencrypted++;
+    }
+
+    /**
+     * HMIS lives inside {@code tenant.config} JSONB as
+     * {@code hmis_vendors[].api_key_encrypted}. Walks tenants, parses JSONB,
+     * rewrites each v1-HKDF api_key_encrypted value that isn't already in
+     * tenant_dek.
+     */
+    private Counts reencryptHmisJsonbColumn(Connection conn, byte[] masterKekBytes) throws Exception {
+        Counts counts = new Counts();
+        List<TenantConfig> updates = new ArrayList<>();
+
+        try (PreparedStatement select = conn.prepareStatement(
+                "SELECT id, config FROM tenant WHERE config IS NOT NULL");
+                ResultSet rs = select.executeQuery()) {
+            while (rs.next()) {
+                UUID tenantId = (UUID) rs.getObject("id");
+                String configJson = rs.getString("config");
+                if (configJson == null || configJson.isBlank()) continue;
+
+                JsonNode root;
+                try {
+                    root = objectMapper.readTree(configJson);
+                } catch (Exception parseErr) {
+                    log.debug("V83: tenant {} has unparseable config — skipping", tenantId);
+                    continue;
+                }
+                if (!root.has("hmis_vendors") || !root.get("hmis_vendors").isArray()) continue;
+                JsonNode vendorsNode = root.get("hmis_vendors");
+                if (vendorsNode.isEmpty()) continue;
+
+                boolean mutated = false;
+                for (JsonNode vendor : vendorsNode) {
+                    if (!(vendor instanceof ObjectNode vendorObj)) continue;
+                    if (!vendor.has("api_key_encrypted")) continue;
+                    String stored = vendor.get("api_key_encrypted").asText();
+                    if (stored == null || stored.isBlank() || !isV1(stored)) continue;
+
+                    UUID kid = extractKidFromV1Envelope(stored);
+                    if (kid == null) continue;
+                    if (kidExistsInTenantDek(conn, kid)) {
+                        counts.skippedAlreadyTenantDek++;
+                        continue;
+                    }
+
+                    SecretKey legacyDek = deriveHkdfKey(masterKekBytes, tenantId, PURPOSE_HMIS);
+                    String plaintext = decryptV1(legacyDek, stored);
+
+                    TenantDekRow dek = findOrCreateActiveTenantDek(
+                            conn, masterKekBytes, tenantId, DEK_PURPOSE_HMIS);
+                    String newStored = encryptV1(dek.dek, dek.kid, plaintext);
+
+                    String verify = decryptV1(dek.dek, newStored);
+                    if (!plaintext.equals(verify)) {
+                        throw new IllegalStateException(
+                                "V83 HMIS round-trip mismatch for tenant " + tenantId);
+                    }
+
+                    vendorObj.put("api_key_encrypted", newStored);
+                    mutated = true;
+                    counts.reencrypted++;
+                }
+
+                if (mutated) {
+                    updates.add(new TenantConfig(tenantId, objectMapper.writeValueAsString(root)));
+                }
+            }
+        }
+
+        if (updates.isEmpty()) return counts;
+        try (PreparedStatement update = conn.prepareStatement(
+                "UPDATE tenant SET config = ?::jsonb WHERE id = ?")) {
+            for (TenantConfig u : updates) {
+                update.setString(1, u.configJson);
+                update.setObject(2, u.tenantId);
+                update.addBatch();
+            }
+            update.executeBatch();
+        }
+        return counts;
+    }
+
+    // ------------------------------------------------------------------
+    // tenant_dek inline writes (mirror TenantDekService.getOrCreateActiveDek)
+    // ------------------------------------------------------------------
+
+    private TenantDekRow findOrCreateActiveTenantDek(Connection conn, byte[] masterKekBytes,
+                                                      UUID tenantId, String dekPurpose) throws SQLException {
+        // V82 RESTRICTIVE INSERT/UPDATE require app.tenant_id = tenantId.
+        bindTenantGuc(conn, tenantId);
+
+        // Optimistic read — already-active row from a previous call this tx.
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT kid, wrapped_dek FROM tenant_dek "
+                + "WHERE tenant_id = ? AND purpose = ? AND active = TRUE")) {
+            ps.setObject(1, tenantId);
+            ps.setString(2, dekPurpose);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    UUID kid = (UUID) rs.getObject("kid");
+                    byte[] wrapped = rs.getBytes("wrapped_dek");
+                    SecretKey dek = unwrapDekWithKwp(masterKekBytes, tenantId, wrapped);
+                    return new TenantDekRow(kid, dek);
+                }
+            }
+        }
+
+        // First DEK for (tenant, purpose). Generate + wrap + INSERT.
+        byte[] rawDek = new byte[DEK_LENGTH_BYTES];
+        secureRandom.nextBytes(rawDek);
+        byte[] wrapped = wrapDekWithKwp(masterKekBytes, tenantId, rawDek);
+        UUID newKid = UUID.randomUUID();
+
+        try (PreparedStatement ps = conn.prepareStatement(
+                "INSERT INTO tenant_dek (kid, tenant_id, purpose, generation, wrapped_dek, active) "
+                + "VALUES (?, ?, ?, 1, ?, TRUE) ON CONFLICT DO NOTHING")) {
+            ps.setObject(1, newKid);
+            ps.setObject(2, tenantId);
+            ps.setString(3, dekPurpose);
+            ps.setBytes(4, wrapped);
+            ps.executeUpdate();
+        }
+
+        // Re-SELECT: captures a concurrent winner or our own INSERT.
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT kid, wrapped_dek FROM tenant_dek "
+                + "WHERE tenant_id = ? AND purpose = ? AND active = TRUE")) {
+            ps.setObject(1, tenantId);
+            ps.setString(2, dekPurpose);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (rs.next()) {
+                    UUID kid = (UUID) rs.getObject("kid");
+                    byte[] winningWrapped = rs.getBytes("wrapped_dek");
+                    SecretKey dek = unwrapDekWithKwp(masterKekBytes, tenantId, winningWrapped);
+                    return new TenantDekRow(kid, dek);
+                }
+            }
+        }
+        throw new IllegalStateException(
+                "tenant_dek INSERT + re-select returned empty for (" + tenantId + ", "
+                + dekPurpose + ") — partial unique index invariant violated");
+    }
+
+    private boolean kidExistsInTenantDek(Connection conn, UUID kid) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT 1 FROM tenant_dek WHERE kid = ?")) {
+            ps.setObject(1, kid);
+            try (ResultSet rs = ps.executeQuery()) {
+                return rs.next();
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Rotation-readiness probe (Q-F6-4)
+    // ------------------------------------------------------------------
+
+    private ProbeResult runRotationReadinessProbe(Connection conn, byte[] masterKekBytes) throws Exception {
+        UUID tenantId = null;
+        String purpose = null;
+        UUID gen1Kid = null;
+
+        // Find any active gen=1 row in tenant_dek. If none exists (fresh
+        // Testcontainer, no V74 output to migrate), skip the probe cleanly.
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT tenant_id, purpose, kid FROM tenant_dek "
+                + "WHERE generation = 1 AND active = TRUE LIMIT 1");
+                ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                tenantId = (UUID) rs.getObject("tenant_id");
+                purpose = rs.getString("purpose");
+                gen1Kid = (UUID) rs.getObject("kid");
+            }
+        }
+        if (tenantId == null) {
+            log.info("V83: no tenant_dek rows to probe rotation against — skipping probe");
+            return new ProbeResult("skipped_no_rows");
+        }
+
+        bindTenantGuc(conn, tenantId);
+
+        // Build a gen=2 DEK for the atomic rotation.
+        byte[] gen2Raw = new byte[DEK_LENGTH_BYTES];
+        secureRandom.nextBytes(gen2Raw);
+        byte[] gen2Wrapped = wrapDekWithKwp(masterKekBytes, tenantId, gen2Raw);
+        UUID gen2Kid = UUID.randomUUID();
+
+        // Rotation order matters for the partial unique index:
+        // (tenant_id, purpose) WHERE active=TRUE — having two active rows
+        // would violate it. UPDATE gen=1 to inactive FIRST (0 active rows
+        // briefly, which is allowed), THEN INSERT gen=2 active=TRUE.
+        // clock_timestamp() (not NOW()) matches V82's DEFAULT for created_at —
+        // NOW() returns the tx-start timestamp, which can be EARLIER than a
+        // row's DEFAULT clock_timestamp() created_at when both fall in the
+        // same tx. That would violate the tenant_dek_rotated_after_created
+        // CHECK (rotated_at >= created_at). Caught in V83's own IT suite
+        // first run before the migration shipped.
+        try (PreparedStatement updateOld = conn.prepareStatement(
+                "UPDATE tenant_dek SET active = FALSE, rotated_at = clock_timestamp() "
+                + "WHERE tenant_id = ? AND purpose = ? AND generation = 1")) {
+            updateOld.setObject(1, tenantId);
+            updateOld.setString(2, purpose);
+            updateOld.executeUpdate();
+        }
+
+        try (PreparedStatement insertNew = conn.prepareStatement(
+                "INSERT INTO tenant_dek (kid, tenant_id, purpose, generation, wrapped_dek, active) "
+                + "VALUES (?, ?, ?, 2, ?, TRUE)")) {
+            insertNew.setObject(1, gen2Kid);
+            insertNew.setObject(2, tenantId);
+            insertNew.setString(3, purpose);
+            insertNew.setBytes(4, gen2Wrapped);
+            insertNew.executeUpdate();
+        }
+
+        // Assertion: exactly one active row for (tenant, purpose), and it's gen=2.
+        int activeCount;
+        int activeGen;
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT COUNT(*), MAX(generation) FROM tenant_dek "
+                + "WHERE tenant_id = ? AND purpose = ? AND active = TRUE");
+                ResultSet rs = executeWithParams(ps, tenantId, purpose)) {
+            rs.next();
+            activeCount = rs.getInt(1);
+            activeGen = rs.getInt(2);
+        }
+        if (activeCount != 1 || activeGen != 2) {
+            throw new IllegalStateException(
+                    "V83 rotation probe assertion failed: activeCount=" + activeCount
+                    + " activeGen=" + activeGen + " (expected 1, 2)");
+        }
+
+        // Grace-window assertion: gen=1 kid still resolves + unwraps.
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT wrapped_dek FROM tenant_dek WHERE kid = ?")) {
+            ps.setObject(1, gen1Kid);
+            try (ResultSet rs = ps.executeQuery()) {
+                if (!rs.next()) {
+                    throw new IllegalStateException(
+                            "V83 rotation probe: gen=1 row missing post-rotation");
+                }
+                byte[] wrapped = rs.getBytes("wrapped_dek");
+                SecretKey decommissionedDek = unwrapDekWithKwp(masterKekBytes, tenantId, wrapped);
+                if (decommissionedDek == null) {
+                    throw new IllegalStateException(
+                            "V83 rotation probe: gen=1 unwrap returned null");
+                }
+            }
+        }
+
+        // Flip back — delete gen=2, revert gen=1 to active + clear rotated_at.
+        // Deleting gen=2 fires the BEFORE DELETE trigger; we need to set the
+        // shred GUC to match the row's tenant. Same pattern hardDelete will use.
+        bindShredGuc(conn, tenantId);
+        try (PreparedStatement deleteGen2 = conn.prepareStatement(
+                "DELETE FROM tenant_dek WHERE tenant_id = ? AND purpose = ? AND generation = 2")) {
+            deleteGen2.setObject(1, tenantId);
+            deleteGen2.setString(2, purpose);
+            deleteGen2.executeUpdate();
+        }
+        // Clear the shred GUC so later statements don't accidentally delete.
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT set_config('fabt.shred_in_progress', '', true)");
+                ResultSet rs = ps.executeQuery()) {
+            rs.next();
+        }
+
+        try (PreparedStatement revertGen1 = conn.prepareStatement(
+                "UPDATE tenant_dek SET active = TRUE, rotated_at = NULL "
+                + "WHERE tenant_id = ? AND purpose = ? AND generation = 1")) {
+            revertGen1.setObject(1, tenantId);
+            revertGen1.setString(2, purpose);
+            revertGen1.executeUpdate();
+        }
+
+        log.info("V83 rotation probe succeeded against tenant={} purpose={}", tenantId, purpose);
+        return new ProbeResult("passed");
+    }
+
+    private static ResultSet executeWithParams(PreparedStatement ps, UUID tenantId, String purpose)
+            throws SQLException {
+        ps.setObject(1, tenantId);
+        ps.setString(2, purpose);
+        return ps.executeQuery();
+    }
+
+    private void bindShredGuc(Connection conn, UUID tenantId) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT set_config('fabt.shred_in_progress', ?, true)")) {
+            ps.setString(1, tenantId.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+            }
+        }
+    }
+
+    private void bindTenantGuc(Connection conn, UUID tenantId) throws SQLException {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT set_config('app.tenant_id', ?, true)")) {
+            ps.setString(1, tenantId == null ? "" : tenantId.toString());
+            try (ResultSet rs = ps.executeQuery()) {
+                rs.next();
+            }
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Envelope + HKDF + AES-KWP inline (mirrors runtime code)
+    // ------------------------------------------------------------------
+
+    private static boolean isV1(String stored) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            if (decoded.length < V1_MAGIC.length + 1) return false;
+            for (int i = 0; i < V1_MAGIC.length; i++) {
+                if (decoded[i] != V1_MAGIC[i]) return false;
+            }
+            return decoded[V1_MAGIC.length] == V1_VERSION;
+        } catch (IllegalArgumentException badBase64) {
+            return false;
+        }
+    }
+
+    private static UUID extractKidFromV1Envelope(String stored) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            if (decoded.length < ENVELOPE_HEADER_LENGTH) return null;
+            ByteBuffer buf = ByteBuffer.wrap(decoded);
+            buf.position(V1_MAGIC.length + 1);
+            long hi = buf.getLong();
+            long lo = buf.getLong();
+            return new UUID(hi, lo);
+        } catch (Exception parseErr) {
+            return null;
+        }
+    }
+
+    private String encryptV1(SecretKey dek, UUID kid, String plaintext) {
+        try {
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            secureRandom.nextBytes(iv);
+            Cipher cipher = Cipher.getInstance(AES_GCM);
+            cipher.init(Cipher.ENCRYPT_MODE, dek, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            byte[] ct = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+
+            ByteBuffer buf = ByteBuffer.allocate(ENVELOPE_HEADER_LENGTH + ct.length);
+            buf.put(V1_MAGIC);
+            buf.put(V1_VERSION);
+            buf.putLong(kid.getMostSignificantBits());
+            buf.putLong(kid.getLeastSignificantBits());
+            buf.put(iv);
+            buf.put(ct);
+            return Base64.getEncoder().encodeToString(buf.array());
+        } catch (Exception cryptoErr) {
+            throw new RuntimeException("V83 v1 encrypt failed", cryptoErr);
+        }
+    }
+
+    private static String decryptV1(SecretKey dek, String stored) {
+        try {
+            byte[] decoded = Base64.getDecoder().decode(stored);
+            ByteBuffer buf = ByteBuffer.wrap(decoded);
+            buf.position(V1_MAGIC.length + 1 + 16); // skip magic + version + kid
+            byte[] iv = new byte[GCM_IV_LENGTH];
+            buf.get(iv);
+            byte[] ct = new byte[buf.remaining()];
+            buf.get(ct);
+
+            Cipher cipher = Cipher.getInstance(AES_GCM);
+            cipher.init(Cipher.DECRYPT_MODE, dek, new GCMParameterSpec(GCM_TAG_LENGTH_BITS, iv));
+            return new String(cipher.doFinal(ct), StandardCharsets.UTF_8);
+        } catch (Exception cryptoErr) {
+            throw new RuntimeException("V83 v1 decrypt failed", cryptoErr);
+        }
+    }
+
+    private static SecretKey deriveHkdfKey(byte[] masterKekBytes, UUID tenantId, String purpose) {
+        try {
+            byte[] salt = uuidToBytes(tenantId);
+            String context = "fabt:" + HKDF_CONTEXT_VERSION + ":" + tenantId + ":" + purpose;
+            byte[] info = context.getBytes(StandardCharsets.UTF_8);
+            byte[] derived = hkdfSha256(masterKekBytes, salt, info, DEK_LENGTH_BYTES);
+            return new SecretKeySpec(derived, "AES");
+        } catch (Exception e) {
+            throw new RuntimeException("V83 HKDF derivation failed", e);
+        }
+    }
+
+    private static byte[] wrapDekWithKwp(byte[] masterKekBytes, UUID tenantId, byte[] rawDek) {
+        try {
+            SecretKey wrappingKey = deriveHkdfKey(masterKekBytes, tenantId, PURPOSE_KEK_WRAP);
+            Cipher cipher = Cipher.getInstance(AES_KWP);
+            cipher.init(Cipher.WRAP_MODE, wrappingKey);
+            SecretKey dekAsKey = new SecretKeySpec(rawDek, "AES");
+            return cipher.wrap(dekAsKey);
+        } catch (Exception e) {
+            throw new RuntimeException("V83 AES-KWP wrap failed for tenant " + tenantId, e);
+        }
+    }
+
+    private static SecretKey unwrapDekWithKwp(byte[] masterKekBytes, UUID tenantId, byte[] wrappedDek) {
+        try {
+            SecretKey wrappingKey = deriveHkdfKey(masterKekBytes, tenantId, PURPOSE_KEK_WRAP);
+            Cipher cipher = Cipher.getInstance(AES_KWP);
+            cipher.init(Cipher.UNWRAP_MODE, wrappingKey);
+            return (SecretKey) cipher.unwrap(wrappedDek, "AES", Cipher.SECRET_KEY);
+        } catch (Exception e) {
+            throw new RuntimeException("V83 AES-KWP unwrap failed for tenant " + tenantId, e);
+        }
+    }
+
+    private static byte[] uuidToBytes(UUID uuid) {
+        ByteBuffer buf = ByteBuffer.allocate(16);
+        buf.putLong(uuid.getMostSignificantBits());
+        buf.putLong(uuid.getLeastSignificantBits());
+        return buf.array();
+    }
+
+    /** RFC 5869 HKDF-SHA256, same as V74 + runtime. */
+    private static byte[] hkdfSha256(byte[] ikm, byte[] salt, byte[] info, int outputLength)
+            throws Exception {
+        final int OUT = 32;
+        byte[] effectiveSalt = (salt == null || salt.length == 0) ? new byte[OUT] : salt;
+
+        Mac extract = Mac.getInstance("HmacSHA256");
+        extract.init(new SecretKeySpec(effectiveSalt, "HmacSHA256"));
+        byte[] prk = extract.doFinal(ikm);
+
+        Mac expand = Mac.getInstance("HmacSHA256");
+        expand.init(new SecretKeySpec(prk, "HmacSHA256"));
+        int blocks = (outputLength + OUT - 1) / OUT;
+        byte[] result = new byte[outputLength];
+        byte[] previous = new byte[0];
+        int written = 0;
+        for (int i = 1; i <= blocks; i++) {
+            expand.reset();
+            expand.update(previous);
+            expand.update(info);
+            expand.update((byte) i);
+            previous = expand.doFinal();
+            int copyLen = Math.min(OUT, outputLength - written);
+            System.arraycopy(previous, 0, result, written, copyLen);
+            written += copyLen;
+        }
+        return result;
+    }
+
+    // ------------------------------------------------------------------
+    // Audit row
+    // ------------------------------------------------------------------
+
+    private void writeAuditRow(Connection conn, String sessionRole,
+                                Instant started, Instant completed, long durationMs,
+                                String kekFingerprint,
+                                Counts totp, Counts webhook, Counts oauth2, Counts hmis,
+                                ProbeResult probe) throws SQLException {
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("migration", "V83");
+        details.put("started_at", started.toString());
+        details.put("completed_at", completed.toString());
+        details.put("duration_ms", durationMs);
+        details.put("master_kek_fingerprint", kekFingerprint);
+        details.put("flyway_role", sessionRole);
+        details.put("totp_reencrypted", totp.reencrypted);
+        details.put("totp_skipped_already_tenant_dek", totp.skippedAlreadyTenantDek);
+        details.put("webhook_reencrypted", webhook.reencrypted);
+        details.put("webhook_skipped_already_tenant_dek", webhook.skippedAlreadyTenantDek);
+        details.put("oauth2_reencrypted", oauth2.reencrypted);
+        details.put("oauth2_skipped_already_tenant_dek", oauth2.skippedAlreadyTenantDek);
+        details.put("hmis_reencrypted", hmis.reencrypted);
+        details.put("hmis_skipped_already_tenant_dek", hmis.skippedAlreadyTenantDek);
+        details.put("rotation_probe_result", probe.result);
+
+        String detailsJson;
+        try {
+            detailsJson = objectMapper.writeValueAsString(details);
+        } catch (Exception serializeErr) {
+            throw new IllegalStateException("V83 audit JSONB serialization failed", serializeErr);
+        }
+
+        UUID systemTenantId = UUID.fromString("00000000-0000-0000-0000-000000000001");
+        bindTenantGuc(conn, systemTenantId);
+        try (PreparedStatement insert = conn.prepareStatement(
+                "INSERT INTO audit_events (action, tenant_id, details) VALUES (?, ?, ?::jsonb)")) {
+            insert.setString(1, "SYSTEM_MIGRATION_V83_TENANT_DEK");
+            insert.setObject(2, systemTenantId);
+            insert.setString(3, detailsJson);
+            insert.executeUpdate();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Diagnostic helpers
+    // ------------------------------------------------------------------
+
+    private static String fetchSessionRole(Connection conn) {
+        try (PreparedStatement ps = conn.prepareStatement(
+                "SELECT current_user, rolbypassrls, rolsuper "
+                + "FROM pg_roles WHERE rolname = current_user");
+                ResultSet rs = ps.executeQuery()) {
+            if (rs.next()) {
+                return String.format("%s (bypassrls=%s, superuser=%s)",
+                        rs.getString("current_user"),
+                        rs.getBoolean("rolbypassrls"),
+                        rs.getBoolean("rolsuper"));
+            }
+        } catch (SQLException ignored) {
+        }
+        return "unknown";
+    }
+
+    private static String fingerprintMasterKek(byte[] masterKekBytes) {
+        try {
+            Mac mac = Mac.getInstance("HmacSHA256");
+            mac.init(new SecretKeySpec(masterKekBytes, "HmacSHA256"));
+            byte[] fingerprint = mac.doFinal(
+                    "v83-audit-fingerprint".getBytes(StandardCharsets.UTF_8));
+            byte[] truncated = new byte[8];
+            System.arraycopy(fingerprint, 0, truncated, 0, 8);
+            return HexFormat.of().formatHex(truncated);
+        } catch (Exception e) {
+            return "unknown";
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Inner types
+    // ------------------------------------------------------------------
+
+    private record Row(UUID id, UUID tenantId, String stored) {}
+    private record TenantConfig(UUID tenantId, String configJson) {}
+    private record TenantDekRow(UUID kid, SecretKey dek) {}
+    private record ProbeResult(String result) {}
+
+    private static final class Counts {
+        int reencrypted;
+        int skippedAlreadyTenantDek;
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/repository/ApiKeyRepository.java
+++ b/backend/src/main/java/org/fabt/auth/repository/ApiKeyRepository.java
@@ -32,4 +32,19 @@ public interface ApiKeyRepository extends CrudRepository<ApiKey, UUID> {
     @Query("SELECT * FROM api_key WHERE id = :id AND tenant_id = :tenantId")
     Optional<ApiKey> findByIdAndTenantId(@Param("id") UUID id,
                                           @Param("tenantId") UUID tenantId);
+
+    /**
+     * Phase F §D3 active-state guard. Returns the API key only if the owning tenant
+     * is ACTIVE; a row belonging to a SUSPENDED/OFFBOARDING/ARCHIVED/DELETED tenant
+     * appears as empty (caller maps to 404 — no existence leak). This is the
+     * preferred read-path method for request-bound operations; use the plain
+     * {@link #findByIdAndTenantId} only when the caller is annotated
+     * {@link org.fabt.shared.security.TenantInternal} (e.g. the lifecycle service
+     * itself, batch sweeps).
+     */
+    @Query("SELECT ak.* FROM api_key ak "
+         + "INNER JOIN tenant t ON t.id = ak.tenant_id "
+         + "WHERE ak.id = :id AND ak.tenant_id = :tenantId AND t.state = 'ACTIVE'")
+    Optional<ApiKey> findByIdAndActiveTenantId(@Param("id") UUID id,
+                                                @Param("tenantId") UUID tenantId);
 }

--- a/backend/src/main/java/org/fabt/auth/repository/TenantOAuth2ProviderRepository.java
+++ b/backend/src/main/java/org/fabt/auth/repository/TenantOAuth2ProviderRepository.java
@@ -30,4 +30,15 @@ public interface TenantOAuth2ProviderRepository extends CrudRepository<TenantOAu
     @Query("SELECT * FROM tenant_oauth2_provider WHERE id = :id AND tenant_id = :tenantId")
     Optional<TenantOAuth2Provider> findByIdAndTenantId(@Param("id") UUID id,
                                                         @Param("tenantId") UUID tenantId);
+
+    /**
+     * Phase F §D3 active-state guard. Returns the provider only if the owning tenant
+     * is ACTIVE; rows for non-ACTIVE tenants appear as empty (caller maps to 404).
+     * Preferred over {@link #findByIdAndTenantId} for request-bound paths.
+     */
+    @Query("SELECT p.* FROM tenant_oauth2_provider p "
+         + "INNER JOIN tenant t ON t.id = p.tenant_id "
+         + "WHERE p.id = :id AND p.tenant_id = :tenantId AND t.state = 'ACTIVE'")
+    Optional<TenantOAuth2Provider> findByIdAndActiveTenantId(@Param("id") UUID id,
+                                                              @Param("tenantId") UUID tenantId);
 }

--- a/backend/src/main/java/org/fabt/auth/service/ApiKeyService.java
+++ b/backend/src/main/java/org/fabt/auth/service/ApiKeyService.java
@@ -196,7 +196,7 @@ public class ApiKeyService {
      * forgotten at one site while the others are hardened.
      */
     private ApiKey findByIdOrThrow(UUID keyId) {
-        return apiKeyRepository.findByIdAndTenantId(keyId, TenantContext.getTenantId())
+        return apiKeyRepository.findByIdAndActiveTenantId(keyId, TenantContext.getTenantId())
                 .orElseThrow(() -> new NoSuchElementException("API key not found: " + keyId));
     }
 

--- a/backend/src/main/java/org/fabt/auth/service/ApiKeyService.java
+++ b/backend/src/main/java/org/fabt/auth/service/ApiKeyService.java
@@ -17,6 +17,7 @@ import org.fabt.shared.web.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.fabt.shared.security.TenantUnscoped;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -26,10 +27,12 @@ public class ApiKeyService {
 
     private static final Logger log = LoggerFactory.getLogger(ApiKeyService.class);
     private final ApiKeyRepository apiKeyRepository;
+    private final JdbcTemplate jdbc;
     private final SecureRandom secureRandom = new SecureRandom();
 
-    public ApiKeyService(ApiKeyRepository apiKeyRepository) {
+    public ApiKeyService(ApiKeyRepository apiKeyRepository, JdbcTemplate jdbc) {
         this.apiKeyRepository = apiKeyRepository;
+        this.jdbc = jdbc;
     }
 
     /**
@@ -120,6 +123,49 @@ public class ApiKeyService {
         apiKeyRepository.save(existing);
 
         return new ApiKeyCreateResult(existing.getId(), plaintextKey, keySuffix);
+    }
+
+    /**
+     * Bulk-deactivates every API key belonging to {@code tenantId} as part of
+     * a platform-admin-triggered tenant quarantine (Phase F suspend, §D11
+     * action 2 of 5). Clears {@code active} and both grace-period columns so
+     * neither the current key nor a recently-rotated key in its grace window
+     * can still authenticate.
+     *
+     * <p><b>Explicit tenantId parameter (NOT from TenantContext) is intentional.</b>
+     * This is a system-initiated bulk operation invoked from
+     * {@code TenantLifecycleService.suspend} — there is no request-bound
+     * TenantContext at the call site (the platform admin's tenant != the
+     * target tenant being suspended). Mirrors {@link org.fabt.shared.security.TenantKeyRotationService#bumpJwtKeyGeneration}'s
+     * signature convention. The F-3 ArchUnit Family D rule will apply
+     * {@code @TenantInternal} to this method to restrict callers; for F-2 the
+     * Javadoc is the enforcement contract.</p>
+     *
+     * @param tenantId the tenant whose keys to deactivate (must not be null)
+     * @return the number of rows updated (zero if the tenant has no keys)
+     */
+    @Transactional
+    public int deactivateAllForTenant(UUID tenantId) {
+        // api_key is not RLS-protected (verified: no policy on this table in
+        // V8, V68, V69) — direct UPDATE WHERE tenant_id=? is the idiomatic
+        // bulk path. No set_config needed.
+        //
+        // Deliberately NOT gated on `active = TRUE`. Matches the per-key
+        // deactivate() behavior which always NULLs both grace-period columns
+        // regardless of prior active state. Defense-in-depth: if
+        // findByOldKeyHashWithinGracePeriod ever loses its `active = true`
+        // clause, a deactivated key with a lingering old_key_hash + unexpired
+        // old_key_expires_at could re-authenticate. Warroom (Sam) F-2
+        // pre-commit 2026-04-23.
+        int affected = jdbc.update(
+            "UPDATE api_key SET active = FALSE, "
+            + "old_key_hash = NULL, old_key_expires_at = NULL "
+            + "WHERE tenant_id = ?",
+            tenantId);
+        if (affected > 0) {
+            log.info("Deactivated {} API keys for tenant {} (tenant quarantine)", affected, tenantId);
+        }
+        return affected;
     }
 
     /**

--- a/backend/src/main/java/org/fabt/auth/service/TenantOAuth2ProviderService.java
+++ b/backend/src/main/java/org/fabt/auth/service/TenantOAuth2ProviderService.java
@@ -154,7 +154,7 @@ public class TenantOAuth2ProviderService {
      * at one site while the others are hardened.
      */
     private TenantOAuth2Provider findByIdOrThrow(UUID id) {
-        return providerRepository.findByIdAndTenantId(id, TenantContext.getTenantId())
+        return providerRepository.findByIdAndActiveTenantId(id, TenantContext.getTenantId())
                 .orElseThrow(() -> new NoSuchElementException("OAuth2 provider not found: " + id));
     }
 

--- a/backend/src/main/java/org/fabt/referral/repository/ReferralTokenRepository.java
+++ b/backend/src/main/java/org/fabt/referral/repository/ReferralTokenRepository.java
@@ -93,6 +93,22 @@ public class ReferralTokenRepository {
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
+    /**
+     * Phase F §D3 active-state guard. Returns the referral token only if the owning
+     * tenant is ACTIVE; rows belonging to SUSPENDED/OFFBOARDING/ARCHIVED/DELETED
+     * tenants appear as empty (caller maps to 404 — no existence leak). Preferred
+     * over {@link #findByIdAndTenantId} for request-bound paths; system paths
+     * (expire tasklet, escalation batch) keep using the plain variant.
+     */
+    public Optional<ReferralToken> findByIdAndActiveTenantId(UUID id, UUID tenantId) {
+        List<ReferralToken> results = jdbcTemplate.query(
+                "SELECT rt.* FROM referral_token rt "
+                + "INNER JOIN tenant t ON t.id = rt.tenant_id "
+                + "WHERE rt.id = ? AND rt.tenant_id = ? AND t.state = 'ACTIVE'",
+                ROW_MAPPER, id, tenantId);
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
     public List<ReferralToken> findPendingByShelterId(UUID shelterId) {
         return jdbcTemplate.query(
                 "SELECT * FROM referral_token WHERE shelter_id = ? AND status = 'PENDING' ORDER BY created_at",

--- a/backend/src/main/java/org/fabt/referral/service/ReferralTokenService.java
+++ b/backend/src/main/java/org/fabt/referral/service/ReferralTokenService.java
@@ -348,7 +348,7 @@ public class ReferralTokenService {
      * site while the others are hardened.
      */
     private ReferralToken findByIdOrThrow(UUID tokenId) {
-        return repository.findByIdAndTenantId(tokenId, TenantContext.getTenantId())
+        return repository.findByIdAndActiveTenantId(tokenId, TenantContext.getTenantId())
                 .orElseThrow(() -> new NoSuchElementException("Referral token not found: " + tokenId));
     }
 
@@ -467,7 +467,7 @@ public class ReferralTokenService {
                 // read is OFF the hot path — only triggered on contention.
                 // Tenant-scoped per 8.5 / 8.6 — cross-tenant tokens return null
                 // → 404, consistent with the getById leak fix.
-                ReferralToken existing = repository.findByIdAndTenantId(tokenId, TenantContext.getTenantId()).orElse(null);
+                ReferralToken existing = repository.findByIdAndActiveTenantId(tokenId, TenantContext.getTenantId()).orElse(null);
                 if (existing == null) {
                     throw new NoSuchElementException("Referral token not found: " + tokenId);
                 }
@@ -518,7 +518,7 @@ public class ReferralTokenService {
         int updated = repository.tryRelease(tokenId, adminId, override);
         if (updated == 0) {
             // Tenant-scoped diagnostic — cross-tenant tokens appear as NOT_FOUND.
-            ReferralToken existing = repository.findByIdAndTenantId(tokenId, TenantContext.getTenantId()).orElse(null);
+            ReferralToken existing = repository.findByIdAndActiveTenantId(tokenId, TenantContext.getTenantId()).orElse(null);
             if (existing == null) {
                 throw new NoSuchElementException("Referral token not found: " + tokenId);
             }
@@ -534,7 +534,7 @@ public class ReferralTokenService {
             throw new AccessDeniedException("You do not hold the claim on this referral");
         }
 
-        ReferralToken token = repository.findByIdAndTenantId(tokenId, TenantContext.getTenantId()).orElse(null);
+        ReferralToken token = repository.findByIdAndActiveTenantId(tokenId, TenantContext.getTenantId()).orElse(null);
         UUID tenantId = token != null ? token.getTenantId() : TenantContext.getTenantId();
 
         publishAudit(adminId, tokenId, AuditEventTypes.DV_REFERRAL_RELEASED,

--- a/backend/src/main/java/org/fabt/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/org/fabt/reservation/repository/ReservationRepository.java
@@ -79,6 +79,23 @@ public class ReservationRepository {
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
+    /**
+     * Phase F §D3 active-state guard. Returns the reservation only if the owning
+     * tenant is ACTIVE; non-ACTIVE tenants' reservations appear as empty (caller maps
+     * to 404 — no existence leak). Preferred over {@link #findByIdAndTenantId} for
+     * request-bound paths.
+     */
+    public Optional<Reservation> findByIdAndActiveTenantId(UUID id, UUID tenantId) {
+        List<Reservation> results = jdbcTemplate.query(
+                "SELECT r.* FROM reservation r "
+                + "INNER JOIN tenant t ON t.id = r.tenant_id "
+                + "WHERE r.id = ? AND r.tenant_id = ? AND t.state = 'ACTIVE'",
+                ROW_MAPPER,
+                id, tenantId
+        );
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
     public Optional<Reservation> findById(UUID id) {
         List<Reservation> results = jdbcTemplate.query(
                 "SELECT * FROM reservation WHERE id = ?",

--- a/backend/src/main/java/org/fabt/reservation/service/ReservationService.java
+++ b/backend/src/main/java/org/fabt/reservation/service/ReservationService.java
@@ -150,7 +150,7 @@ public class ReservationService implements HeldReservationCleaner {
     public Reservation confirmReservation(UUID reservationId, UUID userId) {
         UUID tenantId = TenantContext.getTenantId();
 
-        Reservation reservation = reservationRepository.findByIdAndTenantId(reservationId, tenantId)
+        Reservation reservation = reservationRepository.findByIdAndActiveTenantId(reservationId, tenantId)
                 .orElseThrow(() -> new NoSuchElementException("Reservation not found: " + reservationId));
 
         if (!reservation.isHeld()) {
@@ -228,7 +228,7 @@ public class ReservationService implements HeldReservationCleaner {
     public Reservation cancelReservation(UUID reservationId, UUID userId) {
         UUID tenantId = TenantContext.getTenantId();
 
-        Reservation reservation = reservationRepository.findByIdAndTenantId(reservationId, tenantId)
+        Reservation reservation = reservationRepository.findByIdAndActiveTenantId(reservationId, tenantId)
                 .orElseThrow(() -> new NoSuchElementException("Reservation not found: " + reservationId));
 
         if (!reservation.isHeld()) {

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
@@ -197,6 +197,67 @@ public final class AuditEventTypes {
      */
     public static final String CROSS_TENANT_POLICY_READ = "CROSS_TENANT_POLICY_READ";
 
+    // ─── Tenant lifecycle (Phase F, multi-tenant-production-readiness §D8) ───
+    //
+    // Every lifecycle audit row carries a details JSON with at minimum:
+    //   { actor_user_id, justification, previous_state, new_state }
+    // Phase G's platform_admin_access_log will read actor_user_id + justification
+    // directly; adopt the schema from F-1 so G3 has no retrofit (design §D8, §G).
+    //
+    // Persistence path: event-bus (PROPAGATION_REQUIRED) for create/suspend/
+    // unsuspend/offboard/archive — operator-initiated, safe to join caller's
+    // tx. The one exception is TENANT_HARD_DELETED which must be committed
+    // BEFORE the destructive tx (see Javadoc below) so failed-delete attempts
+    // still leave forensic breadcrumbs.
+
+    /**
+     * Emitted by {@code TenantLifecycleService.create} after a successful atomic
+     * bootstrap (tenant row + JWT gen-1 key + DEKs + empty audit_chain_head seed).
+     * Detail blob: {@code {actor_user_id, slug, name, data_residency_region}}.
+     */
+    public static final String TENANT_CREATED = "TENANT_CREATED";
+
+    /**
+     * Emitted by {@code TenantLifecycleService.suspend} after the 5-action quarantine
+     * (bump JWT gen, deactivate API keys, stop worker dispatch, flip state, audit).
+     * Detail blob: {@code {actor_user_id, justification, previous_state}}.
+     */
+    public static final String TENANT_SUSPENDED = "TENANT_SUSPENDED";
+
+    /**
+     * Emitted by {@code TenantLifecycleService.unsuspend} when a SUSPENDED tenant
+     * is restored to ACTIVE after incident resolution.
+     * Detail blob: {@code {actor_user_id, justification, suspend_audit_row_id}}.
+     */
+    public static final String TENANT_UNSUSPENDED = "TENANT_UNSUSPENDED";
+
+    /**
+     * Emitted by {@code TenantLifecycleService.offboard} when state transitions to
+     * OFFBOARDING. The export workflow runs as part of the same transition (F-5).
+     * Detail blob: {@code {actor_user_id, justification, previous_state, export_receipt_uri}}.
+     */
+    public static final String TENANT_OFFBOARDING_STARTED = "TENANT_OFFBOARDING_STARTED";
+
+    /**
+     * Emitted by {@code TenantLifecycleService.archive} after export-complete check.
+     * Starts the 30-day retention window before hard-delete is permitted.
+     * Detail blob: {@code {actor_user_id, justification, archived_at, export_receipt_uri}}.
+     */
+    public static final String TENANT_ARCHIVED = "TENANT_ARCHIVED";
+
+    /**
+     * Emitted by {@code TenantLifecycleService.hardDelete} as the crypto-shred trigger.
+     *
+     * <p><b>Persisted BEFORE the destructive transaction</b> (separate tx + commit
+     * first, then the tenant + tenant_key_material + tenant_audit_chain_head
+     * DELETE cascade). Rationale: a failed hardDelete attempt leaves no row for
+     * a post-mortem to inspect if the audit INSERT is inside the destructive tx
+     * and both roll back together. Attempted-shred evidence survives.
+     *
+     * <p>Detail blob: {@code {actor_user_id, justification, archived_at, retention_days}}.</p>
+     */
+    public static final String TENANT_HARD_DELETED = "TENANT_HARD_DELETED";
+
     private AuditEventTypes() {
         // utility class — do not instantiate
     }

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventTypes.java
@@ -245,6 +245,38 @@ public final class AuditEventTypes {
      */
     public static final String TENANT_ARCHIVED = "TENANT_ARCHIVED";
 
+    // ─── Tenant lifecycle ATTEMPT REJECTIONS (Phase F slice F-3.6) ───
+    //
+    // Emitted when a lifecycle transition is rejected by the §D8 FSM — e.g. a
+    // platform admin attempts to suspend an already-SUSPENDED tenant. Without
+    // these rows, an attacker who can reach the admin endpoints could probe
+    // tenant ids with no forensic trail left on failure. Persisted via
+    // DetachedAuditPersister (REQUIRES_NEW) so the audit row survives the
+    // IllegalStateTransitionException that rolls back the caller's transaction.
+    // Marcus warroom F-2 HIGH + F-3.6 plan.
+    //
+    // Details schema mirrors the success-path audit rows plus a
+    // `rejection_reason` field carrying the exception message for triage.
+
+    /**
+     * Emitted by {@code TenantLifecycleService.suspend} when the §D8 FSM rejects the
+     * transition (caller attempted to suspend a non-ACTIVE tenant). Details include
+     * actor_user_id, justification, current_state, requested_state, rejection_reason.
+     */
+    public static final String TENANT_SUSPEND_REJECTED = "TENANT_SUSPEND_REJECTED";
+
+    /** {@code TenantLifecycleService.unsuspend} rejection (not SUSPENDED). */
+    public static final String TENANT_UNSUSPEND_REJECTED = "TENANT_UNSUSPEND_REJECTED";
+
+    /** {@code TenantLifecycleService.offboard} rejection (ARCHIVED/DELETED cannot offboard). */
+    public static final String TENANT_OFFBOARD_REJECTED = "TENANT_OFFBOARD_REJECTED";
+
+    /** {@code TenantLifecycleService.archive} rejection (not OFFBOARDING). */
+    public static final String TENANT_ARCHIVE_REJECTED = "TENANT_ARCHIVE_REJECTED";
+
+    /** {@code TenantLifecycleService.hardDelete} rejection (not ARCHIVED or retention not met). */
+    public static final String TENANT_HARD_DELETE_REJECTED = "TENANT_HARD_DELETE_REJECTED";
+
     /**
      * Emitted by {@code TenantLifecycleService.hardDelete} as the crypto-shred trigger.
      *

--- a/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
+++ b/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
@@ -113,6 +113,33 @@ public class KeyDerivationService {
     }
 
     /**
+     * Derives the per-tenant AES-KWP wrapping key used by
+     * {@link TenantDekService} to wrap / unwrap random per-tenant DEKs in
+     * the {@code tenant_dek} table. Per F-6.0 design (design-f6-real-
+     * cryptoshred §3 D61), this is the ONLY HKDF-derived key that survives
+     * Phase F — all other DEKs become random + wrapped + shreddable.
+     *
+     * <p><b>Package-private access.</b> The wrapping key is the single most
+     * privileged output of this class: anyone who can call this method and
+     * read a {@code wrapped_dek} row can recover the plaintext DEK. Access
+     * is package-private so the class remains extensible in the
+     * {@code shared.security} package while ArchUnit Family F rule 7.8h
+     * pins actual callers to {@link TenantDekService} at build time.
+     * Application code outside {@code shared.security} cannot reach this
+     * method; a reflection-bypass is possible but would be flagged by the
+     * same ArchUnit rule (it scans for any reference to the method name,
+     * reflective or direct).
+     *
+     * <p><b>Why HKDF is safe here.</b> The wrapping key alone decrypts
+     * nothing; the shred surface is the {@code tenant_dek.wrapped_dek}
+     * column. An adversary who recomputes the wrapping key gains nothing
+     * without a wrapped-DEK row to unwrap. See §2 threat model.
+     */
+    SecretKey deriveKekWrappingKey(UUID tenantId) {
+        return deriveKey(tenantId, "kek-wrap");
+    }
+
+    /**
      * Derives a 32-byte key for the given tenant + purpose. Private; callers
      * must use the typed {@code deriveXxxKey} methods above so the purpose
      * value is constrained at compile time. Same-input determinism is the

--- a/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
+++ b/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
@@ -92,22 +92,48 @@ public class KeyDerivationService {
         return deriveKey(tenantId, "jwt-sign");
     }
 
-    /** Derives the per-tenant TOTP shared-secret encryption DEK (AES-256-GCM). */
+    /**
+     * Derives the per-tenant TOTP shared-secret encryption DEK.
+     *
+     * @deprecated since v0.51.0 — data encryption now uses random DEKs
+     * owned by {@link TenantDekService} to enable real crypto-shred per
+     * NIST SP 800-88 Rev 2. This deterministic-HKDF path is retained
+     * only for (a) the V74 legacy migration + (b) the
+     * {@code CryptoShredGapIntegrationTest} adversary simulation. Phase L
+     * cleanup removes it entirely. New data-encryption callers must go
+     * through {@code SecretEncryptionService.encryptForTenant}.
+     */
+    @Deprecated(since = "v0.51.0", forRemoval = true)
     public SecretKey deriveTotpKey(UUID tenantId) {
         return deriveKey(tenantId, "totp");
     }
 
-    /** Derives the per-tenant webhook-callback secret encryption DEK (AES-256-GCM). */
+    /**
+     * Derives the per-tenant webhook-callback secret encryption DEK.
+     *
+     * @deprecated since v0.51.0 — see {@link #deriveTotpKey} javadoc.
+     */
+    @Deprecated(since = "v0.51.0", forRemoval = true)
     public SecretKey deriveWebhookSecretKey(UUID tenantId) {
         return deriveKey(tenantId, "webhook-secret");
     }
 
-    /** Derives the per-tenant OAuth2 client-secret encryption DEK (AES-256-GCM). */
+    /**
+     * Derives the per-tenant OAuth2 client-secret encryption DEK.
+     *
+     * @deprecated since v0.51.0 — see {@link #deriveTotpKey} javadoc.
+     */
+    @Deprecated(since = "v0.51.0", forRemoval = true)
     public SecretKey deriveOauth2ClientSecretKey(UUID tenantId) {
         return deriveKey(tenantId, "oauth2-client-secret");
     }
 
-    /** Derives the per-tenant HMIS API-key encryption DEK (AES-256-GCM). */
+    /**
+     * Derives the per-tenant HMIS API-key encryption DEK.
+     *
+     * @deprecated since v0.51.0 — see {@link #deriveTotpKey} javadoc.
+     */
+    @Deprecated(since = "v0.51.0", forRemoval = true)
     public SecretKey deriveHmisApiKey(UUID tenantId) {
         return deriveKey(tenantId, "hmis-api-key");
     }

--- a/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
+++ b/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
@@ -150,11 +150,20 @@ public class KeyDerivationService {
      * read a {@code wrapped_dek} row can recover the plaintext DEK. Access
      * is package-private so the class remains extensible in the
      * {@code shared.security} package while ArchUnit Family F rule 7.8h
-     * pins actual callers to {@link TenantDekService} at build time.
-     * Application code outside {@code shared.security} cannot reach this
-     * method; a reflection-bypass is possible but would be flagged by the
-     * same ArchUnit rule (it scans for any reference to the method name,
-     * reflective or direct).
+     * ({@code CryptoShredArchitectureTest}) pins direct callers to
+     * {@link TenantDekService} at build time.
+     *
+     * <p><b>Reflection is NOT caught by the 7.8h rule</b> (warroom pass-4
+     * docs fix, 2026-04-24). ArchUnit's {@code callMethod} inspects
+     * bytecode call-sites only; a reflective
+     * {@code Method.setAccessible(true)} + {@code invoke} compiles as a
+     * call to {@code java.lang.reflect.Method.invoke} in the caller's
+     * bytecode, not a direct call to this method. The pilot-scale
+     * threat model accepts this gap — FABT runs no third-party code in
+     * the backend JVM. Phase L hardening will add a separate rule that
+     * scans for {@code setAccessible(true)} targeting
+     * {@code KeyDerivationService.class.getDeclaredMethod(...)} if the
+     * deployment perimeter widens (e.g., to plugin-based integrations).
      *
      * <p><b>Why HKDF is safe here.</b> The wrapping key alone decrypts
      * nothing; the shred surface is the {@code tenant_dek.wrapped_dek}

--- a/backend/src/main/java/org/fabt/shared/security/PurposeMismatchException.java
+++ b/backend/src/main/java/org/fabt/shared/security/PurposeMismatchException.java
@@ -1,0 +1,44 @@
+package org.fabt.shared.security;
+
+import java.util.UUID;
+
+/**
+ * Raised by {@link SecretEncryptionService#decryptForTenant} when the
+ * caller's declared {@link KeyPurpose} disagrees with the purpose recorded
+ * on the resolved {@code tenant_dek} row.
+ *
+ * <p>Before F-6.0 Option A, a purpose mismatch surfaced as a generic
+ * {@code RuntimeException} from the AES-GCM tag-verification failure
+ * (wrong DEK → wrong tag). That path still exists as defense-in-depth,
+ * but an explicit check upstream makes the contract testable and gives
+ * incident responders a clear signal to distinguish "wrong purpose"
+ * (programming bug, benign) from "forged ciphertext" (attack, hostile).
+ *
+ * <p>Extends {@link SecurityException} so Spring's
+ * {@code @ControllerAdvice} treats it as a security boundary event, not
+ * a generic 500. The wire-level response is still a generic decrypt
+ * failure so clients cannot distinguish "wrong purpose" from other
+ * decrypt errors — the discrimination is for logs + audits only.
+ */
+public class PurposeMismatchException extends SecurityException {
+
+    private final UUID kid;
+    private final UUID tenantId;
+    private final KeyPurpose expectedPurpose;
+    private final KeyPurpose actualPurpose;
+
+    public PurposeMismatchException(UUID kid, UUID tenantId,
+                                     KeyPurpose expectedPurpose, KeyPurpose actualPurpose) {
+        super("Purpose mismatch for kid " + kid + ": caller expected "
+            + expectedPurpose + " but tenant_dek records " + actualPurpose);
+        this.kid = kid;
+        this.tenantId = tenantId;
+        this.expectedPurpose = expectedPurpose;
+        this.actualPurpose = actualPurpose;
+    }
+
+    public UUID getKid() { return kid; }
+    public UUID getTenantId() { return tenantId; }
+    public KeyPurpose getExpectedPurpose() { return expectedPurpose; }
+    public KeyPurpose getActualPurpose() { return actualPurpose; }
+}

--- a/backend/src/main/java/org/fabt/shared/security/SecretEncryptionService.java
+++ b/backend/src/main/java/org/fabt/shared/security/SecretEncryptionService.java
@@ -65,6 +65,7 @@ public class SecretEncryptionService {
     private final MasterKekProvider masterKekProvider;
     private final KeyDerivationService keyDerivationService;
     private final KidRegistryService kidRegistryService;
+    private final TenantDekService tenantDekService;
     private final MeterRegistry meterRegistry;
     private final ApplicationEventPublisher eventPublisher;
 
@@ -92,11 +93,13 @@ public class SecretEncryptionService {
             MasterKekProvider masterKekProvider,
             KeyDerivationService keyDerivationService,
             KidRegistryService kidRegistryService,
+            TenantDekService tenantDekService,
             ObjectProvider<MeterRegistry> meterRegistryProvider,
             ObjectProvider<ApplicationEventPublisher> eventPublisherProvider) {
         this.masterKekProvider = masterKekProvider;
         this.keyDerivationService = keyDerivationService;
         this.kidRegistryService = kidRegistryService;
+        this.tenantDekService = tenantDekService;
         this.secretKey = masterKekProvider.getPlatformKey();
         this.configured = true;
         this.meterRegistry = meterRegistryProvider.getIfAvailable();
@@ -108,26 +111,43 @@ public class SecretEncryptionService {
     // ------------------------------------------------------------------
 
     /**
-     * Encrypts {@code plaintext} for storage under the per-tenant DEK
-     * derived for {@code (tenantId, purpose)}. Wraps the result in a v1
-     * {@link EncryptionEnvelope} carrying the kid registered for the
-     * tenant's active generation.
+     * Encrypts {@code plaintext} for storage under the per-tenant random
+     * DEK owned by {@link TenantDekService} for {@code (tenantId, purpose)}.
+     * Wraps the result in a v1 {@link EncryptionEnvelope} carrying the kid
+     * minted when the DEK was first generated.
      *
-     * <p>Lazy bootstrap: the first encrypt for a tenant creates its
-     * {@code tenant_key_material} active generation + kid via
-     * {@link KidRegistryService#findOrCreateActiveKid(java.util.UUID)}.
-     * Subsequent encrypts reuse the same kid until rotation.
+     * <p><b>F-6.0 refactor (2026-04-24):</b> was HKDF-derived DEK +
+     * {@link KidRegistryService} kid. Now random DEK +
+     * {@link TenantDekService} kid, enabling real crypto-shred: deleting
+     * the {@code tenant_dek} row destroys the only copy of the DEK, which
+     * is what the TDD anchor {@code CryptoShredGapIntegrationTest} tests.
+     *
+     * <p>Lazy bootstrap: the first encrypt for a {@code (tenant, purpose)}
+     * pair creates the {@code tenant_dek} row + generates the random DEK
+     * + wraps under the HKDF-derived wrapping key. Subsequent encrypts
+     * reuse the same kid + DEK until rotation.
      */
     public String encryptForTenant(java.util.UUID tenantId, KeyPurpose purpose, String plaintext) {
-        java.util.UUID kid = kidRegistryService.findOrCreateActiveKid(tenantId);
-        SecretKey dek = purpose.deriveKey(keyDerivationService, tenantId);
+        if (purpose == KeyPurpose.JWT_SIGN) {
+            // JWT signing keys have their own lifecycle (kid_to_tenant_key +
+            // tenant_key_material, Phase A3). They are deliberately NOT in
+            // tenant_dek's purpose CHECK constraint — data encryption and
+            // JWT signing are separate concerns with different rotation,
+            // audit, and shred semantics. A caller reaching here with
+            // JWT_SIGN is a programming bug, not an attack surface.
+            throw new IllegalArgumentException(
+                    "KeyPurpose.JWT_SIGN is not a data-encryption purpose; "
+                    + "JWT signing uses JwtService + kid_to_tenant_key, not "
+                    + "SecretEncryptionService + tenant_dek.");
+        }
+        TenantDekService.ActiveDek active = tenantDekService.getOrCreateActiveDek(tenantId, purpose);
         try {
             byte[] iv = new byte[GCM_IV_LENGTH];
             secureRandom.nextBytes(iv);
             Cipher cipher = Cipher.getInstance(ALGORITHM);
-            cipher.init(Cipher.ENCRYPT_MODE, dek, new GCMParameterSpec(GCM_TAG_LENGTH, iv));
+            cipher.init(Cipher.ENCRYPT_MODE, active.dek(), new GCMParameterSpec(GCM_TAG_LENGTH, iv));
             byte[] ciphertextWithTag = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
-            return new EncryptionEnvelope(kid, iv, ciphertextWithTag).encode();
+            return new EncryptionEnvelope(active.kid(), iv, ciphertextWithTag).encode();
         } catch (Exception e) {
             throw new RuntimeException("Failed to encrypt secret for tenant " + tenantId, e);
         }
@@ -137,8 +157,19 @@ public class SecretEncryptionService {
      * Decrypts a stored ciphertext for the given tenant + purpose. Routes
      * to the v0 legacy path if the bytes don't carry the v1 magic.
      *
+     * <p><b>F-6.0 refactor (2026-04-24):</b> resolves kids via
+     * {@link TenantDekService} ({@code tenant_dek} table) instead of
+     * {@link KidRegistryService} ({@code kid_to_tenant_key} table — now
+     * JWT-only). Adds an explicit {@link PurposeMismatchException} for
+     * when the caller's {@link KeyPurpose} disagrees with the row's
+     * recorded purpose, instead of relying on the GCM auth-tag failure.
+     *
      * @throws CrossTenantCiphertextException if the kid resolves to a
-     *         different tenant than {@code tenantId}
+     *         different tenant than {@code tenantId}, or if the kid is
+     *         unregistered (sentinel {@link #UNKNOWN_KID_SENTINEL_TENANT}
+     *         per C-A3-1).
+     * @throws PurposeMismatchException if the kid resolves to the caller's
+     *         tenant but to a different {@link KeyPurpose}.
      */
     public String decryptForTenant(java.util.UUID tenantId, KeyPurpose purpose, String stored) {
         byte[] decoded = java.util.Base64.getDecoder().decode(stored);
@@ -153,22 +184,81 @@ public class SecretEncryptionService {
             return CiphertextV0Decoder.decrypt(masterKekProvider.getPlatformKey(), stored);
         }
         EncryptionEnvelope envelope = EncryptionEnvelope.decode(stored);
-        KidRegistryService.KidResolution resolved;
+        TenantDekService.ResolvedDek resolved;
         try {
-            resolved = kidRegistryService.resolveKid(envelope.kid());
-        } catch (java.util.NoSuchElementException unknownKid) {
-            // C-A3-1: an unregistered kid is presented as cross-tenant rejection
-            // (same 403 response, same audit action) so an attacker cannot
-            // distinguish "kid doesn't exist anywhere" (would be 404) from
-            // "kid exists for a different tenant" (403). The sentinel
-            // actualTenantId in the audit JSONB discriminates the two cases
-            // for incident responders without leaking to the client.
-            throw new CrossTenantCiphertextException(
-                    envelope.kid(), tenantId, UNKNOWN_KID_SENTINEL_TENANT);
+            resolved = tenantDekService.resolveDek(envelope.kid());
+        } catch (java.util.NoSuchElementException notInTenantDek) {
+            // Transitional fallback: the kid might belong to a legacy v1
+            // envelope produced by V74 (the old HKDF-DEK path), which
+            // registered kids in kid_to_tenant_key rather than tenant_dek.
+            // V83 re-encrypts these legacy envelopes under fresh tenant_dek
+            // DEKs, after which this fallback path becomes unreachable
+            // for conforming deployments. Kept as defense-in-depth + smooth
+            // deployment during the V82→V83 window where a pod may see a
+            // mix of old and new formats. Phase L (task 7.8h ArchUnit
+            // removal) retires this path entirely.
+            return decryptV1LegacyHkdf(tenantId, purpose, envelope);
         }
         if (!resolved.tenantId().equals(tenantId)) {
             throw new CrossTenantCiphertextException(envelope.kid(), tenantId, resolved.tenantId());
         }
+        if (resolved.purpose() != purpose) {
+            // F-6.0 explicit purpose-mismatch per warroom pass-2 Alex minor
+            // fix. Upstream of the GCM tag check so the type of the failure
+            // (programming bug vs forged ciphertext) is captured. The GCM
+            // tag would also catch this (different DEK under Option A → wrong
+            // tag) — we check explicitly so callers can distinguish.
+            throw new PurposeMismatchException(
+                    envelope.kid(), tenantId, purpose, resolved.purpose());
+        }
+        try {
+            Cipher cipher = Cipher.getInstance(ALGORITHM);
+            cipher.init(Cipher.DECRYPT_MODE, resolved.dek(), new GCMParameterSpec(GCM_TAG_LENGTH, envelope.iv()));
+            byte[] plaintext = cipher.doFinal(envelope.ciphertextWithTag());
+            return new String(plaintext, StandardCharsets.UTF_8);
+        } catch (Exception e) {
+            throw new RuntimeException("Failed to decrypt v1 ciphertext for tenant " + tenantId, e);
+        }
+    }
+
+    /**
+     * Transitional legacy decrypt for v1 envelopes whose kid lives in
+     * {@code kid_to_tenant_key} rather than {@code tenant_dek} — i.e.,
+     * envelopes produced by V74 under the HKDF-DEK scheme before the F-6.0
+     * refactor. Falls through to {@link CrossTenantCiphertextException}
+     * with the unknown-kid sentinel per C-A3-1 if the kid is unknown to
+     * both registries.
+     *
+     * <p>Post-V83, this path is exercised only for stale/cached envelopes
+     * held outside the DB (request-time replay, bug-reported historical
+     * values). The counter {@code secret.decrypt.v1.legacy_hkdf} emitted
+     * below tracks residual calls; an extended flatline is the signal to
+     * retire this method in Phase L.
+     */
+    private String decryptV1LegacyHkdf(java.util.UUID tenantId, KeyPurpose purpose,
+                                        EncryptionEnvelope envelope) {
+        KidRegistryService.KidResolution legacy;
+        try {
+            legacy = kidRegistryService.resolveKid(envelope.kid());
+        } catch (java.util.NoSuchElementException unknown) {
+            throw new CrossTenantCiphertextException(
+                    envelope.kid(), tenantId, UNKNOWN_KID_SENTINEL_TENANT);
+        }
+        if (!legacy.tenantId().equals(tenantId)) {
+            throw new CrossTenantCiphertextException(
+                    envelope.kid(), tenantId, legacy.tenantId());
+        }
+        if (meterRegistry != null) {
+            Counter.builder("secret.decrypt.v1.legacy_hkdf")
+                    .description("v1 envelopes decrypted via the legacy HKDF-DEK path "
+                            + "(kid in kid_to_tenant_key, not tenant_dek). "
+                            + "Post-V83 should trend to zero; extended flatline = "
+                            + "safe to remove the compat shim in Phase L.")
+                    .tag("purpose", purpose.name())
+                    .register(meterRegistry)
+                    .increment();
+        }
+        @SuppressWarnings("removal")
         SecretKey dek = purpose.deriveKey(keyDerivationService, tenantId);
         try {
             Cipher cipher = Cipher.getInstance(ALGORITHM);
@@ -176,7 +266,8 @@ public class SecretEncryptionService {
             byte[] plaintext = cipher.doFinal(envelope.ciphertextWithTag());
             return new String(plaintext, StandardCharsets.UTF_8);
         } catch (Exception e) {
-            throw new RuntimeException("Failed to decrypt v1 ciphertext for tenant " + tenantId, e);
+            throw new RuntimeException(
+                    "Failed to decrypt v1 ciphertext (legacy HKDF path) for tenant " + tenantId, e);
         }
     }
 

--- a/backend/src/main/java/org/fabt/shared/security/SecretEncryptionService.java
+++ b/backend/src/main/java/org/fabt/shared/security/SecretEncryptionService.java
@@ -172,6 +172,21 @@ public class SecretEncryptionService {
      *         tenant but to a different {@link KeyPurpose}.
      */
     public String decryptForTenant(java.util.UUID tenantId, KeyPurpose purpose, String stored) {
+        if (purpose == KeyPurpose.JWT_SIGN) {
+            // Symmetric with encryptForTenant's JWT_SIGN guard. Warroom pass-3
+            // Marcus blocker: without this guard, a caller passing JWT_SIGN
+            // with a v1 envelope whose kid happens to live in kid_to_tenant_key
+            // would fall through to decryptV1LegacyHkdf, which calls
+            // purpose.deriveKey(keyDerivationService, tenantId) → routes to
+            // deriveJwtSigningKey (the HMAC signing key). Feeding an HMAC key
+            // into AES-GCM is a cross-primitive key-reuse vector; the GCM tag
+            // fails but timing/error channels could signal JWT-kid existence.
+            // Reject at the boundary.
+            throw new IllegalArgumentException(
+                    "KeyPurpose.JWT_SIGN is not a data-encryption purpose; "
+                    + "JWT signing uses JwtService + kid_to_tenant_key, not "
+                    + "SecretEncryptionService + tenant_dek.");
+        }
         byte[] decoded = java.util.Base64.getDecoder().decode(stored);
         if (!EncryptionEnvelope.isV1Envelope(decoded)) {
             // v0 fallback — Phase 0 single-platform-key envelope. Design D42

--- a/backend/src/main/java/org/fabt/shared/security/TenantDekService.java
+++ b/backend/src/main/java/org/fabt/shared/security/TenantDekService.java
@@ -1,0 +1,312 @@
+package org.fabt.shared.security;
+
+import java.security.SecureRandom;
+import java.time.Duration;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Owns the {@code tenant_dek} table (V82). Creates, wraps, unwraps, and
+ * caches per-tenant, per-purpose random DEKs — the shred-surface of the
+ * F-6 crypto-shred design.
+ *
+ * <p><b>Why this service exists.</b> Phase A's
+ * {@link KeyDerivationService} derived DEKs deterministically from
+ * {@code (master_KEK, tenantId, purpose)} via HKDF-SHA256. The TDD anchor
+ * {@code CryptoShredGapIntegrationTest} proved that path has no shred
+ * surface: an adversary with {@code master_KEK} + a pre-shred ciphertext
+ * recovers plaintext via public primitives in milliseconds. Option A (the
+ * warroom-approved fix) replaces the deterministic DEK with a random DEK
+ * stored wrapped in {@code tenant_dek}; destroying the row destroys the
+ * only copy of the DEK.
+ *
+ * <h2>Wrapping scheme</h2>
+ *
+ * <ul>
+ *   <li>DEK: 32 random bytes from {@link SecureRandom} (AES-256 key length).</li>
+ *   <li>Wrapping key: HKDF-SHA256 of {@code (master_KEK, tenantId, "kek-wrap")}
+ *       via {@link KeyDerivationService#deriveKekWrappingKey}. Deterministic,
+ *       but safe — see §3 D61 of the design: the wrapping key alone decrypts
+ *       nothing; the shred surface is the wrapped_dek row, not the wrapping
+ *       key.</li>
+ *   <li>Wrap primitive: AES-KWP per RFC 5649 / NIST SP 800-38F §6.3. JDK-native
+ *       via {@code Cipher.getInstance("AESWrapPad")}. 8-byte overhead → 40-byte
+ *       wrapped output for a 32-byte DEK.</li>
+ * </ul>
+ *
+ * <h2>Caches</h2>
+ *
+ * <ul>
+ *   <li><b>Active-DEK cache</b>: {@code (tenantId, purpose)} → {@link ActiveDek}.
+ *       5-min TTL. Keyed on a composite so a single tenant's TOTP DEK never
+ *       serves a webhook-secret encrypt request.</li>
+ *   <li><b>Kid resolution cache</b>: {@code kid} → {@link ResolvedDek}. 1-hour TTL.
+ *       Kid resolution is immutable by design — once a (tenant, purpose,
+ *       generation) kid is minted, it never re-points.</li>
+ * </ul>
+ *
+ * <p>Cache invalidation is the key isolation boundary. Per §5 of the design,
+ * {@link #invalidateTenantDeks} walks both caches and evicts every entry
+ * owned by the given tenant. {@link TenantLifecycleService} calls this on
+ * OFFBOARDING/ARCHIVED transitions (post-commit) AND before {@code hardDelete}
+ * fires the cascade — the pre-transition invalidation closes the hot-JVM
+ * window Alex flagged in pass-1.
+ *
+ * <h2>RLS</h2>
+ *
+ * Writes bind {@code app.tenant_id} in-tx so the V82 RESTRICTIVE policies
+ * allow the INSERT. Reads (resolveDek) are PERMISSIVE at the table level
+ * because the decrypt path runs before tenant context is bound. Delete path
+ * is gated by the V82 trigger guard ({@code fabt.shred_in_progress} GUC
+ * equality), reachable only from {@link TenantLifecycleService#hardDelete}
+ * per ArchUnit rule 7.8j.
+ */
+@Service
+public class TenantDekService {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantDekService.class);
+
+    private static final int DEK_LENGTH_BYTES = 32;  // AES-256
+    private static final String AES_KWP_CIPHER = "AESWrapPad";
+
+    private final JdbcTemplate jdbc;
+    private final KeyDerivationService keyDerivationService;
+    private final SecureRandom secureRandom;
+
+    /**
+     * Active-DEK cache. Key is a {@link ActiveDekCacheKey} record; Caffeine
+     * supports any hashable key type, and the record's auto-generated
+     * {@code hashCode}/{@code equals} keep key identity purpose-scoped.
+     * 5-minute TTL bounds staleness if rotation fires out-of-band.
+     */
+    @TenantScopedByConstruction("key is the composite (tenantId, purpose); cache IS tenant-scoped by construction — no raw tenantId key leaks a different tenant's DEK because lookups require both pieces")
+    private final Cache<ActiveDekCacheKey, ActiveDek> activeDekCache = Caffeine.newBuilder()
+            .maximumSize(10_000)
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .build();
+
+    /**
+     * Kid resolution cache. Kid is a globally-unique opaque UUID; resolution
+     * (kid → tenant, purpose, generation, DEK) is immutable by design. 1-hour
+     * TTL because the mapping never re-points; eviction only on tenant hard-
+     * delete or explicit rotation.
+     */
+    @TenantUnscopedCache("kid is a globally-unique opaque UUID assigned once at tenant_dek insert; resolution (kid → tenant, purpose, generation, DEK) is immutable by design; decrypt path reads this cache BEFORE TenantContext is bound — cache-site tenant-scoping is impossible at this stage")
+    private final Cache<UUID, ResolvedDek> resolvedDekCache = Caffeine.newBuilder()
+            .maximumSize(100_000)
+            .expireAfterWrite(Duration.ofHours(1))
+            .build();
+
+    public TenantDekService(JdbcTemplate jdbc, KeyDerivationService keyDerivationService) {
+        this.jdbc = jdbc;
+        this.keyDerivationService = keyDerivationService;
+        this.secureRandom = new SecureRandom();
+    }
+
+    // ------------------------------------------------------------------
+    // Public API
+    // ------------------------------------------------------------------
+
+    /**
+     * Returns the active DEK for {@code (tenant, purpose)} — unwrapped,
+     * ready to use for AES-GCM encrypt. Lazily creates both the
+     * {@code tenant_dek} row and a random DEK on first call. Idempotent —
+     * concurrent first-encrypts converge on a single row via the V82
+     * unique index + {@code ON CONFLICT DO NOTHING}.
+     */
+    @Transactional
+    public ActiveDek getOrCreateActiveDek(UUID tenantId, KeyPurpose purpose) {
+        ActiveDekCacheKey key = new ActiveDekCacheKey(tenantId, purpose);
+        ActiveDek cached = activeDekCache.getIfPresent(key);
+        if (cached != null) {
+            return cached;
+        }
+
+        // Bind app.tenant_id for the V82 RESTRICTIVE INSERT policy. Third
+        // arg `true` = is_local → GUC auto-clears at tx commit/rollback,
+        // does not leak to subsequent txs on the same pooled connection.
+        // Parameterized — never concatenate the tenantId into the SQL.
+        jdbc.queryForObject(
+            "SELECT set_config('app.tenant_id', ?, true)",
+            String.class,
+            tenantId.toString());
+
+        // Optimistic read — the common case post-bootstrap. Hits the
+        // partial unique index (tenant_id, purpose) WHERE active = TRUE.
+        ActiveDek existing = loadActiveDek(tenantId, purpose);
+        if (existing != null) {
+            activeDekCache.put(key, existing);
+            return existing;
+        }
+
+        // First encrypt for this (tenant, purpose). Generate a random DEK,
+        // wrap it, INSERT with ON CONFLICT DO NOTHING (no target — covers
+        // BOTH unique indexes per Sam pass-1: the composite (tenant, purpose,
+        // generation) AND the partial (tenant, purpose) WHERE active).
+        byte[] rawDek = new byte[DEK_LENGTH_BYTES];
+        secureRandom.nextBytes(rawDek);
+        byte[] wrappedDek = wrap(tenantId, rawDek);
+
+        UUID newKid = UUID.randomUUID();
+        jdbc.update(
+            "INSERT INTO tenant_dek (kid, tenant_id, purpose, generation, wrapped_dek, active) "
+            + "VALUES (?, ?, ?, 1, ?, TRUE) "
+            + "ON CONFLICT DO NOTHING",
+            newKid, tenantId, purpose.name(), wrappedDek);
+
+        // Re-SELECT. If our insert won, we get newKid; if a concurrent
+        // thread won, we get theirs. Either way, exactly one active row
+        // exists for this (tenant, purpose).
+        ActiveDek resolved = loadActiveDek(tenantId, purpose);
+        if (resolved == null) {
+            throw new IllegalStateException(
+                "tenant_dek insert + re-select returned no active row for "
+                + "(" + tenantId + ", " + purpose + ") — this violates the "
+                + "partial unique index invariant and is a bug");
+        }
+        activeDekCache.put(key, resolved);
+        log.info("Created tenant_dek row kid={} for tenant={} purpose={} generation={}",
+            resolved.kid(), tenantId, purpose, resolved.generation());
+        return resolved;
+    }
+
+    /**
+     * Resolves a kid back to its unwrapped DEK plus metadata for the
+     * decrypt path. Throws {@link NoSuchElementException} on unknown kid;
+     * the caller ({@code SecretEncryptionService.decryptForTenant})
+     * translates to {@link CrossTenantCiphertextException} with the
+     * unknown-kid sentinel per C-A3-1.
+     */
+    @Transactional(readOnly = true)
+    public ResolvedDek resolveDek(UUID kid) {
+        ResolvedDek cached = resolvedDekCache.getIfPresent(kid);
+        if (cached != null) {
+            return cached;
+        }
+
+        // PERMISSIVE SELECT on tenant_dek (V82) — no app.tenant_id binding
+        // needed here. Safe because kids are opaque UUIDs; enumeration
+        // yields no tenant identity.
+        ResolvedDek resolved;
+        try {
+            resolved = jdbc.queryForObject(
+                "SELECT kid, tenant_id, purpose, generation, wrapped_dek "
+                + "FROM tenant_dek WHERE kid = ?",
+                (rs, rowNum) -> {
+                    UUID rowKid = (UUID) rs.getObject("kid");
+                    UUID tenantId = (UUID) rs.getObject("tenant_id");
+                    KeyPurpose purpose = KeyPurpose.valueOf(rs.getString("purpose"));
+                    int generation = rs.getInt("generation");
+                    byte[] wrappedDek = rs.getBytes("wrapped_dek");
+                    SecretKey dek = unwrap(tenantId, wrappedDek);
+                    return new ResolvedDek(rowKid, tenantId, purpose, generation, dek);
+                },
+                kid);
+        } catch (EmptyResultDataAccessException notFound) {
+            throw new NoSuchElementException("kid not registered in tenant_dek: " + kid);
+        }
+        resolvedDekCache.put(kid, resolved);
+        return resolved;
+    }
+
+    /**
+     * Evicts every cache entry owned by {@code tenantId} from both caches.
+     * Called by {@link TenantLifecycleService} on OFFBOARDING/ARCHIVED
+     * transitions (via {@code AFTER_COMMIT} listener) and on hardDelete
+     * (pre-CASCADE). Idempotent — safe to call for a tenant with zero
+     * cached entries.
+     *
+     * <p>O(cache-size) via {@code asMap().entrySet()} scan. At pilot scale
+     * (cache max 10k + 100k entries) that's ~100µs; no indexing needed.
+     */
+    public void invalidateTenantDeks(UUID tenantId) {
+        activeDekCache.asMap().keySet().removeIf(key -> key.tenantId().equals(tenantId));
+        resolvedDekCache.asMap().values().removeIf(resolved -> resolved.tenantId().equals(tenantId));
+    }
+
+    // ------------------------------------------------------------------
+    // AES-KWP wrap / unwrap
+    // ------------------------------------------------------------------
+
+    /** Wraps raw DEK bytes under the per-tenant wrapping key. Output is
+     *  RFC 5649 AES-KWP: 40 bytes for a 32-byte DEK (8-byte overhead). */
+    private byte[] wrap(UUID tenantId, byte[] rawDek) {
+        try {
+            SecretKey wrappingKey = keyDerivationService.deriveKekWrappingKey(tenantId);
+            Cipher cipher = Cipher.getInstance(AES_KWP_CIPHER);
+            cipher.init(Cipher.WRAP_MODE, wrappingKey);
+            SecretKey dekAsKey = new SecretKeySpec(rawDek, "AES");
+            return cipher.wrap(dekAsKey);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                "AES-KWP wrap failed for tenant " + tenantId + " — JDK should ship AESWrapPad", e);
+        }
+    }
+
+    /** Unwraps a wrapped DEK back into a usable {@link SecretKey} for AES-GCM. */
+    private SecretKey unwrap(UUID tenantId, byte[] wrappedDek) {
+        try {
+            SecretKey wrappingKey = keyDerivationService.deriveKekWrappingKey(tenantId);
+            Cipher cipher = Cipher.getInstance(AES_KWP_CIPHER);
+            cipher.init(Cipher.UNWRAP_MODE, wrappingKey);
+            // "AES" algorithm name + Cipher.SECRET_KEY mode → SecretKeySpec
+            // wrapping the unwrapped 32 bytes.
+            return (SecretKey) cipher.unwrap(wrappedDek, "AES", Cipher.SECRET_KEY);
+        } catch (Exception e) {
+            throw new IllegalStateException(
+                "AES-KWP unwrap failed for tenant " + tenantId
+                + " — likely corrupt wrapped_dek or derivation mismatch", e);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Private SELECT helper
+    // ------------------------------------------------------------------
+
+    private ActiveDek loadActiveDek(UUID tenantId, KeyPurpose purpose) {
+        try {
+            return jdbc.queryForObject(
+                "SELECT kid, generation, wrapped_dek FROM tenant_dek "
+                + "WHERE tenant_id = ? AND purpose = ? AND active = TRUE",
+                (rs, rowNum) -> {
+                    UUID kid = (UUID) rs.getObject("kid");
+                    int generation = rs.getInt("generation");
+                    byte[] wrappedDek = rs.getBytes("wrapped_dek");
+                    SecretKey dek = unwrap(tenantId, wrappedDek);
+                    return new ActiveDek(kid, dek, generation);
+                },
+                tenantId, purpose.name());
+        } catch (EmptyResultDataAccessException empty) {
+            return null;
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Value types
+    // ------------------------------------------------------------------
+
+    /** Composite cache key for the active-DEK cache. */
+    record ActiveDekCacheKey(UUID tenantId, KeyPurpose purpose) {}
+
+    /** Result of {@link #getOrCreateActiveDek}: the kid to emit in the
+     *  envelope + the unwrapped DEK + the generation. */
+    public record ActiveDek(UUID kid, SecretKey dek, int generation) {}
+
+    /** Result of {@link #resolveDek}: full kid-to-(tenant, purpose,
+     *  generation, DEK) resolution for the decrypt path. */
+    public record ResolvedDek(UUID kid, UUID tenantId, KeyPurpose purpose,
+                              int generation, SecretKey dek) {}
+}

--- a/backend/src/main/java/org/fabt/shared/security/TenantInternal.java
+++ b/backend/src/main/java/org/fabt/shared/security/TenantInternal.java
@@ -1,0 +1,35 @@
+package org.fabt.shared.security;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Marks a method or class as legitimately bypassing the F-3 tenant-state read-path
+ * guard. Used by paths that cannot rely on the active-state check because they run
+ * either before a tenant is fully ACTIVE (e.g. {@code TenantLifecycleService.create}
+ * during bootstrap) or deliberately across all tenant states (e.g. the lifecycle
+ * service's own state transitions, batch-job cleanup sweeps, crypto-shred paths).
+ *
+ * <p>Every use MUST include a justification string explaining why the bypass is safe.
+ * The ArchUnit Family D rule ({@code TenantGuardArchitectureTest}) reads this annotation
+ * to allow public methods to call {@code findByIdAndTenantId} without swapping to the
+ * {@code findByIdAndActiveTenantId} variant. Think of it as the {@code SAFE_SITES}
+ * allowlist's inline analogue — an annotation-local justification instead of a central
+ * registry.</p>
+ *
+ * <p>Analogous to {@link TenantUnscoped} (which marks code that legitimately spans
+ * multiple tenants). {@code @TenantInternal} is for code that operates on ONE tenant's
+ * data but in a lifecycle state where the ACTIVE gate would be wrong.</p>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.METHOD, ElementType.TYPE})
+public @interface TenantInternal {
+    /**
+     * Free-form justification explaining why this method/class legitimately bypasses
+     * the ACTIVE-state read guard. Required — a call site without a reason is
+     * indistinguishable from a forgotten migration.
+     */
+    String value();
+}

--- a/backend/src/main/java/org/fabt/subscription/repository/SubscriptionRepository.java
+++ b/backend/src/main/java/org/fabt/subscription/repository/SubscriptionRepository.java
@@ -27,4 +27,17 @@ public interface SubscriptionRepository extends CrudRepository<Subscription, UUI
     @Query("SELECT * FROM subscription WHERE id = :id AND tenant_id = :tenantId")
     Optional<Subscription> findByIdAndTenantId(@Param("id") UUID id,
                                                 @Param("tenantId") UUID tenantId);
+
+    /**
+     * Phase F §D3 active-state guard. Returns the subscription only if the owning
+     * tenant is ACTIVE; rows for non-ACTIVE tenants appear as empty (caller maps to
+     * 404 — no existence leak). Preferred over {@link #findByIdAndTenantId} for
+     * request-bound paths; the plain variant is for {@code @TenantInternal}
+     * call sites (lifecycle service, batch sweeps).
+     */
+    @Query("SELECT s.* FROM subscription s "
+         + "INNER JOIN tenant t ON t.id = s.tenant_id "
+         + "WHERE s.id = :id AND s.tenant_id = :tenantId AND t.state = 'ACTIVE'")
+    Optional<Subscription> findByIdAndActiveTenantId(@Param("id") UUID id,
+                                                      @Param("tenantId") UUID tenantId);
 }

--- a/backend/src/main/java/org/fabt/subscription/service/SubscriptionService.java
+++ b/backend/src/main/java/org/fabt/subscription/service/SubscriptionService.java
@@ -126,7 +126,7 @@ public class SubscriptionService {
      * ArchUnit.
      */
     private Subscription findByIdOrThrow(UUID id) {
-        return subscriptionRepository.findByIdAndTenantId(id, TenantContext.getTenantId())
+        return subscriptionRepository.findByIdAndActiveTenantId(id, TenantContext.getTenantId())
                 .orElseThrow(() -> new NoSuchElementException("Subscription not found: " + id));
     }
 

--- a/backend/src/main/java/org/fabt/surge/repository/SurgeEventRepository.java
+++ b/backend/src/main/java/org/fabt/surge/repository/SurgeEventRepository.java
@@ -63,6 +63,22 @@ public class SurgeEventRepository {
         return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
     }
 
+    /**
+     * Phase F §D3 active-state guard. Returns the surge event only if the owning
+     * tenant is ACTIVE; rows for non-ACTIVE tenants appear as empty (caller maps to
+     * 404 — no existence leak). Preferred over {@link #findByIdAndTenantId} for
+     * request-bound paths; the plain variant is for {@code @TenantInternal} callers.
+     */
+    public Optional<SurgeEvent> findByIdAndActiveTenantId(UUID id, UUID tenantId) {
+        List<SurgeEvent> results = jdbcTemplate.query(
+                "SELECT se.* FROM surge_event se "
+                + "INNER JOIN tenant t ON t.id = se.tenant_id "
+                + "WHERE se.id = ? AND se.tenant_id = ? AND t.state = 'ACTIVE'",
+                ROW_MAPPER, id, tenantId
+        );
+        return results.isEmpty() ? Optional.empty() : Optional.of(results.get(0));
+    }
+
     public Optional<SurgeEvent> findActiveByTenantId(UUID tenantId) {
         List<SurgeEvent> results = jdbcTemplate.query(
                 "SELECT * FROM surge_event WHERE tenant_id = ? AND status = 'ACTIVE' LIMIT 1",

--- a/backend/src/main/java/org/fabt/surge/service/SurgeEventService.java
+++ b/backend/src/main/java/org/fabt/surge/service/SurgeEventService.java
@@ -83,7 +83,7 @@ public class SurgeEventService {
     public SurgeEvent deactivate(UUID surgeEventId, UUID deactivatedBy) {
         UUID tenantId = TenantContext.getTenantId();
 
-        SurgeEvent event = repository.findByIdAndTenantId(surgeEventId, tenantId)
+        SurgeEvent event = repository.findByIdAndActiveTenantId(surgeEventId, tenantId)
                 .orElseThrow(() -> new NoSuchElementException("Surge event not found: " + surgeEventId));
 
         if (!event.isActive()) {
@@ -141,6 +141,6 @@ public class SurgeEventService {
     @Transactional(readOnly = true)
     public Optional<SurgeEvent> findById(UUID id) {
         UUID tenantId = TenantContext.getTenantId();
-        return repository.findByIdAndTenantId(id, tenantId);
+        return repository.findByIdAndActiveTenantId(id, tenantId);
     }
 }

--- a/backend/src/main/java/org/fabt/surge/service/SurgeEventService.java
+++ b/backend/src/main/java/org/fabt/surge/service/SurgeEventService.java
@@ -13,6 +13,7 @@ import org.fabt.availability.repository.BedAvailabilityRepository;
 import org.fabt.observability.ObservabilityMetrics;
 import org.fabt.shared.event.DomainEvent;
 import org.fabt.shared.event.EventBus;
+import org.fabt.shared.security.TenantInternal;
 import org.fabt.shared.web.TenantContext;
 import org.fabt.shelter.service.ShelterService;
 import org.fabt.surge.domain.SurgeEvent;
@@ -110,6 +111,11 @@ public class SurgeEventService {
         return event;
     }
 
+    @TenantInternal("batch-scheduler path; passes null tenantId to findByIdAndTenantId "
+            + "which never matches (tenant_id NOT NULL), so the event-publish block below "
+            + "never fires — a latent bug predating F-3 that needs its own refactor to bind "
+            + "tenant context from the surge row. Intentionally NOT swapped to the ACTIVE "
+            + "variant by F-3; tracked in project_f3_part2_resume_point.md.")
     @Transactional
     public void expireSurge(UUID surgeEventId) {
         repository.updateStatus(surgeEventId, SurgeEventStatus.EXPIRED, null);

--- a/backend/src/main/java/org/fabt/tenant/api/TenantController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantController.java
@@ -12,9 +12,12 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.fabt.observability.ObservabilityConfigService;
 import org.fabt.observability.ObservabilityConfigService.ObservabilityConfig;
+import org.fabt.shared.web.TenantContext;
 import org.fabt.shared.web.TenantPathGuard;
 import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.service.TenantLifecycleService;
 import org.fabt.tenant.service.TenantService;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -37,11 +40,22 @@ public class TenantController {
 
     private final TenantService tenantService;
     private final ObservabilityConfigService observabilityConfigService;
+    /**
+     * Optional — the F-4 atomic-create path. Present when
+     * {@code fabt.tenant.lifecycle.enabled=true}, absent otherwise. When present,
+     * {@link #create} delegates here for the full bootstrap (audit_chain_head seed,
+     * eager JWT key material, TENANT_CREATED audit). When absent, falls back to the
+     * legacy {@link TenantService#create} path which relies on lazy-at-first-login
+     * key material bootstrap.
+     */
+    private final ObjectProvider<TenantLifecycleService> tenantLifecycleServiceProvider;
 
     public TenantController(TenantService tenantService,
-                            ObservabilityConfigService observabilityConfigService) {
+                            ObservabilityConfigService observabilityConfigService,
+                            ObjectProvider<TenantLifecycleService> tenantLifecycleServiceProvider) {
         this.tenantService = tenantService;
         this.observabilityConfigService = observabilityConfigService;
+        this.tenantLifecycleServiceProvider = tenantLifecycleServiceProvider;
     }
 
     @Operation(
@@ -55,7 +69,19 @@ public class TenantController {
     )
     @PostMapping
     public ResponseEntity<TenantResponse> create(@Valid @RequestBody CreateTenantRequest request) {
-        Tenant tenant = tenantService.create(request.name(), request.slug());
+        // F-4: prefer the lifecycle service's atomic bootstrap when the feature
+        // flag is on (TenantLifecycleService bean exists). Falls back to the
+        // legacy TenantService.create path when the bean is absent — that path
+        // relies on lazy-at-first-login JWT key material bootstrap and does NOT
+        // seed the audit_chain_head row, but remains correct for backwards
+        // compatibility while the flag rolls out.
+        TenantLifecycleService lifecycle = tenantLifecycleServiceProvider.getIfAvailable();
+        Tenant tenant;
+        if (lifecycle != null) {
+            tenant = lifecycle.create(request.name(), request.slug(), TenantContext.getUserId());
+        } else {
+            tenant = tenantService.create(request.name(), request.slug());
+        }
         return ResponseEntity.status(HttpStatus.CREATED).body(TenantResponse.from(tenant));
     }
 

--- a/backend/src/main/java/org/fabt/tenant/api/TenantLifecycleExceptionAdvice.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantLifecycleExceptionAdvice.java
@@ -1,0 +1,93 @@
+package org.fabt.tenant.api;
+
+import java.util.Locale;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.fabt.shared.web.ErrorResponse;
+import org.fabt.tenant.domain.TenantStateGuardException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.MessageSource;
+import org.springframework.context.i18n.LocaleContextHolder;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.RequestContextHolder;
+import org.springframework.web.context.request.ServletRequestAttributes;
+
+/**
+ * Tenant-module-local exception handler. Lives in the tenant module because the
+ * {@link TenantStateGuardException} type resides here, and
+ * {@code org.fabt.shared.web.GlobalExceptionHandler} must not depend on any domain
+ * module (enforced by {@code ArchitectureTest.shared_non_security_should_not_depend_on_modules}).
+ * Spring supports multiple {@code @RestControllerAdvice} beans — this one handles
+ * tenant-lifecycle exceptions, the shared one handles cross-cutting concerns
+ * (auth, validation, etc.).
+ */
+@RestControllerAdvice
+public class TenantLifecycleExceptionAdvice {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantLifecycleExceptionAdvice.class);
+
+    private final MessageSource messageSource;
+    private final MeterRegistry meterRegistry;
+
+    public TenantLifecycleExceptionAdvice(MessageSource messageSource, MeterRegistry meterRegistry) {
+        this.messageSource = messageSource;
+        this.meterRegistry = meterRegistry;
+    }
+
+    @ExceptionHandler(TenantStateGuardException.class)
+    public ResponseEntity<ErrorResponse> handleTenantStateGuard(TenantStateGuardException ex) {
+        // Phase F §D3 — no existence leak. Branch on HTTP method so reads get 404
+        // (attacker probing UUIDs sees the same 404 whether the tenant exists or not)
+        // and writes get 503 with Retry-After (operator action required before the
+        // tenant will accept mutations again — suspends can be lifted, archives cannot).
+        String httpMethod = currentRequestMethod();
+        boolean isReadMethod = "GET".equals(httpMethod) || "HEAD".equals(httpMethod);
+
+        // Counter for observability — tenant-id intentionally NOT tagged (would
+        // leak a non-existent tenant id guess via Prometheus cardinality).
+        Counter.builder("fabt.security.tenant_state_guard_rejection")
+                .tag("kind", ex.kind().name().toLowerCase())
+                .tag("http_method", httpMethod)
+                .register(meterRegistry)
+                .increment();
+
+        if (isReadMethod || ex.kind() == TenantStateGuardException.Kind.NOT_FOUND) {
+            log.warn("TenantStateGuard 404 (kind={}, method={})", ex.kind(), httpMethod);
+            Locale locale = LocaleContextHolder.getLocale();
+            String message = messageSource.getMessage(
+                "error.not_found", null, "The requested resource was not found", locale);
+            return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(new ErrorResponse("not_found", message, 404));
+        }
+
+        // Write against a non-active tenant — 503 with Retry-After. Tuned to 3600s
+        // (1 hour) matching the operator-oncall response window for quarantine-review.
+        // ARCHIVED/DELETED tenants will never come back, but the client still gets the
+        // generic 503 — no state leak. D3 consistency: we do NOT say "this tenant is
+        // archived/deleted" in the body.
+        log.warn("TenantStateGuard 503 (kind={}, method={})", ex.kind(), httpMethod);
+        return ResponseEntity
+            .status(HttpStatus.SERVICE_UNAVAILABLE)
+            .header("Retry-After", "3600")
+            .body(new ErrorResponse("service_unavailable",
+                "Service temporarily unavailable for this resource", 503));
+    }
+
+    /**
+     * Current HTTP method, best-effort. Falls back to {@code "UNKNOWN"} off the request
+     * path (async, test invocations) so counters still tag something sensible.
+     */
+    private static String currentRequestMethod() {
+        var attrs = RequestContextHolder.getRequestAttributes();
+        if (attrs instanceof ServletRequestAttributes sra) {
+            return sra.getRequest().getMethod();
+        }
+        return "UNKNOWN";
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/api/TenantStateHandlerInterceptor.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantStateHandlerInterceptor.java
@@ -1,0 +1,69 @@
+package org.fabt.tenant.api;
+
+import java.util.UUID;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.fabt.shared.web.TenantContext;
+import org.fabt.tenant.service.TenantStateGuard;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.servlet.HandlerInterceptor;
+
+/**
+ * Single-point read-path enforcement for F-3.3. Runs after {@code JwtAuthenticationFilter}
+ * (and {@code ApiKeyAuthenticationFilter}) have bound {@link TenantContext}, but before
+ * the controller method executes. Short-circuits any request whose caller belongs to a
+ * non-ACTIVE tenant with a 404 / 503 via {@link TenantStateGuardException} →
+ * {@link TenantLifecycleExceptionAdvice}.
+ *
+ * <p><b>What this covers:</b> every MVC request that landed an authenticated caller on a
+ * tenant. The interceptor delegates to {@link TenantStateGuard#requireActive} so the
+ * 10s cache bounds DB load. Defense-in-depth complement to the F-3.2 SQL JOIN guards
+ * (which protect the target data's tenant state; this protects the caller's tenant
+ * state).</p>
+ *
+ * <p><b>What this does NOT cover (intentionally):</b>
+ * <ul>
+ *   <li>Pre-auth / public endpoints — no {@link TenantContext} bound, interceptor skips.
+ *   <li>Batch jobs / scheduled tasks — not MVC, interceptor doesn't fire; those paths
+ *       are explicitly tenant-unscoped or bind {@link TenantContext#SYSTEM_TENANT_ID}.
+ *   <li>Platform-admin cross-tenant operations where the admin's tenant is ACTIVE but
+ *       the TARGET tenant is non-ACTIVE — the admin's request passes this gate; the
+ *       F-3.2 SQL JOIN on tenant-owned reads blocks the target-side access.
+ *   <li>{@link TenantContext#SYSTEM_TENANT_ID} — skipped; system tenant is a sentinel,
+ *       not a real tenant with a lifecycle.
+ * </ul>
+ */
+@Component
+public class TenantStateHandlerInterceptor implements HandlerInterceptor {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantStateHandlerInterceptor.class);
+
+    private final TenantStateGuard tenantStateGuard;
+
+    public TenantStateHandlerInterceptor(TenantStateGuard tenantStateGuard) {
+        this.tenantStateGuard = tenantStateGuard;
+    }
+
+    @Override
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
+        UUID tenantId = TenantContext.getTenantId();
+        if (tenantId == null) {
+            // No tenant context — pre-auth endpoint, public endpoint, or batch path.
+            // Nothing to guard. Let the request proceed.
+            return true;
+        }
+        if (TenantContext.SYSTEM_TENANT_ID.equals(tenantId)) {
+            // System sentinel — internal batch/migration paths that happen to route
+            // through MVC. No lifecycle state to check.
+            return true;
+        }
+        // Throws TenantStateGuardException on non-ACTIVE / NOT_FOUND; caught by
+        // TenantLifecycleExceptionAdvice → 404/503 response.
+        tenantStateGuard.requireActive(tenantId);
+        return true;
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/api/TenantWebMvcConfigurer.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantWebMvcConfigurer.java
@@ -1,0 +1,28 @@
+package org.fabt.tenant.api;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.InterceptorRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+/**
+ * Registers tenant-module MVC interceptors. Lives alongside the interceptor itself
+ * (not in {@code shared.web}) because {@code shared.web} must not depend on any
+ * domain module per
+ * {@code ArchitectureTest.shared_non_security_should_not_depend_on_modules}.
+ * Spring picks up all {@link WebMvcConfigurer} beans automatically, so there is no
+ * central registry.
+ */
+@Configuration
+public class TenantWebMvcConfigurer implements WebMvcConfigurer {
+
+    private final TenantStateHandlerInterceptor tenantStateHandlerInterceptor;
+
+    public TenantWebMvcConfigurer(TenantStateHandlerInterceptor tenantStateHandlerInterceptor) {
+        this.tenantStateHandlerInterceptor = tenantStateHandlerInterceptor;
+    }
+
+    @Override
+    public void addInterceptors(InterceptorRegistry registry) {
+        registry.addInterceptor(tenantStateHandlerInterceptor);
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/domain/IllegalStateTransitionException.java
+++ b/backend/src/main/java/org/fabt/tenant/domain/IllegalStateTransitionException.java
@@ -1,0 +1,26 @@
+package org.fabt.tenant.domain;
+
+/**
+ * Thrown when a tenant lifecycle transition violates the §D8 FSM (see {@link TenantState}).
+ * Callers that map to HTTP should translate to {@code 409 Conflict} — the resource exists
+ * but its current state does not permit the requested operation.
+ */
+public class IllegalStateTransitionException extends RuntimeException {
+
+    private final TenantState from;
+    private final TenantState to;
+
+    public IllegalStateTransitionException(TenantState from, TenantState to, String reason) {
+        super("illegal tenant state transition " + from + " -> " + to + ": " + reason);
+        this.from = from;
+        this.to = to;
+    }
+
+    public TenantState from() {
+        return from;
+    }
+
+    public TenantState to() {
+        return to;
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/domain/Tenant.java
+++ b/backend/src/main/java/org/fabt/tenant/domain/Tenant.java
@@ -17,6 +17,14 @@ public class Tenant {
     private JsonString config;
     private Instant createdAt;
     private Instant updatedAt;
+    /**
+     * Lifecycle state. Mirrors the {@code tenant_state} enum column declared in V60.
+     * Defaults to {@link TenantState#ACTIVE} so existing {@link org.fabt.tenant.service.TenantService}
+     * {@code create()} paths (which never touch state) match the DB default.
+     * Write-path state mutations flow exclusively through
+     * {@code TenantLifecycleService} once Phase F slice F-4 lands.
+     */
+    private TenantState state = TenantState.ACTIVE;
 
     public Tenant() {
     }
@@ -76,5 +84,13 @@ public class Tenant {
 
     public void setUpdatedAt(Instant updatedAt) {
         this.updatedAt = updatedAt;
+    }
+
+    public TenantState getState() {
+        return state;
+    }
+
+    public void setState(TenantState state) {
+        this.state = state;
     }
 }

--- a/backend/src/main/java/org/fabt/tenant/domain/Tenant.java
+++ b/backend/src/main/java/org/fabt/tenant/domain/Tenant.java
@@ -26,6 +26,21 @@ public class Tenant {
      */
     private TenantState state = TenantState.ACTIVE;
 
+    /**
+     * Set by {@code TenantLifecycleService.offboard} (Phase F slice F-5) with the
+     * filesystem path (v0.51.0) or S3 URI (Phase H) where the GDPR Art. 20
+     * data-portability export landed. NULL for ACTIVE / SUSPENDED tenants;
+     * required non-null before {@code archive()} may transition to ARCHIVED.
+     */
+    private String offboardExportReceiptUri;
+
+    /**
+     * Stamped when {@code archive()} transitions state to ARCHIVED. Starts the
+     * 30-day retention window that {@code hardDelete()} (F-6) gates on. NULL for
+     * non-ARCHIVED tenants.
+     */
+    private Instant archivedAt;
+
     public Tenant() {
     }
 
@@ -92,5 +107,21 @@ public class Tenant {
 
     public void setState(TenantState state) {
         this.state = state;
+    }
+
+    public String getOffboardExportReceiptUri() {
+        return offboardExportReceiptUri;
+    }
+
+    public void setOffboardExportReceiptUri(String offboardExportReceiptUri) {
+        this.offboardExportReceiptUri = offboardExportReceiptUri;
+    }
+
+    public Instant getArchivedAt() {
+        return archivedAt;
+    }
+
+    public void setArchivedAt(Instant archivedAt) {
+        this.archivedAt = archivedAt;
     }
 }

--- a/backend/src/main/java/org/fabt/tenant/domain/TenantState.java
+++ b/backend/src/main/java/org/fabt/tenant/domain/TenantState.java
@@ -1,0 +1,69 @@
+package org.fabt.tenant.domain;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Tenant lifecycle state. Mirrors the PostgreSQL {@code tenant_state} enum declared in
+ * migration V60 ({@code ACTIVE | SUSPENDED | OFFBOARDING | ARCHIVED | DELETED}). The FSM
+ * is the authoritative gate for write-path operations — see
+ * {@code multi-tenant-production-readiness} design §D8.
+ *
+ * <p>Allowed transitions (design §D8):</p>
+ * <pre>
+ *   ACTIVE     -> SUSPENDED, OFFBOARDING
+ *   SUSPENDED  -> ACTIVE, OFFBOARDING
+ *   OFFBOARDING -> ARCHIVED
+ *   ARCHIVED   -> DELETED
+ *   DELETED    -> (terminal; no outgoing transitions)
+ * </pre>
+ *
+ * <p>Disallowed transitions of note: {@code DELETED -> *} and {@code ARCHIVED -> ACTIVE}
+ * (re-onboarding is a fresh {@code create}, not a revival). Self-transitions are rejected
+ * so idempotency-checking callers surface as 409 rather than a silent no-op.</p>
+ */
+public enum TenantState {
+    ACTIVE,
+    SUSPENDED,
+    OFFBOARDING,
+    ARCHIVED,
+    DELETED;
+
+    private Set<TenantState> allowedNext;
+
+    static {
+        ACTIVE.allowedNext = EnumSet.of(SUSPENDED, OFFBOARDING);
+        SUSPENDED.allowedNext = EnumSet.of(ACTIVE, OFFBOARDING);
+        OFFBOARDING.allowedNext = EnumSet.of(ARCHIVED);
+        ARCHIVED.allowedNext = EnumSet.of(DELETED);
+        DELETED.allowedNext = EnumSet.noneOf(TenantState.class);
+    }
+
+    public boolean canTransitionTo(TenantState target) {
+        return allowedNext.contains(target);
+    }
+
+    public Set<TenantState> allowedNext() {
+        return EnumSet.copyOf(allowedNext);
+    }
+
+    /**
+     * Asserts that transitioning {@code from -> to} is permitted by §D8. Throws
+     * {@link IllegalStateTransitionException} when the transition would violate the FSM,
+     * including when {@code from == to} (self-transitions are an idempotency concern and
+     * must be handled by the caller before reaching the assertion).
+     */
+    public static void assertTransition(TenantState from, TenantState to) {
+        if (from == null || to == null) {
+            throw new IllegalArgumentException("from and to must be non-null");
+        }
+        if (from == to) {
+            throw new IllegalStateTransitionException(from, to,
+                "self-transition not allowed — caller must no-op or return 409 before calling assertTransition");
+        }
+        if (!from.canTransitionTo(to)) {
+            throw new IllegalStateTransitionException(from, to,
+                "transition not permitted by FSM §D8");
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/domain/TenantStateGuardException.java
+++ b/backend/src/main/java/org/fabt/tenant/domain/TenantStateGuardException.java
@@ -1,0 +1,70 @@
+package org.fabt.tenant.domain;
+
+import java.util.UUID;
+
+/**
+ * Thrown when an operation targets a tenant whose lifecycle state forbids the request.
+ * Drives the F-3 read-path enforcement: reads from non-ACTIVE tenants return 404 (no
+ * existence leak per design §D3), writes return 503 with {@code Retry-After}. See
+ * {@link org.fabt.shared.web.GlobalExceptionHandler} for the HTTP-method branching.
+ *
+ * <p>Two shapes:
+ * <ul>
+ *   <li>{@link Kind#NOT_FOUND} — the tenant id does not resolve to a row. Always 404,
+ *       regardless of HTTP method. This is structurally identical to "wrong tenant"
+ *       (an attacker probing UUIDs gets the same signal whether the tenant exists or
+ *       not), which is the point.</li>
+ *   <li>{@link Kind#NON_ACTIVE} — the tenant exists but is SUSPENDED / OFFBOARDING /
+ *       ARCHIVED / DELETED. 404 on reads (no existence leak), 503 with
+ *       {@code Retry-After} on writes (operator action required before the tenant
+ *       can accept mutations again).</li>
+ * </ul>
+ */
+public class TenantStateGuardException extends RuntimeException {
+
+    public enum Kind {
+        NOT_FOUND,
+        NON_ACTIVE
+    }
+
+    private final Kind kind;
+    private final UUID tenantId;
+    private final TenantState observedState;
+
+    public static TenantStateGuardException notFound(UUID tenantId) {
+        return new TenantStateGuardException(Kind.NOT_FOUND, tenantId, null,
+            "tenant not found: " + tenantId);
+    }
+
+    public static TenantStateGuardException nonActive(UUID tenantId, TenantState observedState) {
+        return new TenantStateGuardException(Kind.NON_ACTIVE, tenantId, observedState,
+            "tenant " + tenantId + " is not ACTIVE (observed state: " + observedState + ")");
+    }
+
+    private TenantStateGuardException(Kind kind, UUID tenantId, TenantState observedState,
+                                       String message) {
+        super(message);
+        this.kind = kind;
+        this.tenantId = tenantId;
+        this.observedState = observedState;
+    }
+
+    public Kind kind() {
+        return kind;
+    }
+
+    public UUID tenantId() {
+        return tenantId;
+    }
+
+    /**
+     * Observed state for {@link Kind#NON_ACTIVE}; {@code null} for {@link Kind#NOT_FOUND}.
+     * Deliberately NOT surfaced in the HTTP response body — leaking "SUSPENDED" vs
+     * "OFFBOARDING" vs "ARCHIVED" tells an attacker where in the lifecycle a tenant
+     * sits. Controllers / exception handlers see this for logging + audit; response
+     * bodies get a generic "not_found" or "service_unavailable".
+     */
+    public TenantState observedState() {
+        return observedState;
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -61,6 +61,7 @@ public class TenantLifecycleService {
     private final JdbcTemplate jdbc;
     private final TenantStateGuard tenantStateGuard;
     private final DetachedAuditPersister detachedAuditPersister;
+    private final TenantOffboardExportService offboardExportService;
 
     public TenantLifecycleService(TenantRepository tenantRepository,
                                    TenantKeyRotationService tenantKeyRotationService,
@@ -69,7 +70,8 @@ public class TenantLifecycleService {
                                    ApplicationEventPublisher eventPublisher,
                                    JdbcTemplate jdbc,
                                    TenantStateGuard tenantStateGuard,
-                                   DetachedAuditPersister detachedAuditPersister) {
+                                   DetachedAuditPersister detachedAuditPersister,
+                                   TenantOffboardExportService offboardExportService) {
         this.tenantRepository = tenantRepository;
         this.tenantKeyRotationService = tenantKeyRotationService;
         this.kidRegistryService = kidRegistryService;
@@ -78,6 +80,7 @@ public class TenantLifecycleService {
         this.jdbc = jdbc;
         this.tenantStateGuard = tenantStateGuard;
         this.detachedAuditPersister = detachedAuditPersister;
+        this.offboardExportService = offboardExportService;
     }
 
     /**
@@ -376,27 +379,101 @@ public class TenantLifecycleService {
     }
 
     /**
-     * Transition {ACTIVE, SUSPENDED} → OFFBOARDING. Slice F-5 wires the export workflow
-     * (schema'd JSON dump written to a GDPR Art. 20 delivery location) and stores the
-     * export receipt URI on the tenant row.
+     * Transition {ACTIVE, SUSPENDED} → OFFBOARDING. Triggers the GDPR Art. 20 export
+     * via {@link TenantOffboardExportService}, stores the resulting receipt URI on
+     * the tenant row, and emits {@link AuditEventTypes#TENANT_OFFBOARDING_STARTED}.
+     *
+     * <p>Ordering inside the single {@code @Transactional}: load + assert → bind
+     * GUC for audit → generate export (joins the tx, consistent snapshot) → flip
+     * state + store receipt URI → save → audit → after-commit cache invalidation.
+     * If any step throws, everything rolls back — no half-offboarded tenant with
+     * receipt URI but ACTIVE state, and the {@code .partial} export file is
+     * cleaned up by the exporter's own finally block.</p>
      */
     @Transactional
     public Tenant offboard(UUID tenantId, UUID actorUserId, String justification) {
         return wrapAttemptAudit(tenantId, actorUserId, justification,
             AuditEventTypes.TENANT_OFFBOARD_REJECTED,
-            () -> transitionTo(tenantId, TenantState.OFFBOARDING));
+            () -> doOffboard(tenantId, actorUserId, justification));
+    }
+
+    private Tenant doOffboard(UUID tenantId, UUID actorUserId, String justification) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
+        TenantState previous = tenant.getState();
+        TenantState.assertTransition(previous, TenantState.OFFBOARDING);
+
+        bindTenantContextForAudit(tenantId);
+
+        // Export BEFORE flipping state so the export still sees the consistent
+        // pre-offboarding view. Joins the outer tx.
+        String exportUri = offboardExportService.exportTenant(tenantId);
+
+        tenant.setState(TenantState.OFFBOARDING);
+        tenant.setOffboardExportReceiptUri(exportUri);
+        tenant.setUpdatedAt(java.time.Instant.now());
+        Tenant saved = tenantRepository.save(tenant);
+
+        Map<String, Object> extras = new LinkedHashMap<>();
+        extras.put("export_receipt_uri", exportUri);
+        eventPublisher.publishEvent(new AuditEventRecord(
+            actorUserId, null, AuditEventTypes.TENANT_OFFBOARDING_STARTED,
+            auditDetails(actorUserId, justification, previous, extras),
+            null));
+
+        scheduleStateCacheInvalidation(tenantId);
+        return saved;
     }
 
     /**
-     * Transition OFFBOARDING → ARCHIVED. Slice F-5 adds the {@code archived_at}
-     * timestamp write and requires a non-null {@code offboard_export_receipt_uri}
-     * before permitting the transition.
+     * Transition OFFBOARDING → ARCHIVED. Requires that {@code offboard()} has
+     * already run and stored a non-null {@code offboard_export_receipt_uri};
+     * enforces GDPR Art. 20 sequencing — no archive without export. Stamps
+     * {@code archived_at} with the current timestamp to start the 30-day retention
+     * window that {@code hardDelete()} (F-6) checks.
      */
     @Transactional
     public Tenant archive(UUID tenantId, UUID actorUserId, String justification) {
         return wrapAttemptAudit(tenantId, actorUserId, justification,
             AuditEventTypes.TENANT_ARCHIVE_REJECTED,
-            () -> transitionTo(tenantId, TenantState.ARCHIVED));
+            () -> doArchive(tenantId, actorUserId, justification));
+    }
+
+    private Tenant doArchive(UUID tenantId, UUID actorUserId, String justification) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
+        TenantState previous = tenant.getState();
+        TenantState.assertTransition(previous, TenantState.ARCHIVED);
+
+        // Gate: must have an export receipt. A tenant that somehow reached
+        // OFFBOARDING without a receipt (future code path that bypasses offboard
+        // service) cannot proceed to ARCHIVED — §D8 FSM allows OFFBOARDING →
+        // ARCHIVED but the GDPR-Art-20 contract adds this receipt check.
+        if (tenant.getOffboardExportReceiptUri() == null
+                || tenant.getOffboardExportReceiptUri().isBlank()) {
+            throw new IllegalStateException(
+                "Tenant " + tenantId + " cannot be archived without an offboard "
+                + "export receipt — run offboard() first");
+        }
+
+        bindTenantContextForAudit(tenantId);
+
+        java.time.Instant archivedAt = java.time.Instant.now();
+        tenant.setState(TenantState.ARCHIVED);
+        tenant.setArchivedAt(archivedAt);
+        tenant.setUpdatedAt(archivedAt);
+        Tenant saved = tenantRepository.save(tenant);
+
+        Map<String, Object> extras = new LinkedHashMap<>();
+        extras.put("archived_at", archivedAt.toString());
+        extras.put("export_receipt_uri", tenant.getOffboardExportReceiptUri());
+        eventPublisher.publishEvent(new AuditEventRecord(
+            actorUserId, null, AuditEventTypes.TENANT_ARCHIVED,
+            auditDetails(actorUserId, justification, previous, extras),
+            null));
+
+        scheduleStateCacheInvalidation(tenantId);
+        return saved;
     }
 
     /**

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -8,7 +8,9 @@ import java.util.UUID;
 import org.fabt.auth.service.ApiKeyService;
 import org.fabt.shared.audit.AuditEventRecord;
 import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.audit.DetachedAuditPersister;
 import org.fabt.shared.security.TenantKeyRotationService;
+import org.fabt.tenant.domain.IllegalStateTransitionException;
 import org.fabt.tenant.domain.Tenant;
 import org.fabt.tenant.domain.TenantState;
 import org.fabt.tenant.repository.TenantRepository;
@@ -54,19 +56,52 @@ public class TenantLifecycleService {
     private final ApplicationEventPublisher eventPublisher;
     private final JdbcTemplate jdbc;
     private final TenantStateGuard tenantStateGuard;
+    private final DetachedAuditPersister detachedAuditPersister;
 
     public TenantLifecycleService(TenantRepository tenantRepository,
                                    TenantKeyRotationService tenantKeyRotationService,
                                    ApiKeyService apiKeyService,
                                    ApplicationEventPublisher eventPublisher,
                                    JdbcTemplate jdbc,
-                                   TenantStateGuard tenantStateGuard) {
+                                   TenantStateGuard tenantStateGuard,
+                                   DetachedAuditPersister detachedAuditPersister) {
         this.tenantRepository = tenantRepository;
         this.tenantKeyRotationService = tenantKeyRotationService;
         this.apiKeyService = apiKeyService;
         this.eventPublisher = eventPublisher;
         this.jdbc = jdbc;
         this.tenantStateGuard = tenantStateGuard;
+        this.detachedAuditPersister = detachedAuditPersister;
+    }
+
+    /**
+     * Helper to wrap a transition attempt in the Family-D attempt-audit pattern: if
+     * the §D8 FSM rejects, persist a {@code *_REJECTED} audit row via the detached
+     * persister (REQUIRES_NEW) BEFORE re-throwing. The detached persister swallows
+     * its own errors so a failing audit row doesn't mask the original
+     * {@link IllegalStateTransitionException}.
+     *
+     * <p>Why REQUIRES_NEW: the outer {@code @Transactional} on the calling method
+     * will roll back when the FSM exception propagates out. If we persisted the
+     * audit row in the outer tx, it would roll back too — losing the forensic
+     * evidence. Marcus warroom F-2 HIGH pattern, formalised in F-3.6.</p>
+     */
+    private <T> T wrapAttemptAudit(UUID tenantId, UUID actorUserId, String justification,
+                                    String rejectedAction,
+                                    java.util.function.Supplier<T> action) {
+        try {
+            return action.get();
+        } catch (IllegalStateTransitionException rejected) {
+            Map<String, Object> details = new LinkedHashMap<>();
+            details.put("actor_user_id", actorUserId == null ? null : actorUserId.toString());
+            details.put("justification", justification);
+            details.put("current_state", rejected.from() == null ? null : rejected.from().name());
+            details.put("requested_state", rejected.to() == null ? null : rejected.to().name());
+            details.put("rejection_reason", rejected.getMessage());
+            detachedAuditPersister.persistDetached(tenantId,
+                new AuditEventRecord(actorUserId, null, rejectedAction, details, null));
+            throw rejected;
+        }
     }
 
     /**
@@ -170,6 +205,12 @@ public class TenantLifecycleService {
      */
     @Transactional
     public Tenant suspend(UUID tenantId, UUID actorUserId, String justification) {
+        return wrapAttemptAudit(tenantId, actorUserId, justification,
+            AuditEventTypes.TENANT_SUSPEND_REJECTED,
+            () -> doSuspend(tenantId, actorUserId, justification));
+    }
+
+    private Tenant doSuspend(UUID tenantId, UUID actorUserId, String justification) {
         Tenant tenant = tenantRepository.findById(tenantId)
             .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
         TenantState previous = tenant.getState();
@@ -219,6 +260,12 @@ public class TenantLifecycleService {
      */
     @Transactional
     public Tenant unsuspend(UUID tenantId, UUID actorUserId, String justification) {
+        return wrapAttemptAudit(tenantId, actorUserId, justification,
+            AuditEventTypes.TENANT_UNSUSPEND_REJECTED,
+            () -> doUnsuspend(tenantId, actorUserId, justification));
+    }
+
+    private Tenant doUnsuspend(UUID tenantId, UUID actorUserId, String justification) {
         Tenant tenant = tenantRepository.findById(tenantId)
             .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
         TenantState previous = tenant.getState();
@@ -248,7 +295,9 @@ public class TenantLifecycleService {
      */
     @Transactional
     public Tenant offboard(UUID tenantId, UUID actorUserId, String justification) {
-        return transitionTo(tenantId, TenantState.OFFBOARDING);
+        return wrapAttemptAudit(tenantId, actorUserId, justification,
+            AuditEventTypes.TENANT_OFFBOARD_REJECTED,
+            () -> transitionTo(tenantId, TenantState.OFFBOARDING));
     }
 
     /**
@@ -258,7 +307,9 @@ public class TenantLifecycleService {
      */
     @Transactional
     public Tenant archive(UUID tenantId, UUID actorUserId, String justification) {
-        return transitionTo(tenantId, TenantState.ARCHIVED);
+        return wrapAttemptAudit(tenantId, actorUserId, justification,
+            AuditEventTypes.TENANT_ARCHIVE_REJECTED,
+            () -> transitionTo(tenantId, TenantState.ARCHIVED));
     }
 
     /**

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -6,17 +6,23 @@ import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import java.time.temporal.ChronoUnit;
+import java.util.HexFormat;
+
 import org.fabt.auth.service.ApiKeyService;
 import org.fabt.shared.audit.AuditEventRecord;
 import org.fabt.shared.audit.AuditEventTypes;
 import org.fabt.shared.audit.DetachedAuditPersister;
 import org.fabt.shared.config.JsonString;
 import org.fabt.shared.security.KidRegistryService;
+import org.fabt.shared.security.TenantDekService;
 import org.fabt.shared.security.TenantKeyRotationService;
+import org.fabt.shared.web.TenantContext;
 import org.fabt.tenant.domain.IllegalStateTransitionException;
 import org.fabt.tenant.domain.Tenant;
 import org.fabt.tenant.domain.TenantState;
 import org.fabt.tenant.repository.TenantRepository;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -62,6 +68,14 @@ public class TenantLifecycleService {
     private final TenantStateGuard tenantStateGuard;
     private final DetachedAuditPersister detachedAuditPersister;
     private final TenantOffboardExportService offboardExportService;
+    private final TenantDekService tenantDekService;
+
+    /**
+     * 30-day retention window before ARCHIVED → DELETED is permitted, per V81
+     * column comment + design §D11 + GDPR Art. 17 industry practice. Config-
+     * overridable for test harnesses that need instant shred verification.
+     */
+    private final long hardDeleteRetentionDays;
 
     public TenantLifecycleService(TenantRepository tenantRepository,
                                    TenantKeyRotationService tenantKeyRotationService,
@@ -71,7 +85,10 @@ public class TenantLifecycleService {
                                    JdbcTemplate jdbc,
                                    TenantStateGuard tenantStateGuard,
                                    DetachedAuditPersister detachedAuditPersister,
-                                   TenantOffboardExportService offboardExportService) {
+                                   TenantOffboardExportService offboardExportService,
+                                   TenantDekService tenantDekService,
+                                   @Value("${fabt.tenant.hard-delete.retention-days:30}")
+                                   long hardDeleteRetentionDays) {
         this.tenantRepository = tenantRepository;
         this.tenantKeyRotationService = tenantKeyRotationService;
         this.kidRegistryService = kidRegistryService;
@@ -81,6 +98,8 @@ public class TenantLifecycleService {
         this.tenantStateGuard = tenantStateGuard;
         this.detachedAuditPersister = detachedAuditPersister;
         this.offboardExportService = offboardExportService;
+        this.tenantDekService = tenantDekService;
+        this.hardDeleteRetentionDays = hardDeleteRetentionDays;
     }
 
     /**
@@ -477,20 +496,210 @@ public class TenantLifecycleService {
     }
 
     /**
-     * Crypto-shred: ARCHIVED → DELETED with the key-material, audit-chain-head, and
-     * tenant row DELETE cascade (design §D11). Implementation deferred to slice F-6,
-     * which (a) gates on {@code archived_at < NOW() - 30d}, (b) writes TENANT_HARD_DELETED
-     * audit row in a separate committed tx BEFORE the destructive tx, (c) deletes in the
-     * order {@code tenant_key_material → tenant_audit_chain_head → tenant} per §D11.
+     * Crypto-shred: ARCHIVED → DELETED. Fires a single {@code DELETE FROM tenant}
+     * that triggers the CASCADE chain across 22 child FKs (18 from V84 + 4 from
+     * V61/V80/V82), destroying every per-tenant row including the
+     * {@code tenant_dek} rows that hold the wrapped DEKs for this tenant's
+     * data encryption. Post-commit, the DEK material exists nowhere — not in
+     * the DB, not in the app caches — which is what makes the §D11 crypto-shred
+     * claim true (TDD anchor {@code CryptoShredGapIntegrationTest} flips from
+     * @Disabled+red to @Enabled+green with this slice).
      *
-     * <p>Not {@code @Transactional} yet — F-6's two-tx pattern (audit-commit first,
-     * destructive-tx second) is NOT a single {@code @Transactional} wrap anyway. The
-     * annotation arrives on a private helper in F-6, not here.</p>
+     * <h3>Preconditions</h3>
+     * <ol>
+     *   <li>State must currently be ARCHIVED (FSM §D8).</li>
+     *   <li>{@code archived_at} must be non-null (data integrity — ARCHIVED
+     *       without a timestamp is a V81-contract violation).</li>
+     *   <li>{@code archived_at + hardDeleteRetentionDays} must be in the past.
+     *       Retention window starts the day archive() fires.</li>
+     * </ol>
+     *
+     * <h3>Sequence</h3>
+     * <ol>
+     *   <li>Capture {@code tenant_audit_chain_head.last_hash} BEFORE the
+     *       CASCADE destroys the row (warroom pass-2 Riley fix — auditors
+     *       need the terminal hash to prove the chain ended cleanly).</li>
+     *   <li>Bind {@code fabt.shred_in_progress} GUC to this tenantId — the
+     *       V82 trigger guard on tenant_dek DELETE requires it, so the FK
+     *       cascade to tenant_dek succeeds only on this shred path. ArchUnit
+     *       Family F rule 7.8j pins this GUC-write to this method only.</li>
+     *   <li>{@code DELETE FROM tenant WHERE id = ?} — the single statement
+     *       that fires the entire CASCADE chain. Must affect exactly 1 row;
+     *       otherwise something is badly wrong and we fail loud.</li>
+     *   <li>After-commit hook: invalidate TenantDekService + TenantStateGuard
+     *       caches, and write the platform-owned {@code TENANT_HARD_DELETED}
+     *       tombstone to {@code audit_events} with NULL-referencing tenantId
+     *       (audit_events has no FK to tenant per V57 / Q-F6-5) + chain hash
+     *       embedded. Fires only on successful commit — rollback scenario
+     *       leaves everything consistent.</li>
+     * </ol>
+     *
+     * <p>Throws {@link IllegalStateTransitionException} if state != ARCHIVED.
+     * Throws {@link IllegalStateException} if archived_at is null or the
+     * retention window hasn't elapsed. FSM rejections emit a
+     * {@code TENANT_HARD_DELETE_REJECTED} attempt-audit via the detached
+     * persister before propagating.
      */
+    @Transactional
     public void hardDelete(UUID tenantId, UUID actorUserId, String justification) {
-        throw new UnsupportedOperationException(
-            "TenantLifecycleService.hardDelete is implemented in slice F-6 with full "
-            + "crypto-shred cascade and audit-before-destructive-tx ordering");
+        wrapAttemptAudit(tenantId, actorUserId, justification,
+            AuditEventTypes.TENANT_HARD_DELETE_REJECTED,
+            () -> {
+                doHardDelete(tenantId, actorUserId, justification);
+                return null;
+            });
+    }
+
+    private void doHardDelete(UUID tenantId, UUID actorUserId, String justification) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
+        TenantState previous = tenant.getState();
+        TenantState.assertTransition(previous, TenantState.DELETED);  // ARCHIVED → DELETED only
+
+        // Data-integrity check: ARCHIVED state implies archived_at stamped. If
+        // someone manually flipped state without stamping the timestamp, fail
+        // loud rather than shred with an unknown retention baseline.
+        Instant archivedAt = tenant.getArchivedAt();
+        if (archivedAt == null) {
+            throw new IllegalStateException(
+                "Tenant " + tenantId + " cannot be hard-deleted: state is ARCHIVED but "
+                + "archived_at is NULL — archive() must have stamped a timestamp. Data corruption?");
+        }
+
+        // Retention window gate (V81 column comment + §D11 + GDPR Art. 17
+        // industry practice). Configurable for tests; prod defaults to 30 days.
+        Instant shredEligibleAt = archivedAt.plus(hardDeleteRetentionDays, ChronoUnit.DAYS);
+        Instant now = Instant.now();
+        if (now.isBefore(shredEligibleAt)) {
+            throw new IllegalStateException(String.format(
+                "Tenant %s cannot be hard-deleted: archived_at=%s + %d-day retention = %s, "
+                + "eligible in %d seconds (now=%s)",
+                tenantId, archivedAt, hardDeleteRetentionDays, shredEligibleAt,
+                shredEligibleAt.getEpochSecond() - now.getEpochSecond(), now));
+        }
+
+        // Capture the audit chain hash BEFORE the CASCADE destroys it.
+        // Warroom pass-2 Riley: auditors need the terminal hash to prove the
+        // chain ended cleanly at a specific Merkle root rather than "vanished."
+        String lastChainHash = captureLastAuditChainHash(tenantId);
+
+        // Bind the shred-guard GUC. V82's BEFORE DELETE trigger on tenant_dek
+        // raises unless this GUC matches OLD.tenant_id. Setting it here unlocks
+        // the tenant_dek rows for the CASCADE fire. Parameterized — never
+        // concatenate the tenant ID into the SQL (warroom pass-2 Marcus).
+        // ArchUnit rule 7.8j will pin this call site to this method only.
+        jdbc.queryForObject("SELECT set_config('fabt.shred_in_progress', ?, true)",
+            String.class, tenantId.toString());
+
+        // Bind app.tenant_id too, for RLS policies on any child table that
+        // checks current_setting before CASCADE fires (audit_events is the
+        // only one that might want to read this — the tombstone is written
+        // AFTER_COMMIT with SYSTEM_TENANT_ID, but belt-and-braces).
+        bindTenantContextForAudit(tenantId);
+
+        // THE single DELETE that performs the shred. The CASCADE chain
+        // unwinds 22 FKs (18 V84 + 4 V61/V80/V82), taking the tenant_dek
+        // rows with them. After this statement commits, the wrapped DEKs
+        // for this tenant exist nowhere — the crypto-shred is complete.
+        int rows = jdbc.update("DELETE FROM tenant WHERE id = ?", tenantId);
+        if (rows != 1) {
+            throw new IllegalStateException(
+                "hardDelete expected DELETE FROM tenant to affect 1 row, got "
+                + rows + " for tenantId=" + tenantId);
+        }
+
+        // Schedule tombstone + cache invalidation for AFTER_COMMIT. Tombstone
+        // fires ONLY on successful commit; on rollback the tenant row still
+        // exists and no "deleted" claim is persisted.
+        scheduleHardDeleteAfterCommit(tenantId, previous, actorUserId,
+            justification, lastChainHash);
+    }
+
+    /**
+     * Reads {@code tenant_audit_chain_head.last_hash} for the given tenant
+     * before the CASCADE destroys it. Returns a lowercase hex string, or
+     * null if the tenant has no chain head (created but never audited —
+     * unusual but possible).
+     *
+     * <p>Best-effort: if the query throws (e.g., tx is already poisoned),
+     * logs a warning and returns a sentinel string. The tombstone still
+     * writes; we just lose one field of forensic context.
+     */
+    private String captureLastAuditChainHash(UUID tenantId) {
+        try {
+            byte[] hash = jdbc.query(
+                "SELECT last_hash FROM tenant_audit_chain_head WHERE tenant_id = ?",
+                rs -> rs.next() ? rs.getBytes(1) : null,
+                tenantId);
+            return hash != null ? HexFormat.of().formatHex(hash) : null;
+        } catch (Exception e) {
+            // Non-fatal — forensic metadata only. Tombstone records the failure
+            // so an operator can investigate if the field is missing.
+            return "(capture-failed: " + e.getClass().getSimpleName() + ")";
+        }
+    }
+
+    /**
+     * Registers an after-commit hook that (a) invalidates both
+     * {@link TenantDekService} and {@link TenantStateGuard} caches, and
+     * (b) writes the platform-owned {@code TENANT_HARD_DELETED} tombstone.
+     *
+     * <p>Fires only on successful commit (per
+     * {@link TransactionSynchronization#afterCommit()} contract). If the
+     * outer tx rolls back — because the DELETE failed or a CASCADE constraint
+     * violation surfaced — neither caches get evicted nor tombstones get
+     * written; the cache stays consistent with the still-present DB state.
+     *
+     * <p>Tombstone writes via {@link DetachedAuditPersister} (REQUIRES_NEW)
+     * under {@code SYSTEM_TENANT_ID} — {@code audit_events} has no FK to
+     * tenant per V57 / Q-F6-5, so the platform-owned row survives the shred
+     * and gives compliance auditors a "tenant X deleted on Y by Z" record.
+     * Details JSON embeds the terminal chain hash captured pre-CASCADE.
+     */
+    private void scheduleHardDeleteAfterCommit(UUID tenantId, TenantState previous,
+                                                UUID actorUserId, String justification,
+                                                String lastChainHash) {
+        Runnable afterCommit = () -> {
+            // 1. Cache invalidation — evicts per-tenant active-DEK cache +
+            //    per-kid resolution cache, plus the TenantStateGuard cache.
+            //    Idempotent (safe to run even when caches are empty).
+            tenantDekService.invalidateTenantDeks(tenantId);
+            tenantStateGuard.invalidate(tenantId);
+
+            // 2. Platform tombstone. SYSTEM_TENANT_ID scope matches V74's
+            //    pattern for migration-origin audits. The deleted tenant's
+            //    UUID lives in the details JSONB.
+            Map<String, Object> tombstoneDetails = new LinkedHashMap<>();
+            tombstoneDetails.put("deleted_tenant_id", tenantId.toString());
+            tombstoneDetails.put("actor_user_id", actorUserId == null ? null : actorUserId.toString());
+            tombstoneDetails.put("justification", justification);
+            tombstoneDetails.put("deleted_at", Instant.now().toString());
+            tombstoneDetails.put("previous_state", previous.name());
+            tombstoneDetails.put("last_audit_chain_hash",
+                lastChainHash != null ? lastChainHash : "(no chain)");
+            detachedAuditPersister.persistDetached(
+                TenantContext.SYSTEM_TENANT_ID,
+                new AuditEventRecord(actorUserId, null,
+                    AuditEventTypes.TENANT_HARD_DELETED,
+                    tombstoneDetails, null));
+        };
+
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+            && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        afterCommit.run();
+                    }
+                });
+        } else {
+            // Defensive fallback — all callers are @Transactional so this is
+            // unreachable in practice. Running synchronously keeps unit tests
+            // without a real tx green; if a future refactor drops the
+            // @Transactional, neither cache nor tombstone is lost.
+            afterCommit.run();
+        }
     }
 
     /**

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -1,0 +1,129 @@
+package org.fabt.tenant.service;
+
+import java.util.NoSuchElementException;
+import java.util.UUID;
+
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.repository.TenantRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Tenant lifecycle FSM, authoritative owner of every {@code tenant.state} write.
+ *
+ * <p><b>Sole write path directive:</b> this service is the only component permitted to
+ * mutate {@link Tenant#setState(TenantState)}. {@code TenantService} remains canonical
+ * for tenant name/config/read paths but does NOT touch state. Duplicate state-mutation
+ * paths are a compliance hazard (GDPR Art. 17 erasure depends on a single well-audited
+ * transition graph) and will be guarded by an ArchUnit rule in slice F-3.</p>
+ *
+ * <p><b>Current implementation status (slice F-1):</b> FSM skeleton only. Methods perform
+ * the §D8 transition assertion + state column update; they do NOT yet emit audit rows,
+ * bump JWT key generations, deactivate API keys, run offboard exports, or crypto-shred.
+ * Those side effects arrive in slices F-2 (suspend + audit + JWT bump), F-4 (atomic
+ * create), F-5 (offboard export), F-6 (crypto-shred hard-delete). The {@code create}
+ * and {@code hardDelete} methods throw {@link UnsupportedOperationException} in this
+ * slice — full semantics require migrations + services that are not yet in place.</p>
+ *
+ * <p><b>Feature flag:</b> the entire service is gated behind
+ * {@code fabt.tenant.lifecycle.enabled} (default {@code false}). Until slice F-3 ships
+ * the read-path state enforcement, callers MUST NOT rely on lifecycle state for
+ * authorization decisions — the flag stays off in prod until then.</p>
+ *
+ * <p>Design reference: {@code multi-tenant-production-readiness} §D8, §F1–F8.</p>
+ */
+@Service
+@ConditionalOnProperty(name = "fabt.tenant.lifecycle.enabled", havingValue = "true", matchIfMissing = false)
+public class TenantLifecycleService {
+
+    private final TenantRepository tenantRepository;
+
+    public TenantLifecycleService(TenantRepository tenantRepository) {
+        this.tenantRepository = tenantRepository;
+    }
+
+    /**
+     * Atomic tenant-create bootstrap (NEW → ACTIVE). Implementation deferred to slice F-4
+     * (derives JWT gen-1 key, derives DEKs, seeds audit_chain_head, verifies RLS canary).
+     * Callers must continue to use {@link TenantService#create(String, String)} until
+     * F-4 lands and the switch is made with a {@code @Deprecated} redirect.
+     */
+    @Transactional
+    public Tenant create(String name, String slug, UUID actorUserId) {
+        throw new UnsupportedOperationException(
+            "TenantLifecycleService.create is implemented in slice F-4; "
+            + "use TenantService.create until then");
+    }
+
+    /**
+     * Transition ACTIVE → SUSPENDED. Slice F-1 performs the state mutation only; slice
+     * F-2 adds JWT key-generation bump, API-key deactivation, audit emission, and
+     * idempotency handling (second call returns 409, not 200).
+     */
+    @Transactional
+    public Tenant suspend(UUID tenantId, UUID actorUserId, String justification) {
+        return transitionTo(tenantId, TenantState.SUSPENDED);
+    }
+
+    /**
+     * Transition SUSPENDED → ACTIVE. Slice F-2 adds audit emission; JWT keys are NOT
+     * re-rotated on unsuspend (the bump on suspend invalidated all prior tokens, and
+     * unsuspend issues a fresh JWT from the current gen at next login).
+     */
+    @Transactional
+    public Tenant unsuspend(UUID tenantId, UUID actorUserId, String justification) {
+        return transitionTo(tenantId, TenantState.ACTIVE);
+    }
+
+    /**
+     * Transition {ACTIVE, SUSPENDED} → OFFBOARDING. Slice F-5 wires the export workflow
+     * (schema'd JSON dump written to a GDPR Art. 20 delivery location) and stores the
+     * export receipt URI on the tenant row.
+     */
+    @Transactional
+    public Tenant offboard(UUID tenantId, UUID actorUserId, String justification) {
+        return transitionTo(tenantId, TenantState.OFFBOARDING);
+    }
+
+    /**
+     * Transition OFFBOARDING → ARCHIVED. Slice F-5 adds the {@code archived_at}
+     * timestamp write and requires a non-null {@code offboard_export_receipt_uri}
+     * before permitting the transition.
+     */
+    @Transactional
+    public Tenant archive(UUID tenantId, UUID actorUserId, String justification) {
+        return transitionTo(tenantId, TenantState.ARCHIVED);
+    }
+
+    /**
+     * Crypto-shred: ARCHIVED → DELETED with the key-material, audit-chain-head, and
+     * tenant row DELETE cascade (design §D11). Implementation deferred to slice F-6,
+     * which (a) gates on {@code archived_at < NOW() - 30d}, (b) writes TENANT_HARD_DELETED
+     * audit row in a separate committed tx BEFORE the destructive tx, (c) deletes in the
+     * order {@code tenant_key_material → tenant_audit_chain_head → tenant} per §D11.
+     */
+    @Transactional
+    public void hardDelete(UUID tenantId, UUID actorUserId, String justification) {
+        throw new UnsupportedOperationException(
+            "TenantLifecycleService.hardDelete is implemented in slice F-6 with full "
+            + "crypto-shred cascade and audit-before-destructive-tx ordering");
+    }
+
+    /**
+     * Core transition helper: load tenant, assert transition via {@link TenantState#assertTransition},
+     * flip state, save. Extracted so every lifecycle method shares the same guard.
+     *
+     * <p>Throws {@link NoSuchElementException} if the tenant does not exist (F-3 translates
+     * to 404). Throws {@link org.fabt.tenant.domain.IllegalStateTransitionException} if the
+     * transition violates §D8 (F-3 translates to 409).</p>
+     */
+    private Tenant transitionTo(UUID tenantId, TenantState target) {
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
+        TenantState.assertTransition(tenant.getState(), target);
+        tenant.setState(target);
+        return tenantRepository.save(tenant);
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -17,6 +17,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
@@ -52,17 +53,47 @@ public class TenantLifecycleService {
     private final ApiKeyService apiKeyService;
     private final ApplicationEventPublisher eventPublisher;
     private final JdbcTemplate jdbc;
+    private final TenantStateGuard tenantStateGuard;
 
     public TenantLifecycleService(TenantRepository tenantRepository,
                                    TenantKeyRotationService tenantKeyRotationService,
                                    ApiKeyService apiKeyService,
                                    ApplicationEventPublisher eventPublisher,
-                                   JdbcTemplate jdbc) {
+                                   JdbcTemplate jdbc,
+                                   TenantStateGuard tenantStateGuard) {
         this.tenantRepository = tenantRepository;
         this.tenantKeyRotationService = tenantKeyRotationService;
         this.apiKeyService = apiKeyService;
         this.eventPublisher = eventPublisher;
         this.jdbc = jdbc;
+        this.tenantStateGuard = tenantStateGuard;
+    }
+
+    /**
+     * Registers an after-commit hook to invalidate the {@link TenantStateGuard} cache
+     * for {@code tenantId}. Runs ONLY if the transaction commits — on rollback the
+     * state change didn't happen, so the cache entry is still correct. Without this
+     * hook, suspended tenants could continue serving reads for up to the 10s cache
+     * TTL; with it, the next request sees the new state within milliseconds.
+     */
+    private void scheduleStateCacheInvalidation(UUID tenantId) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+            && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        tenantStateGuard.invalidate(tenantId);
+                    }
+                });
+        } else {
+            // Defensive — callers shouldn't reach here (all public methods are
+            // @Transactional and Spring enables synchronization within the tx
+            // boundary). Fall back to synchronous invalidation so unit tests
+            // without a real tx still see the right behavior, and any future
+            // refactor that drops @Transactional doesn't leave the cache stale.
+            tenantStateGuard.invalidate(tenantId);
+        }
     }
 
     /**
@@ -80,7 +111,7 @@ public class TenantLifecycleService {
      * SYSTEM_TENANT_ID. Catching this at call time surfaces the silent regression that
      * would otherwise only show up in production audit queries.</p>
      */
-    private void bindTenantContextForAudit(java.util.UUID tenantId) {
+    private void bindTenantContextForAudit(UUID tenantId) {
         if (!TransactionSynchronizationManager.isActualTransactionActive()) {
             throw new IllegalStateException(
                 "bindTenantContextForAudit requires an active transaction; caller must "
@@ -166,6 +197,7 @@ public class TenantLifecycleService {
                 "deactivatedApiKeys", deactivatedKeys)),
             null));
 
+        scheduleStateCacheInvalidation(tenantId);
         return saved;
     }
 
@@ -205,6 +237,7 @@ public class TenantLifecycleService {
             auditDetails(actorUserId, justification, previous, Map.of()),
             null));
 
+        scheduleStateCacheInvalidation(tenantId);
         return saved;
     }
 
@@ -260,7 +293,9 @@ public class TenantLifecycleService {
             .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
         TenantState.assertTransition(tenant.getState(), target);
         tenant.setState(target);
-        return tenantRepository.save(tenant);
+        Tenant saved = tenantRepository.save(tenant);
+        scheduleStateCacheInvalidation(tenantId);
+        return saved;
     }
 
     /**

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -10,6 +10,8 @@ import java.time.temporal.ChronoUnit;
 import java.util.HexFormat;
 
 import org.fabt.auth.service.ApiKeyService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.fabt.shared.audit.AuditEventRecord;
 import org.fabt.shared.audit.AuditEventTypes;
 import org.fabt.shared.audit.DetachedAuditPersister;
@@ -59,6 +61,8 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 @ConditionalOnProperty(name = "fabt.tenant.lifecycle.enabled", havingValue = "true", matchIfMissing = false)
 public class TenantLifecycleService {
 
+    private static final Logger log = LoggerFactory.getLogger(TenantLifecycleService.class);
+
     private final TenantRepository tenantRepository;
     private final TenantKeyRotationService tenantKeyRotationService;
     private final KidRegistryService kidRegistryService;
@@ -99,6 +103,24 @@ public class TenantLifecycleService {
         this.detachedAuditPersister = detachedAuditPersister;
         this.offboardExportService = offboardExportService;
         this.tenantDekService = tenantDekService;
+
+        // Floor guard per warroom pass-3 (Riley). Negative retention days is
+        // always a configuration error; fail fast before the service ever
+        // accepts a hardDelete call. Zero is valid for test harnesses but
+        // logs WARN so an operator who typo'd 0 into prod config sees the
+        // signal immediately at startup.
+        if (hardDeleteRetentionDays < 0) {
+            throw new IllegalArgumentException(
+                "fabt.tenant.hard-delete.retention-days must be >= 0; got "
+                + hardDeleteRetentionDays);
+        }
+        if (hardDeleteRetentionDays == 0) {
+            log.warn("fabt.tenant.hard-delete.retention-days=0 — ZERO-day retention "
+                + "is valid ONLY for test harnesses. In production the correct "
+                + "value is 30 (GDPR Art. 17 industry practice, V81 column contract). "
+                + "If this log fires outside a test profile, fix the config before "
+                + "any hardDelete is invoked.");
+        }
         this.hardDeleteRetentionDays = hardDeleteRetentionDays;
     }
 

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -1,5 +1,6 @@
 package org.fabt.tenant.service;
 
+import java.time.Instant;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -9,6 +10,8 @@ import org.fabt.auth.service.ApiKeyService;
 import org.fabt.shared.audit.AuditEventRecord;
 import org.fabt.shared.audit.AuditEventTypes;
 import org.fabt.shared.audit.DetachedAuditPersister;
+import org.fabt.shared.config.JsonString;
+import org.fabt.shared.security.KidRegistryService;
 import org.fabt.shared.security.TenantKeyRotationService;
 import org.fabt.tenant.domain.IllegalStateTransitionException;
 import org.fabt.tenant.domain.Tenant;
@@ -52,6 +55,7 @@ public class TenantLifecycleService {
 
     private final TenantRepository tenantRepository;
     private final TenantKeyRotationService tenantKeyRotationService;
+    private final KidRegistryService kidRegistryService;
     private final ApiKeyService apiKeyService;
     private final ApplicationEventPublisher eventPublisher;
     private final JdbcTemplate jdbc;
@@ -60,6 +64,7 @@ public class TenantLifecycleService {
 
     public TenantLifecycleService(TenantRepository tenantRepository,
                                    TenantKeyRotationService tenantKeyRotationService,
+                                   KidRegistryService kidRegistryService,
                                    ApiKeyService apiKeyService,
                                    ApplicationEventPublisher eventPublisher,
                                    JdbcTemplate jdbc,
@@ -67,6 +72,7 @@ public class TenantLifecycleService {
                                    DetachedAuditPersister detachedAuditPersister) {
         this.tenantRepository = tenantRepository;
         this.tenantKeyRotationService = tenantKeyRotationService;
+        this.kidRegistryService = kidRegistryService;
         this.apiKeyService = apiKeyService;
         this.eventPublisher = eventPublisher;
         this.jdbc = jdbc;
@@ -158,19 +164,100 @@ public class TenantLifecycleService {
     }
 
     /**
-     * Atomic tenant-create bootstrap (NEW → ACTIVE). Implementation deferred to slice F-4
-     * (derives JWT gen-1 key, derives DEKs, seeds audit_chain_head, verifies RLS canary).
-     * Callers must continue to use {@link TenantService#create(String, String)} until
-     * F-4 lands and the switch is made with a {@code @Deprecated} redirect.
+     * Atomic tenant-create bootstrap (NEW → ACTIVE) — the F-4 eager replacement for
+     * {@code TenantService.create}'s lazy-bootstrap path.
      *
-     * <p>Not {@code @Transactional} yet — F-4 adds the annotation when real bodies land,
-     * avoiding the wasted tx open-then-rollback cycle that a stub throw would otherwise
-     * incur.</p>
+     * <p>Ordered operations, all joined to the outer {@code @Transactional} (REQUIRED)
+     * so any failure rolls every side effect back together:</p>
+     * <ol>
+     *   <li>Fast slug uniqueness check via {@code existsBySlug}; DB UNIQUE constraint
+     *       is the authoritative gate but catching early lets us return a clean
+     *       {@link IllegalStateException} before spending key-derivation work.</li>
+     *   <li>INSERT tenant row with state=ACTIVE (Spring Data JDBC null-id → INSERT;
+     *       DB fills {@code gen_random_uuid()}). Default config is the empty JsonString;
+     *       typed-config population is a {@link TenantService#updateConfig} concern
+     *       that remains unchanged.</li>
+     *   <li>Bootstrap JWT key material via
+     *       {@link KidRegistryService#findOrCreateActiveKid(UUID)} — inserts gen-1 row
+     *       in {@code tenant_key_material}, registers a fresh kid in
+     *       {@code kid_to_tenant_key}, binds {@code app.tenant_id} for the tx. This
+     *       replaces the lazy-at-first-login bootstrap so the tenant is immediately
+     *       crypto-ready.</li>
+     *   <li>Seed the {@code tenant_audit_chain_head} pointer for Phase G-1's
+     *       hash-chain writer. Empty-hash sentinel (32 zero bytes) — idempotent via
+     *       ON CONFLICT in case the V80 migration backfill already seeded the row for
+     *       a tenant that pre-existed under the legacy path.</li>
+     *   <li>Emit {@link AuditEventTypes#TENANT_CREATED} audit. The GUC bound by step 3
+     *       scopes this audit row to the new tenant's id via D55 path 2.</li>
+     * </ol>
+     *
+     * <p>Failure-injection: any exception in steps 2–5 rolls back the whole tx — no
+     * half-created tenant with crypto but no audit, no ghost audit_chain_head without
+     * a tenant, no orphan key material. Idempotency: duplicate slug →
+     * {@link IllegalStateException} surfaced as 409 by the shared exception
+     * handler.</p>
+     *
+     * @param name          human-readable tenant name
+     * @param slug          URL slug (globally unique, enforced by DB UNIQUE constraint)
+     * @param actorUserId   platform admin performing the create; may be null for
+     *                      system-initiated creates (seed migrations, bootstrap jobs)
+     * @return the newly created tenant aggregate with its database-generated id
      */
+    @Transactional
     public Tenant create(String name, String slug, UUID actorUserId) {
-        throw new UnsupportedOperationException(
-            "TenantLifecycleService.create is implemented in slice F-4; "
-            + "use TenantService.create until then");
+        if (tenantRepository.existsBySlug(slug)) {
+            throw new IllegalStateException("Tenant with slug '" + slug + "' already exists");
+        }
+
+        // Step 1: tenant row.
+        Tenant tenant = new Tenant();
+        tenant.setName(name);
+        tenant.setSlug(slug);
+        tenant.setConfig(JsonString.empty());
+        tenant.setState(TenantState.ACTIVE);
+        Instant now = Instant.now();
+        tenant.setCreatedAt(now);
+        tenant.setUpdatedAt(now);
+        Tenant saved = tenantRepository.save(tenant);
+        UUID tenantId = saved.getId();
+
+        // Step 2: eager JWT key material bootstrap. findOrCreateActiveKid sets
+        // set_config('app.tenant_id', ...) internally AND inserts the gen-1 row +
+        // kid idempotently, so this is safe even if the tenant already had a
+        // lazy-bootstrap race in flight (impossible for a just-created row, but
+        // defense-in-depth).
+        kidRegistryService.findOrCreateActiveKid(tenantId);
+
+        // Step 3: seed the hash-chain head row. ON CONFLICT DO NOTHING because
+        // V80's migration backfill may have already created it if this tenant id
+        // somehow collides with an existing row (paranoid — gen_random_uuid
+        // collision is 2^-122, but makes the operation strictly idempotent).
+        jdbc.update(
+            "INSERT INTO tenant_audit_chain_head (tenant_id, last_hash, last_row_id) "
+            + "VALUES (?, "
+            + "        decode('0000000000000000000000000000000000000000000000000000000000000000', 'hex'), "
+            + "        NULL) "
+            + "ON CONFLICT (tenant_id) DO NOTHING",
+            tenantId);
+
+        // Step 4: audit. The GUC set by findOrCreateActiveKid (step 2) carries
+        // through the remainder of the tx, so D55 path 2 lands this row under
+        // the new tenant's id.
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("actor_user_id", actorUserId == null ? null : actorUserId.toString());
+        details.put("slug", slug);
+        details.put("name", name);
+        eventPublisher.publishEvent(new AuditEventRecord(
+            actorUserId, null, AuditEventTypes.TENANT_CREATED, details, null));
+
+        // No state-cache invalidation needed: the tenant was just created as
+        // ACTIVE, and TenantStateGuard's cache is lazy — the first requireActive
+        // call for this id will populate it correctly. But invalidate anyway to
+        // clear any stale NOT_FOUND sentinel a previous test run may have cached
+        // (hardens test isolation when the Spring singleton survives).
+        scheduleStateCacheInvalidation(tenantId);
+
+        return saved;
     }
 
     /**

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -49,8 +49,11 @@ public class TenantLifecycleService {
      * (derives JWT gen-1 key, derives DEKs, seeds audit_chain_head, verifies RLS canary).
      * Callers must continue to use {@link TenantService#create(String, String)} until
      * F-4 lands and the switch is made with a {@code @Deprecated} redirect.
+     *
+     * <p>Not {@code @Transactional} yet — F-4 adds the annotation when real bodies land,
+     * avoiding the wasted tx open-then-rollback cycle that a stub throw would otherwise
+     * incur.</p>
      */
-    @Transactional
     public Tenant create(String name, String slug, UUID actorUserId) {
         throw new UnsupportedOperationException(
             "TenantLifecycleService.create is implemented in slice F-4; "
@@ -103,8 +106,11 @@ public class TenantLifecycleService {
      * which (a) gates on {@code archived_at < NOW() - 30d}, (b) writes TENANT_HARD_DELETED
      * audit row in a separate committed tx BEFORE the destructive tx, (c) deletes in the
      * order {@code tenant_key_material → tenant_audit_chain_head → tenant} per §D11.
+     *
+     * <p>Not {@code @Transactional} yet — F-6's two-tx pattern (audit-commit first,
+     * destructive-tx second) is NOT a single {@code @Transactional} wrap anyway. The
+     * annotation arrives on a private helper in F-6, not here.</p>
      */
-    @Transactional
     public void hardDelete(UUID tenantId, UUID actorUserId, String justification) {
         throw new UnsupportedOperationException(
             "TenantLifecycleService.hardDelete is implemented in slice F-6 with full "

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -160,6 +160,43 @@ public class TenantLifecycleService {
     }
 
     /**
+     * Wind-down transitions (OFFBOARDING / ARCHIVED) variant of
+     * {@link #scheduleStateCacheInvalidation} that ALSO evicts the
+     * {@link TenantDekService} caches for the tenant. Fires on the same
+     * after-commit hook so either both caches are evicted (commit) or
+     * neither is (rollback).
+     *
+     * <p>Warroom pass-3 blocker fix (Alex): the pass-1 §5 design requirement
+     * to invalidate TenantDekService on OFFBOARDING/ARCHIVED (not just
+     * DELETED) was not wired through to the offboard + archive methods in
+     * earlier slices. Without this hook the 1-hour {@code resolveDek}
+     * cache TTL kept unwrapped DEKs available in JVM memory for up to an
+     * hour after a tenant entered OFFBOARDING — reopening the hot-JVM
+     * decrypt window pass-1 explicitly closed.
+     *
+     * <p>Idempotent with {@link #scheduleStateCacheInvalidation}: both can
+     * be scheduled on the same tx; the ordering doesn't matter because
+     * {@link TenantDekService#invalidateTenantDeks} and
+     * {@link TenantStateGuard#invalidate} don't interact.
+     */
+    private void scheduleWindDownCacheInvalidation(UUID tenantId) {
+        if (TransactionSynchronizationManager.isActualTransactionActive()
+            && TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(
+                new TransactionSynchronization() {
+                    @Override
+                    public void afterCommit() {
+                        tenantDekService.invalidateTenantDeks(tenantId);
+                        tenantStateGuard.invalidate(tenantId);
+                    }
+                });
+        } else {
+            tenantDekService.invalidateTenantDeks(tenantId);
+            tenantStateGuard.invalidate(tenantId);
+        }
+    }
+
+    /**
      * Binds {@code app.tenant_id} session GUC to {@code tenantId} for the duration of
      * the current {@code @Transactional} scope. Mirrors the pattern in
      * {@link TenantKeyRotationService#bumpJwtKeyGeneration} (the B11 ArchUnit rule forbids
@@ -440,7 +477,13 @@ public class TenantLifecycleService {
             auditDetails(actorUserId, justification, previous, extras),
             null));
 
-        scheduleStateCacheInvalidation(tenantId);
+        // Wind-down variant: invalidates BOTH TenantStateGuard AND
+        // TenantDekService caches. Design §5 pass-1 Alex requirement —
+        // closes the hot-JVM decrypt window during the OFFBOARDING retention
+        // period. Without this, the 1-hour resolveDek cache TTL would keep
+        // unwrapped DEKs available on hot pods for up to an hour post-
+        // transition.
+        scheduleWindDownCacheInvalidation(tenantId);
         return saved;
     }
 
@@ -491,7 +534,10 @@ public class TenantLifecycleService {
             auditDetails(actorUserId, justification, previous, extras),
             null));
 
-        scheduleStateCacheInvalidation(tenantId);
+        // Wind-down variant — same rationale as doOffboard. Both OFFBOARDING
+        // and ARCHIVED states open a decrypt window we want to close
+        // at the transition-event, not at the TTL expiry.
+        scheduleWindDownCacheInvalidation(tenantId);
         return saved;
     }
 

--- a/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java
@@ -1,14 +1,23 @@
 package org.fabt.tenant.service;
 
+import java.util.LinkedHashMap;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.UUID;
 
+import org.fabt.auth.service.ApiKeyService;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.security.TenantKeyRotationService;
 import org.fabt.tenant.domain.Tenant;
 import org.fabt.tenant.domain.TenantState;
 import org.fabt.tenant.repository.TenantRepository;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Tenant lifecycle FSM, authoritative owner of every {@code tenant.state} write.
@@ -39,9 +48,47 @@ import org.springframework.transaction.annotation.Transactional;
 public class TenantLifecycleService {
 
     private final TenantRepository tenantRepository;
+    private final TenantKeyRotationService tenantKeyRotationService;
+    private final ApiKeyService apiKeyService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final JdbcTemplate jdbc;
 
-    public TenantLifecycleService(TenantRepository tenantRepository) {
+    public TenantLifecycleService(TenantRepository tenantRepository,
+                                   TenantKeyRotationService tenantKeyRotationService,
+                                   ApiKeyService apiKeyService,
+                                   ApplicationEventPublisher eventPublisher,
+                                   JdbcTemplate jdbc) {
         this.tenantRepository = tenantRepository;
+        this.tenantKeyRotationService = tenantKeyRotationService;
+        this.apiKeyService = apiKeyService;
+        this.eventPublisher = eventPublisher;
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * Binds {@code app.tenant_id} session GUC to {@code tenantId} for the duration of
+     * the current {@code @Transactional} scope. Mirrors the pattern in
+     * {@link TenantKeyRotationService#bumpJwtKeyGeneration} (the B11 ArchUnit rule forbids
+     * nested {@code TenantContext.runWithContext} inside {@code @Transactional}, so we
+     * {@code set_config} directly). {@code AuditEventService} reads this GUC via its D55
+     * three-level lookup so the audit row lands with the correct {@code tenant_id} rather
+     * than the {@code SYSTEM_TENANT_ID} fallback.
+     *
+     * <p>Asserts an active transaction — {@code set_config(..., true)} binds to the
+     * current tx only. Without an active tx the binding scopes to a single statement
+     * and the subsequent audit INSERT silently loses the GUC, falling back to
+     * SYSTEM_TENANT_ID. Catching this at call time surfaces the silent regression that
+     * would otherwise only show up in production audit queries.</p>
+     */
+    private void bindTenantContextForAudit(java.util.UUID tenantId) {
+        if (!TransactionSynchronizationManager.isActualTransactionActive()) {
+            throw new IllegalStateException(
+                "bindTenantContextForAudit requires an active transaction; caller must "
+                + "be @Transactional so set_config(..., is_local=true) persists across "
+                + "the subsequent audit INSERT (D55 path 2)");
+        }
+        jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+            String.class, tenantId.toString());
     }
 
     /**
@@ -61,23 +108,104 @@ public class TenantLifecycleService {
     }
 
     /**
-     * Transition ACTIVE → SUSPENDED. Slice F-1 performs the state mutation only; slice
-     * F-2 adds JWT key-generation bump, API-key deactivation, audit emission, and
-     * idempotency handling (second call returns 409, not 200).
+     * Quarantines a tenant — transitions ACTIVE → SUSPENDED with the §D11 5-action
+     * atomic pattern (here we execute 4 of 5; the 5th — stop background worker
+     * dispatch — is a no-op today because worker dispatch is not yet tenant-scoped,
+     * tracked as part of Phase E).
+     *
+     * <ol>
+     *   <li>Load + FSM assert (self-transition on already-SUSPENDED → 409 via
+     *       {@link org.fabt.tenant.domain.IllegalStateTransitionException}, which is
+     *       the idempotency contract).</li>
+     *   <li>Bump JWT key generation — invalidates every live refresh token across
+     *       the tenant; delegates to {@link TenantKeyRotationService#bumpJwtKeyGeneration}
+     *       (joins this tx via default REQUIRED propagation, emits its own
+     *       {@code JWT_KEY_GENERATION_BUMPED} audit row).</li>
+     *   <li>Deactivate all API keys for the tenant (bulk UPDATE via
+     *       {@link ApiKeyService#deactivateAllForTenant}). Intentionally NOT
+     *       auto-reactivated on {@link #unsuspend}: operator re-issues keys after
+     *       incident review (post-compromise hygiene).</li>
+     *   <li>Flip state to SUSPENDED + save.</li>
+     *   <li>Emit {@link AuditEventTypes#TENANT_SUSPENDED} — details capture
+     *       actor, justification, previous state, and counts returned by steps 2–3
+     *       for forensic join with the {@code JWT_KEY_GENERATION_BUMPED} row.</li>
+     * </ol>
+     *
+     * @param tenantId      the tenant to quarantine
+     * @param actorUserId   platform admin triggering the suspend; may be null for
+     *                      system-initiated operations (e.g. automated abuse response)
+     * @param justification human-readable reason recorded in the audit row
+     * @return the suspended tenant aggregate
      */
     @Transactional
     public Tenant suspend(UUID tenantId, UUID actorUserId, String justification) {
-        return transitionTo(tenantId, TenantState.SUSPENDED);
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
+        TenantState previous = tenant.getState();
+        TenantState.assertTransition(previous, TenantState.SUSPENDED);
+
+        // Bind app.tenant_id GUC so the TENANT_SUSPENDED audit row lands with the
+        // correct tenant_id (AuditEventService D55 path 2). bumpJwtKeyGeneration
+        // also sets this same GUC at its own entry, but re-binding here is
+        // defensive: if a future refactor reorders steps or drops the JWT bump,
+        // the TENANT_SUSPENDED audit must still carry the right tenant_id.
+        bindTenantContextForAudit(tenantId);
+
+        TenantKeyRotationService.RotationResult rotation =
+            tenantKeyRotationService.bumpJwtKeyGeneration(tenantId, actorUserId);
+
+        int deactivatedKeys = apiKeyService.deactivateAllForTenant(tenantId);
+
+        tenant.setState(TenantState.SUSPENDED);
+        Tenant saved = tenantRepository.save(tenant);
+
+        eventPublisher.publishEvent(new AuditEventRecord(
+            actorUserId, null, AuditEventTypes.TENANT_SUSPENDED,
+            auditDetails(actorUserId, justification, previous, Map.of(
+                "revokedKidCount", rotation.revokedKidCount(),
+                "deactivatedApiKeys", deactivatedKeys)),
+            null));
+
+        return saved;
     }
 
     /**
-     * Transition SUSPENDED → ACTIVE. Slice F-2 adds audit emission; JWT keys are NOT
-     * re-rotated on unsuspend (the bump on suspend invalidated all prior tokens, and
-     * unsuspend issues a fresh JWT from the current gen at next login).
+     * Restores a SUSPENDED tenant to ACTIVE. Intentionally asymmetric with
+     * {@link #suspend}:
+     *
+     * <ul>
+     *   <li>JWT keys are <em>not</em> re-rotated — the suspend bump already
+     *       invalidated prior tokens; fresh tokens issue at next login from the
+     *       current generation.</li>
+     *   <li>API keys are <em>not</em> auto-reactivated — post-compromise the
+     *       operator decides which keys to re-issue (D11 safer default).</li>
+     * </ul>
+     *
+     * @param tenantId      the tenant to un-quarantine
+     * @param actorUserId   platform admin triggering the unsuspend; may be null
+     * @param justification reason recorded in the audit row
      */
     @Transactional
     public Tenant unsuspend(UUID tenantId, UUID actorUserId, String justification) {
-        return transitionTo(tenantId, TenantState.ACTIVE);
+        Tenant tenant = tenantRepository.findById(tenantId)
+            .orElseThrow(() -> new NoSuchElementException("tenant not found: " + tenantId));
+        TenantState previous = tenant.getState();
+        TenantState.assertTransition(previous, TenantState.ACTIVE);
+
+        // Bind app.tenant_id so TENANT_UNSUSPENDED audit row lands with the correct
+        // tenant_id. No JWT bump on unsuspend (§D11 post-compromise hygiene), so this
+        // is the only path that sets the GUC for the audit lookup.
+        bindTenantContextForAudit(tenantId);
+
+        tenant.setState(TenantState.ACTIVE);
+        Tenant saved = tenantRepository.save(tenant);
+
+        eventPublisher.publishEvent(new AuditEventRecord(
+            actorUserId, null, AuditEventTypes.TENANT_UNSUSPENDED,
+            auditDetails(actorUserId, justification, previous, Map.of()),
+            null));
+
+        return saved;
     }
 
     /**
@@ -118,8 +246,10 @@ public class TenantLifecycleService {
     }
 
     /**
-     * Core transition helper: load tenant, assert transition via {@link TenantState#assertTransition},
-     * flip state, save. Extracted so every lifecycle method shares the same guard.
+     * Core transition helper used by offboard/archive (suspend/unsuspend inline the same
+     * load-assert-flip-save pattern because they also need to emit audits and call other
+     * services). F-5 will restructure offboard/archive with export logic; until then this
+     * helper keeps those methods shaped like F-1's skeleton.
      *
      * <p>Throws {@link NoSuchElementException} if the tenant does not exist (F-3 translates
      * to 404). Throws {@link org.fabt.tenant.domain.IllegalStateTransitionException} if the
@@ -131,5 +261,26 @@ public class TenantLifecycleService {
         TenantState.assertTransition(tenant.getState(), target);
         tenant.setState(target);
         return tenantRepository.save(tenant);
+    }
+
+    /**
+     * Builds the audit-event details JSON skeleton shared by every Phase F lifecycle
+     * event. The schema is pinned in
+     * {@link AuditEventTypes#TENANT_SUSPENDED} (and peers): Phase G's
+     * {@code platform_admin_access_log} reads {@code actor_user_id} and
+     * {@code justification} directly, so we commit to those field names now.
+     *
+     * <p>{@code extras} layers transition-specific details (e.g. revokedKidCount)
+     * on top without duplicating the baseline at every call site.</p>
+     */
+    private static Map<String, Object> auditDetails(UUID actorUserId, String justification,
+                                                     TenantState previousState,
+                                                     Map<String, Object> extras) {
+        Map<String, Object> details = new LinkedHashMap<>();
+        details.put("actor_user_id", actorUserId == null ? null : actorUserId.toString());
+        details.put("justification", justification);
+        details.put("previous_state", previousState.name());
+        details.putAll(extras);
+        return details;
     }
 }

--- a/backend/src/main/java/org/fabt/tenant/service/TenantOffboardExportService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantOffboardExportService.java
@@ -1,0 +1,264 @@
+package org.fabt.tenant.service;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.sql.ResultSetMetaData;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.UUID;
+
+import tools.jackson.core.JsonGenerator;
+import tools.jackson.core.JsonEncoding;
+import tools.jackson.core.json.JsonFactory;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Streams a tenant's user-facing data to a schema-versioned JSON envelope on local
+ * disk (Q5 resolution: local disk for v0.51.0; S3 migration deferred to Phase H).
+ * Invoked from {@link TenantLifecycleService#offboard} as part of the GDPR Art. 20
+ * data-portability obligation.
+ *
+ * <p><b>Export shape:</b>
+ * <pre>
+ * {
+ *   "schemaVersion": "1.0.0",
+ *   "tenantId": "...",
+ *   "exportedAt": "2026-...",
+ *   "tenant": [ { ... single row ... } ],
+ *   "shelters": [ ... ],
+ *   "users": [ ... ],
+ *   "reservations": [ ... ],
+ *   "referral_tokens": [ ... ],
+ *   "notifications": [ ... ],
+ *   "subscriptions": [ ... ],
+ *   "api_keys": [ ... ]           // hashes REDACTED (see below)
+ * }
+ * </pre>
+ *
+ * <p><b>What's NOT exported (intentionally):</b>
+ * <ul>
+ *   <li>{@code tenant_key_material}, {@code kid_to_tenant_key}, {@code jwt_revocations}
+ *       — platform crypto metadata, not user data.</li>
+ *   <li>{@code audit_events} — platform-held forensic record (GDPR Art. 20 covers
+ *       data the user provided; audit rows are platform-originated).</li>
+ *   <li>{@code api_key.key_hash} + {@code api_key.old_key_hash} — secret hashes,
+ *       deliberately excluded from the SELECT.</li>
+ *   <li>{@code webhook_delivery_log}, {@code hmis_outbox}, {@code hmis_audit_log}
+ *       — operational tables, not user data.</li>
+ * </ul>
+ *
+ * <p><b>Crash-safety:</b> writes to {@code <file>.partial} first, then atomically
+ * renames to the final filename on success. Mid-write failures leave a
+ * {@code .partial} file that an operator can clean up, but the final filename is
+ * always a complete, parseable JSON document — the presence of which is what
+ * {@link TenantLifecycleService#archive} checks as the prerequisite for transition
+ * to ARCHIVED.
+ *
+ * <p><b>Transaction semantics:</b> the caller
+ * ({@link TenantLifecycleService#offboard}) is {@code @Transactional}. The JDBC
+ * queries here join that tx (REQUIRED propagation by default), which gives a
+ * point-in-time-consistent view of the tenant's data — no concurrent write can
+ * change export contents mid-stream. For prod-scale tenants (3 active, ~100 rows
+ * each) the tx is sub-second. When tenant data scales to GB, this service will
+ * need a split-tx refactor; see {@code project_phase_f_implementation_plan.md}
+ * F-5 risk register.
+ */
+@Service
+public class TenantOffboardExportService {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantOffboardExportService.class);
+
+    static final String SCHEMA_VERSION = "1.0.0";
+
+    // Exposed package-private so the schema test can reference the single source of truth.
+    static final String[] EXPORT_TABLES = {"tenant", "shelters", "users", "reservations",
+        "referral_tokens", "notifications", "subscriptions", "api_keys"};
+
+    private static final DateTimeFormatter FILENAME_TS =
+        DateTimeFormatter.ofPattern("yyyyMMdd-HHmmss").withZone(java.time.ZoneOffset.UTC);
+
+    private final JdbcTemplate jdbc;
+    private final JsonFactory jsonFactory;
+    private final Path exportBasePath;
+
+    public TenantOffboardExportService(
+            JdbcTemplate jdbc,
+            @Value("${fabt.tenant.offboard.export-path:/var/fabt/exports}") String exportBasePath) {
+        this.jdbc = jdbc;
+        this.exportBasePath = Path.of(exportBasePath);
+        this.jsonFactory = new JsonFactory();
+    }
+
+    /**
+     * Exports the tenant's user-facing data to
+     * {@code <exportBasePath>/<tenantId>/<YYYYMMDD-HHMMSS>.json} and returns the
+     * absolute path. Callers store the returned URI on
+     * {@code tenant.offboard_export_receipt_uri} so {@code archive()} can verify it
+     * exists.
+     *
+     * @throws UncheckedIOException if the filesystem write fails; the outer
+     *     {@code @Transactional} on the caller rolls back the state transition so
+     *     no half-offboarded tenant persists.
+     */
+    @Transactional(readOnly = true)
+    public String exportTenant(UUID tenantId) {
+        String timestamp = FILENAME_TS.format(Instant.now());
+        Path tenantDir = exportBasePath.resolve(tenantId.toString());
+        Path finalPath = tenantDir.resolve(timestamp + ".json");
+        Path partialPath = tenantDir.resolve(timestamp + ".json.partial");
+
+        try {
+            Files.createDirectories(tenantDir);
+            // Restrict tenant directory to owner-only (rwx------). PII / DV data
+            // sits inside; no reason a co-tenant OS user on the VM should read it.
+            tryRestrictPermissions(tenantDir, "rwx------");
+        } catch (IOException e) {
+            throw new UncheckedIOException("Failed to create export directory " + tenantDir, e);
+        }
+
+        try (OutputStream out = Files.newOutputStream(partialPath,
+                StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
+             JsonGenerator gen = jsonFactory.createGenerator(out, JsonEncoding.UTF8)) {
+
+            // Restrict the partial file to owner-only (rw-------) before we write
+            // any payload. The subsequent atomic rename preserves these perms.
+            tryRestrictPermissions(partialPath, "rw-------");
+
+            gen.writeStartObject();
+            gen.writeStringProperty("schemaVersion", SCHEMA_VERSION);
+            gen.writeStringProperty("tenantId", tenantId.toString());
+            gen.writeStringProperty("exportedAt", Instant.now().toString());
+
+            writeTable(gen, "tenant",
+                "SELECT * FROM tenant WHERE id = ?", tenantId);
+            writeTable(gen, "shelters",
+                "SELECT * FROM shelter WHERE tenant_id = ?", tenantId);
+            writeTable(gen, "users",
+                "SELECT * FROM app_user WHERE tenant_id = ?", tenantId);
+            writeTable(gen, "reservations",
+                "SELECT * FROM reservation WHERE tenant_id = ?", tenantId);
+            writeTable(gen, "referral_tokens",
+                "SELECT * FROM referral_token WHERE tenant_id = ?", tenantId);
+            writeTable(gen, "notifications",
+                "SELECT * FROM notification WHERE tenant_id = ?", tenantId);
+            writeTable(gen, "subscriptions",
+                "SELECT * FROM subscription WHERE tenant_id = ?", tenantId);
+            // api_keys: hashes DELIBERATELY excluded — key_hash + old_key_hash are
+            // secret material even though the plaintext key is not recoverable
+            // from them. The export shows that a key existed (id + suffix +
+            // label + role + active) so the tenant can reconstruct their
+            // inventory, but not the authentication secret itself.
+            writeTable(gen,
+                "api_keys",
+                "SELECT id, tenant_id, shelter_id, key_suffix, label, role, active, "
+                + "created_at, last_used_at FROM api_key WHERE tenant_id = ?",
+                tenantId);
+
+            gen.writeEndObject();
+            gen.flush();
+        } catch (IOException e) {
+            // Clean up the .partial file on any failure so the next attempt
+            // starts fresh. The atomic rename below is the single success signal.
+            try { Files.deleteIfExists(partialPath); } catch (IOException ignored) { }
+            throw new UncheckedIOException(
+                "Failed to write tenant export for " + tenantId, e);
+        }
+
+        try {
+            Files.move(partialPath, finalPath,
+                StandardCopyOption.ATOMIC_MOVE);
+        } catch (IOException e) {
+            try { Files.deleteIfExists(partialPath); } catch (IOException ignored) { }
+            throw new UncheckedIOException(
+                "Failed to atomic-rename export file " + partialPath + " -> " + finalPath, e);
+        }
+
+        log.info("Exported tenant {} data to {}", tenantId, finalPath);
+        return finalPath.toString();
+    }
+
+    /**
+     * Best-effort POSIX permission restriction. Silently no-ops on filesystems
+     * that don't support POSIX perms (Windows dev/test hosts, exotic mounts).
+     * The restriction is a defense-in-depth measure for the Oracle VM (Linux)
+     * where the file could otherwise be readable by any local user via the
+     * default umask.
+     */
+    private static void tryRestrictPermissions(Path path, String posixPerms) {
+        try {
+            Files.setPosixFilePermissions(path, PosixFilePermissions.fromString(posixPerms));
+        } catch (UnsupportedOperationException | IOException ignored) {
+            // Non-POSIX FS or permission-denied (rare — we just created the file);
+            // do not let this block the export. Worst case is the file keeps
+            // umask-derived perms (0644) which is what we had before F-5.
+        }
+    }
+
+    /**
+     * Streams one table into {@code "fieldName": [ {row}, {row}, ... ]}. Uses
+     * {@link JdbcTemplate#query(String, org.springframework.jdbc.core.RowCallbackHandler, Object[])}
+     * with a RowCallbackHandler that writes each row directly to the JsonGenerator
+     * — no full ResultSet materialization, safe for arbitrary row counts.
+     */
+    private void writeTable(JsonGenerator gen, String fieldName, String sql, Object... params) {
+        // Jackson 3's generator methods throw JacksonException (runtime) — not
+        // checked IOException — so no try/catch wrapper is needed here; any
+        // stream-level I/O failure surfaces as a RuntimeException which the
+        // caller's outer handling (UncheckedIOException / tx rollback) catches.
+        gen.writeArrayPropertyStart(fieldName);
+        jdbc.query(sql, rs -> {
+            gen.writeStartObject();
+            ResultSetMetaData meta = rs.getMetaData();
+            for (int i = 1; i <= meta.getColumnCount(); i++) {
+                String colName = meta.getColumnLabel(i);
+                Object value = rs.getObject(i);
+                writeField(gen, colName, value);
+            }
+            gen.writeEndObject();
+        }, params);
+        gen.writeEndArray();
+    }
+
+    /**
+     * Handles the DB types Spring Data JDBC / pgjdbc may return for a SELECT *.
+     * {@link JsonGenerator#writeObjectField} (Jackson 3) does not always produce a
+     * stable representation for {@code java.sql.Timestamp} /
+     * {@code PGobject}; make the fallback explicit as {@code toString()} so the
+     * envelope is reproducible regardless of driver upgrade.
+     */
+    private static void writeField(JsonGenerator gen, String name, Object value) {
+        if (value == null) {
+            gen.writeNullProperty(name);
+            return;
+        }
+        if (value instanceof String s) {
+            gen.writeStringProperty(name, s);
+        } else if (value instanceof UUID u) {
+            gen.writeStringProperty(name, u.toString());
+        } else if (value instanceof Number n) {
+            gen.writeNumberProperty(name, n.doubleValue());
+        } else if (value instanceof Boolean b) {
+            gen.writeBooleanProperty(name, b);
+        } else if (value instanceof java.sql.Timestamp ts) {
+            gen.writeStringProperty(name, ts.toInstant().toString());
+        } else if (value instanceof java.sql.Date d) {
+            gen.writeStringProperty(name, d.toLocalDate().toString());
+        } else {
+            // Fallback — toString() for PGobject (jsonb, enums, etc.) and any
+            // other exotic driver types. Always produces a parseable string.
+            gen.writeStringProperty(name, value.toString());
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/tenant/service/TenantService.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantService.java
@@ -32,6 +32,24 @@ public class TenantService {
         this.objectMapper = objectMapper;
     }
 
+    /**
+     * Legacy tenant-create path. Inserts the {@code tenant} row only; relies on
+     * lazy-at-first-login bootstrap in {@code KidRegistryService.findOrCreateActiveKid}
+     * to populate {@code tenant_key_material} and register the initial kid, and does
+     * NOT seed the {@code tenant_audit_chain_head} row that Phase G's hash-chain
+     * writer will need.
+     *
+     * @deprecated since Phase F slice F-4 (v0.51.0). Prefer
+     *     {@code TenantLifecycleService.create(name, slug, actorUserId)} which
+     *     performs the full atomic bootstrap in one {@code @Transactional} — eager
+     *     key material, audit_chain_head seed, {@code TENANT_CREATED} audit emit.
+     *     {@link org.fabt.tenant.api.TenantController#create} delegates to the
+     *     lifecycle service when the {@code fabt.tenant.lifecycle.enabled} feature
+     *     flag is on and falls back here when it is off. This method stays
+     *     available for the legacy path until the flag is removed (planned for
+     *     F-6 / v0.51.0 tag).
+     */
+    @Deprecated(since = "0.51.0")
     @Transactional
     public Tenant create(String name, String slug) {
         if (tenantRepository.existsBySlug(slug)) {

--- a/backend/src/main/java/org/fabt/tenant/service/TenantStateGuard.java
+++ b/backend/src/main/java/org/fabt/tenant/service/TenantStateGuard.java
@@ -1,0 +1,138 @@
+package org.fabt.tenant.service;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+import org.fabt.shared.security.TenantScopedByConstruction;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.domain.TenantStateGuardException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Read-path gate for the F-3 tenant-state enforcement. Call
+ * {@link #requireActive(UUID)} at service-layer entry points whose repositories don't
+ * use the {@code findByIdAndActiveTenantId} SQL-JOIN pattern — typically paths where
+ * the tenant id comes from JWT/TenantContext rather than a URL variable, and whose
+ * lookups go via FK-chain or self-path queries that wouldn't naturally JOIN to
+ * {@code tenant.state}.
+ *
+ * <p><b>Caching.</b> Caffeine with 10-second TTL + 1000-entry cap (W-TinyLFU eviction). At 10 seconds,
+ * a SUSPENDED tenant's reads can linger up to that window post-quarantine — acceptable
+ * because suspend ALSO bumps the JWT key generation (all live tokens invalidated) and
+ * deactivates API keys. The tenant-state check here is defense-in-depth; the JWT/APK
+ * revocations are the first line. Cache is invalidated by
+ * {@link TenantLifecycleService#suspend}/{@code unsuspend}/etc. via
+ * {@link #invalidate(UUID)} called after-commit so a committed transition is visible
+ * to subsequent requests within ~ms, not 10s.</p>
+ *
+ * <p><b>Why not always JOIN in SQL?</b> The JOIN-to-{@code tenant.state} pattern (used
+ * by F-3 Tier 1 repos) is the stronger enforcement because it's atomic with the read.
+ * But it requires the caller to pass tenantId to the query. Paths that don't have a
+ * tenantId parameter in their repository method (self-path-from-JWT notifications,
+ * FK-chain webhook logs) can't use that pattern without an invasive refactor. Those
+ * paths go through {@code requireActive} at the service entry instead — tight loop
+ * of "ensure tenant is ACTIVE" exactly once per request.</p>
+ */
+@Service
+public class TenantStateGuard {
+
+    private static final Logger log = LoggerFactory.getLogger(TenantStateGuard.class);
+
+    private final JdbcTemplate jdbc;
+
+    /**
+     * Short-TTL cache. 10s is the max staleness window after an operator-triggered
+     * suspend before this guard starts rejecting reads (even without the explicit
+     * {@link #invalidate} call, which operates at-ms latency). Smaller means more
+     * DB load; larger means longer post-suspend-read window. 10s matches the
+     * operator's expected "suspend takes effect now" human-scale latency.
+     */
+    @TenantScopedByConstruction("cache key IS tenantId — entry is the tenant's own state, no cross-tenant confusion possible; explicit invalidate(tenantId) from TenantLifecycleService.suspend/unsuspend/etc. after-commit hook bounds post-transition staleness to ms instead of the 10s TTL")
+    private final Cache<UUID, TenantState> stateCache = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofSeconds(10))
+        .maximumSize(1000)
+        .build();
+
+    public TenantStateGuard(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * Verifies that {@code tenantId} resolves to a tenant in {@link TenantState#ACTIVE}.
+     * Throws {@link TenantStateGuardException} otherwise. Callers typically place this
+     * at the start of a service method — before repository reads — so a SUSPENDED /
+     * OFFBOARDING / ARCHIVED / DELETED tenant's request short-circuits with 404 or 503
+     * (per {@code TenantLifecycleExceptionAdvice}'s HTTP-method branching) instead of
+     * returning data.
+     *
+     * @throws TenantStateGuardException.Kind#NOT_FOUND    tenant id does not exist
+     * @throws TenantStateGuardException.Kind#NON_ACTIVE   tenant exists but state != ACTIVE
+     */
+    public void requireActive(UUID tenantId) {
+        if (tenantId == null) {
+            // Defensive — a null tenantId is itself a 404; same "no existence leak"
+            // posture applies. Callers should have resolved tenantId before this, so
+            // reaching here is a caller bug worth surfacing — log with stack so the
+            // operator can find the missing TenantContext binding.
+            log.warn("TenantStateGuard.requireActive called with null tenantId",
+                new IllegalArgumentException("null tenantId at requireActive"));
+            throw TenantStateGuardException.notFound(null);
+        }
+        TenantState state = stateCache.get(tenantId, this::loadState);
+        if (state == null) {
+            throw TenantStateGuardException.notFound(tenantId);
+        }
+        if (state != TenantState.ACTIVE) {
+            throw TenantStateGuardException.nonActive(tenantId, state);
+        }
+    }
+
+    /**
+     * Invalidates the cached state entry for a tenant. Call after any committed
+     * lifecycle transition so the next request sees the fresh state without the 10s
+     * TTL wait. {@code TenantLifecycleService} calls this via an after-commit hook.
+     */
+    public void invalidate(UUID tenantId) {
+        if (tenantId != null) {
+            stateCache.invalidate(tenantId);
+        }
+    }
+
+    /**
+     * Loader — pulled into its own method so the caller's {@link Cache#get} call can
+     * pass it as a reference. Returns {@code null} on tenant-not-found so Caffeine
+     * doesn't cache a sentinel; {@code requireActive} re-inspects and throws.
+     *
+     * <p>Reads {@code tenant.state} (VARCHAR since V79) and maps via
+     * {@link TenantState#valueOf}. If the DB holds a value outside the enum (which
+     * the CHECK constraint in V79 forbids, but defensive), the valueOf will throw
+     * {@link IllegalArgumentException} — propagates as 500, not 404, so it's clearly
+     * a bug signal not a graceful miss.</p>
+     *
+     * <p><b>RLS fragility note:</b> the bare {@code SELECT state FROM tenant WHERE id = ?}
+     * assumes the {@code tenant} table has NO Row-Level Security enabled (verified
+     * in V68/V69 — tenant itself is not RLS-protected, only tenant-owned entity
+     * tables are). If a future migration ever enables RLS on {@code tenant} without
+     * also adding a permissive policy for the {@code fabt_app} role, this method
+     * silently returns null for every tenant → every request 404s → platform-wide
+     * outage. Any PR that touches RLS on the {@code tenant} table MUST update this
+     * loader (e.g. wrap in a {@code TenantContext.runUnscoped} block, or use
+     * {@code fabt} owner credentials for this one query) AND add a unit test for
+     * the new path.</p>
+     */
+    private TenantState loadState(UUID tenantId) {
+        try {
+            String raw = jdbc.queryForObject(
+                "SELECT state FROM tenant WHERE id = ?", String.class, tenantId);
+            return raw == null ? null : TenantState.valueOf(raw);
+        } catch (EmptyResultDataAccessException notFound) {
+            return null;
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V79__tenant_state_to_varchar.sql
+++ b/backend/src/main/resources/db/migration/V79__tenant_state_to_varchar.sql
@@ -1,0 +1,62 @@
+-- V79 — Phase F slice F-1: convert tenant.state from native PG enum to VARCHAR + CHECK.
+--
+-- The V60 migration declared tenant.state as the native Postgres enum
+-- `tenant_state` (ACTIVE|SUSPENDED|OFFBOARDING|ARCHIVED|DELETED). Spring Data
+-- JDBC 4.x does not support native PG enum columns on the write path: its
+-- default Enum-to-name() conversion sends the value as VARCHAR, and the
+-- userConverters() pipeline is bypassed for types Spring considers "simple"
+-- (all Java enums). See spring-projects/spring-data-relational#1689, #1697,
+-- #1705, #1935 (still open, GDPR-write-path null-handling bug), #2083.
+--
+-- Industry consensus (Crunchy Data, Close.com) is to use VARCHAR + CHECK for
+-- low-cardinality state columns: value-set evolution is non-blocking (NOT
+-- VALID + VALIDATE allows online constraint swaps), DROP VALUE is trivial
+-- (PG enums do not support DROP VALUE — removing a deprecated state would
+-- require a full table rewrite under ACCESS EXCLUSIVE). Matches the rest of
+-- the schema (reservation.status, shelter.deactivation_reason, etc.).
+--
+-- Lock shape (be honest about it): ALTER COLUMN ... TYPE ... USING is a
+-- table rewrite and takes ACCESS EXCLUSIVE on `tenant` for the duration of
+-- the rewrite. ADD CONSTRAINT NOT VALID takes SHARE UPDATE EXCLUSIVE (fast);
+-- VALIDATE CONSTRAINT takes SHARE UPDATE EXCLUSIVE while it scans. DROP TYPE
+-- is metadata-only. With 3 live rows on prod the total window is sub-millisecond;
+-- on a hypothetical million-row future tenant table this would be the operator's
+-- concern and would require a different pattern (e.g. add new column, backfill,
+-- swap, drop). Live rows on prod all carry state='ACTIVE' which is in the
+-- allowed set — no data change.
+
+-- Step 1. Drop the enum-typed default so the ALTER TYPE doesn't trip over
+-- 'ACTIVE'::tenant_state not being castable to the new VARCHAR type's default
+-- context. We'll restore a VARCHAR default after the type change.
+ALTER TABLE tenant
+    ALTER COLUMN state DROP DEFAULT;
+
+-- Step 2. Change the column type. The USING clause is the native enum->text
+-- cast, which is always valid for Postgres enums.
+ALTER TABLE tenant
+    ALTER COLUMN state TYPE VARCHAR(32) USING state::text;
+
+-- Step 3. Restore the default as a VARCHAR literal so new rows without an
+-- explicit state continue to land as 'ACTIVE' (matches the prior enum default).
+ALTER TABLE tenant
+    ALTER COLUMN state SET DEFAULT 'ACTIVE';
+
+-- Step 4. Re-assert value integrity at the DB layer. NOT VALID + VALIDATE
+-- keeps the table writable during the constraint scan (all live rows are
+-- 'ACTIVE', so validation is instant in practice).
+ALTER TABLE tenant
+    ADD CONSTRAINT tenant_state_check
+    CHECK (state IN ('ACTIVE', 'SUSPENDED', 'OFFBOARDING', 'ARCHIVED', 'DELETED'))
+    NOT VALID;
+
+ALTER TABLE tenant VALIDATE CONSTRAINT tenant_state_check;
+
+-- Step 5. Drop the enum type. CASCADE is required because Postgres auto-
+-- creates the array type `tenant_state[]` alongside the base enum — the
+-- array type is not referenced anywhere in the schema but blocks a plain
+-- DROP TYPE on its parent. CASCADE here drops only the array-type
+-- companion; verified via:
+--   SELECT pg_describe_object(classid, objid, objsubid)
+--   FROM pg_depend WHERE refobjid = 'tenant_state'::regtype;
+-- which, post-Step-2, returns only the array-type dependent.
+DROP TYPE tenant_state CASCADE;

--- a/backend/src/main/resources/db/migration/V80__tenant_audit_chain_head_schema.sql
+++ b/backend/src/main/resources/db/migration/V80__tenant_audit_chain_head_schema.sql
@@ -1,0 +1,54 @@
+-- V80 — Phase F slice F-4: per-tenant audit-chain head pointer.
+--
+-- Creates the table that Phase G's audit hash-chain (§G1) will maintain. F-4
+-- creates the table + seeds one row per tenant at create-time so G1's
+-- on-audit-INSERT UPDATE has a pre-existing row to bump — avoids the
+-- chicken-and-egg where every tenant's first audit row would have to create
+-- the chain head as a special case.
+--
+-- This F-4 migration:
+--   * creates the schema
+--   * backfills one row per existing tenant with a placeholder hash
+--     (all-zero SHA-256 prefix) so the chain-verifier has a defined start
+--     state when G1 lands
+--
+-- The ON DELETE CASCADE is load-bearing for F-6's crypto-shred (§D11):
+-- hardDelete(tenant) cascades to remove the chain head along with
+-- tenant_key_material etc., so the destructive path is a single DELETE on
+-- tenant rather than N ordered DELETEs.
+
+CREATE TABLE tenant_audit_chain_head (
+    tenant_id   UUID        PRIMARY KEY REFERENCES tenant(id) ON DELETE CASCADE,
+    -- SHA-256 hash of the most recent audit row in this tenant's chain.
+    -- 32 bytes exactly; G1's hasher will UPDATE this on every insert. On
+    -- create (F-4) we seed with 32 zero bytes as a sentinel meaning
+    -- "chain not yet started" — G1's first insert computes hash(prev=zero || row)
+    -- which is distinguishable from hash(row) alone should forensic review
+    -- need to pin the chain-start event.
+    last_hash   BYTEA       NOT NULL,
+    -- PK of the most recent audit_events row in this tenant's chain. NULL
+    -- until G1's first audit insert for this tenant.
+    last_row_id UUID,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT tenant_audit_chain_head_hash_length
+        CHECK (octet_length(last_hash) = 32)
+);
+
+COMMENT ON TABLE tenant_audit_chain_head IS 'Per-tenant hash-chain pointer for tamper-evident audit (Phase F-4 seed, Phase G-1 writer). Single row per tenant — UPDATEd on every audit INSERT by the future AuditChainHasher component.';
+
+-- Seed one row per existing tenant with the 32-byte all-zero sentinel.
+-- decode('...', 'hex') returns BYTEA; 64 zero hex chars = 32 zero bytes.
+INSERT INTO tenant_audit_chain_head (tenant_id, last_hash, last_row_id)
+SELECT id, decode('0000000000000000000000000000000000000000000000000000000000000000', 'hex'), NULL
+FROM tenant
+ON CONFLICT (tenant_id) DO NOTHING;
+
+-- Phase B RLS posture: audit writes are FORCE-RLS'd on audit_events (V69);
+-- this head table doesn't itself contain audit payload (only a hash pointer),
+-- so RLS is not enabled here. The chain-verifier job will read across tenants
+-- under the fabt owner role per Phase B pattern. G1 may add RLS if tenant-
+-- scoped read queries land; F-4 does not.
+
+-- Grants for the app role. UPDATE only — INSERT is service-layer only via
+-- TenantLifecycleService.create; DELETE only via cascade from tenant.
+GRANT SELECT, INSERT, UPDATE ON tenant_audit_chain_head TO fabt_app;

--- a/backend/src/main/resources/db/migration/V81__tenant_archive_retention_columns.sql
+++ b/backend/src/main/resources/db/migration/V81__tenant_archive_retention_columns.sql
@@ -1,0 +1,26 @@
+-- V81 — Phase F slice F-5: archive retention metadata on tenant.
+--
+-- Adds two columns the offboard/archive flow needs:
+--
+--   offboard_export_receipt_uri TEXT — filesystem path (or future S3 URI)
+--     where TenantOffboardExportService wrote the schema'd JSON dump of the
+--     tenant's user-facing data. Set by offboard(); required to be non-null
+--     before archive() will proceed (GDPR Art. 20 data-portability contract
+--     — a tenant cannot be archived without first receiving its data export).
+--
+--   archived_at TIMESTAMPTZ — stamped when archive() transitions state to
+--     ARCHIVED. Starts the 30-day retention clock that hardDelete() (F-6)
+--     gates on: DELETE only permitted when archived_at < NOW() - 30 days.
+--
+-- Both NULL for ACTIVE and SUSPENDED tenants (the normal operating state).
+-- Migration is a pure ALTER ADD COLUMN with NULLs — takes ACCESS EXCLUSIVE
+-- briefly on tenant for the metadata change but no row rewrite, so
+-- sub-millisecond on any realistic tenant count.
+
+ALTER TABLE tenant
+    ADD COLUMN offboard_export_receipt_uri TEXT,
+    ADD COLUMN archived_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN tenant.offboard_export_receipt_uri IS 'Filesystem path (v0.51.0) or S3 URI (Phase H) where TenantOffboardExportService wrote the GDPR Art. 20 data-portability dump. Set by offboard(); required non-null before archive() proceeds.';
+
+COMMENT ON COLUMN tenant.archived_at IS 'Timestamp when archive() flipped state to ARCHIVED. Starts the 30-day retention clock for hardDelete() (F-6).';

--- a/backend/src/main/resources/db/migration/V82__tenant_dek_schema.sql
+++ b/backend/src/main/resources/db/migration/V82__tenant_dek_schema.sql
@@ -1,0 +1,213 @@
+-- V82 — multi-tenant-production-readiness Phase F task 7.8a
+-- multi-tenant-production-readiness / design-f6-real-cryptoshred §4
+--
+-- Creates the `tenant_dek` table that holds per-tenant, per-purpose random
+-- DEKs wrapped under a master-KEK-derived wrapping key via AES-KWP
+-- (RFC 5649 / NIST SP 800-38F §6.3). This table is the SHRED SURFACE:
+-- destroying rows here destroys the only copy of the DEK, which is what
+-- makes NIST SP 800-88 Rev 2 §2.5 "Cryptographic Erase" actually true.
+--
+-- The TDD anchor test CryptoShredGapIntegrationTest (feature branch
+-- commit b5672da) proves that the legacy §D11 design — deleting
+-- tenant_key_material + kid_to_tenant_key — destroyed nothing an
+-- adversary needed. DEKs were pure HKDF of (master_KEK, tenantId,
+-- purpose); master_KEK + tenantId recovered plaintext post-shred.
+-- V82 + the TenantDekService refactor (task 7.8b/c) close that gap.
+--
+-- Forward-only migration. CREATE TABLE IF NOT EXISTS for idempotency
+-- under partial-apply recovery. V83 populates this table; V84 flips
+-- the 18 peer child-table FKs to CASCADE so hardDelete's single
+-- DELETE FROM tenant takes everything with it.
+--
+-- WARROOM 2026-04-24 pass-2 addressed
+
+-- ----------------------------------------------------------------------
+-- 1. tenant_dek — wrapped per-tenant, per-purpose random DEKs
+-- ----------------------------------------------------------------------
+--
+-- One row per (tenant, purpose, generation). `wrapped_dek` holds the
+-- AES-KWP-wrapped 32-byte AES-256 DEK (40 bytes output per RFC 5649).
+-- TenantDekService.getOrCreateActiveDek inserts on first encrypt for a
+-- purpose; AES-KWP-Unwraps on resolveDek for decrypt.
+--
+-- kid is the envelope's opaque identifier — same format as
+-- kid_to_tenant_key's kid column (random UUID), but RESOLVES to a
+-- DIFFERENT table. Data encryption kids live here; JWT signing kids
+-- live in kid_to_tenant_key. The two pools are disjoint and won't
+-- collide (UUID random).
+
+CREATE TABLE IF NOT EXISTS tenant_dek (
+    kid          UUID PRIMARY KEY,
+    tenant_id    UUID NOT NULL,
+    purpose      VARCHAR(32) NOT NULL,
+    generation   INT NOT NULL DEFAULT 1,
+    wrapped_dek  BYTEA NOT NULL,
+    active       BOOLEAN NOT NULL DEFAULT TRUE,
+    created_at   TIMESTAMPTZ NOT NULL DEFAULT clock_timestamp(),
+    rotated_at   TIMESTAMPTZ,
+
+    -- Closed set of purposes matching org.fabt.shared.security.KeyPurpose.
+    -- Adding a new purpose requires updating BOTH the enum and this check.
+    CONSTRAINT tenant_dek_purpose_check
+        CHECK (purpose IN ('TOTP', 'WEBHOOK_SECRET', 'OAUTH2_CLIENT_SECRET', 'HMIS_API_KEY')),
+
+    -- Temporal consistency — same shape as tenant_key_material constraints
+    -- in V61. rotated_at is stamped on generation flip; a row is either
+    -- active (rotated_at NULL) or inactive (rotated_at NOT NULL).
+    CONSTRAINT tenant_dek_rotated_after_created
+        CHECK (rotated_at IS NULL OR rotated_at >= created_at),
+    CONSTRAINT tenant_dek_active_implies_no_rotated
+        CHECK ((active = TRUE AND rotated_at IS NULL)
+            OR (active = FALSE AND rotated_at IS NOT NULL)),
+
+    -- Key-shred FK: the SINGLE most load-bearing line in this migration.
+    -- Without ON DELETE CASCADE, hardDelete(tenant) would raise an FK
+    -- violation and the wrapped DEKs would survive the "shred" — making
+    -- the entire Option A refactor a no-op. V84 flips the 18 peer FKs
+    -- to CASCADE so the whole chain unwinds from a single DELETE.
+    CONSTRAINT tenant_dek_tenant_fk
+        FOREIGN KEY (tenant_id) REFERENCES tenant(id) ON DELETE CASCADE
+);
+
+-- Each (tenant, purpose, generation) yields exactly one wrapped DEK.
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_dek_tenant_purpose_gen_uq
+    ON tenant_dek (tenant_id, purpose, generation);
+
+-- At most one ACTIVE generation per (tenant, purpose). Rotation bumps
+-- generation + flips old row's active to FALSE atomically in one tx.
+CREATE UNIQUE INDEX IF NOT EXISTS tenant_dek_active_per_tenant_purpose_uq
+    ON tenant_dek (tenant_id, purpose) WHERE active = TRUE;
+
+-- Index for the decrypt-path kid lookup (kid is already PK, so this is
+-- implicit) and for tenant-scoped sweeps (cache invalidation, audits).
+CREATE INDEX IF NOT EXISTS tenant_dek_by_tenant
+    ON tenant_dek (tenant_id);
+
+COMMENT ON TABLE tenant_dek IS
+    'Per-tenant, per-purpose random 256-bit DEKs wrapped via AES-KWP (RFC 5649) under a master-KEK-derived wrapping key. Shred surface per design-f6-real-cryptoshred §3: ON DELETE CASCADE from tenant means hardDelete destroys every wrapped DEK for the tenant in a single DB statement, rendering any surviving ciphertext permanently unrecoverable.';
+
+COMMENT ON COLUMN tenant_dek.kid IS
+    'Opaque random UUID emitted in the v1 EncryptionEnvelope kid field. Disjoint pool from kid_to_tenant_key (which holds JWT-signing kids).';
+
+COMMENT ON COLUMN tenant_dek.wrapped_dek IS
+    'AES-KWP output (40 bytes for a 32-byte DEK). Unwrap requires the master-KEK-derived wrapping key from KeyDerivationService.deriveKekWrappingKey(tenant_id). Without this row the DEK cannot be reconstructed — that is the whole point.';
+
+COMMENT ON COLUMN tenant_dek.purpose IS
+    'Canonical purpose string matching org.fabt.shared.security.KeyPurpose. Purpose binding prevents a TOTP ciphertext from decrypting under the webhook-secret DEK even if both DEKs exist for the same tenant.';
+
+COMMENT ON COLUMN tenant_dek.active IS
+    'TRUE for the current generation per (tenant, purpose); partial unique index enforces at most one active row. Old generations linger during the rotation grace window so pre-rotation ciphertexts still decrypt.';
+
+-- ----------------------------------------------------------------------
+-- 2. Row-Level Security — PERMISSIVE + RESTRICTIVE pair
+-- ----------------------------------------------------------------------
+--
+-- Mirrors V68 tenant_key_material + kid_to_tenant_key pattern (V68 lines
+-- 112-161). Warroom 2026-04-24 pass-1 (Sam) explicitly required the full
+-- pair — PERMISSIVE writes ALONE would silently bypass tenant scoping
+-- because RESTRICTIVE policies can only NARROW a PERMISSIVE set, not
+-- authorize on their own.
+--
+-- Read path: TenantDekService.resolveDek runs BEFORE TenantContext is
+-- bound (decrypt happens in JwtAuthenticationFilter before the filter
+-- chain establishes the tenant). PERMISSIVE SELECT is defensible —
+-- tenant_dek.kid is an opaque random UUID; enumeration yields zero
+-- tenant-identifying information.
+--
+-- Write paths: INSERT/UPDATE/DELETE all tenant-scoped via RESTRICTIVE
+-- policies checking tenant_id = fabt_current_tenant_id(). The one
+-- exception is DELETE via FK CASCADE from hardDelete — see §3 trigger
+-- below, which uses the fabt.shred_in_progress GUC to authorize the
+-- cascade path without needing to set app.tenant_id.
+
+ALTER TABLE tenant_dek ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenant_dek FORCE ROW LEVEL SECURITY;
+
+-- PERMISSIVE (read-all + write baseline)
+CREATE POLICY tenant_dek_select_all ON tenant_dek
+    FOR SELECT USING (true);
+CREATE POLICY tenant_dek_insert_permissive ON tenant_dek
+    FOR INSERT WITH CHECK (true);
+CREATE POLICY tenant_dek_update_permissive ON tenant_dek
+    FOR UPDATE USING (true) WITH CHECK (true);
+CREATE POLICY tenant_dek_delete_permissive ON tenant_dek
+    FOR DELETE USING (true);
+
+-- RESTRICTIVE (the actual tenant-scoping; ANDs with PERMISSIVE).
+CREATE POLICY tenant_dek_insert_restrictive ON tenant_dek
+    AS RESTRICTIVE
+    FOR INSERT WITH CHECK (tenant_id = fabt_current_tenant_id());
+CREATE POLICY tenant_dek_update_restrictive ON tenant_dek
+    AS RESTRICTIVE
+    FOR UPDATE
+    USING (tenant_id = fabt_current_tenant_id())
+    WITH CHECK (tenant_id = fabt_current_tenant_id());
+CREATE POLICY tenant_dek_delete_restrictive ON tenant_dek
+    AS RESTRICTIVE
+    FOR DELETE USING (tenant_id = fabt_current_tenant_id());
+
+-- ----------------------------------------------------------------------
+-- 3. BEFORE DELETE trigger — shred-path guard (Q-F6-6, warroom pass-2)
+-- ----------------------------------------------------------------------
+--
+-- The RESTRICTIVE DELETE policy above only authorizes DELETEs from a
+-- session with app.tenant_id bound to the target tenant. That covers
+-- normal app-layer operation, but NOT the FK CASCADE path fired by
+-- hardDelete: the cascade runs under the caller's session, and the
+-- caller is NOT binding app.tenant_id to the dying tenant (it's
+-- binding a different GUC, fabt.shred_in_progress, per the warroom
+-- trigger mechanism resolution).
+--
+-- This trigger closes the gap: any DELETE on tenant_dek — whether
+-- app-layer via the RLS policy or cascade via the FK — must have
+-- fabt.shred_in_progress set to the row's tenant_id. Otherwise raise.
+--
+-- Defense-in-depth layered over ArchUnit Family F rule 7.8j, which
+-- forbids any non-hardDelete caller from writing this GUC. ArchUnit
+-- catches the app-layer bypass at build time; the trigger catches
+-- the DB-console / ad-hoc DELETE at runtime.
+--
+-- Also catches a cross-tenant-GUC-poisoning attack where an attacker
+-- sets fabt.shred_in_progress to tenant A but tries to DELETE tenant
+-- B's rows — the equality check fails on OLD.tenant_id, trigger raises.
+--
+-- SECURITY_DEFINER is intentional: the trigger must read the session
+-- GUC regardless of the invoking role's search_path. Trigger body is
+-- 3 lines of pure SQL — no expansion surface.
+
+CREATE OR REPLACE FUNCTION tenant_dek_shred_guard() RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    -- current_setting with the second-arg missing_ok=true returns NULL
+    -- when the GUC was never set in this session (the common case).
+    -- IS DISTINCT FROM treats NULL as "not equal," so the trigger raises
+    -- for both "GUC unset" and "GUC set to wrong tenant" with the same
+    -- generic message — an attacker probing the trigger can't
+    -- distinguish "no GUC" from "wrong GUC."
+    IF current_setting('fabt.shred_in_progress', true) IS DISTINCT FROM OLD.tenant_id::text THEN
+        RAISE EXCEPTION 'tenant_dek row deletion attempted outside hardDelete shred path'
+            USING ERRCODE = 'P0001',
+                  HINT = 'Set fabt.shred_in_progress = <tenant_id> via hardDelete before DELETE.';
+    END IF;
+    RETURN OLD;
+END;
+$$;
+
+COMMENT ON FUNCTION tenant_dek_shred_guard() IS
+    'BEFORE DELETE trigger on tenant_dek. Raises unless fabt.shred_in_progress = OLD.tenant_id::text. Paired with ArchUnit rule 7.8j (only TenantLifecycleService.hardDelete may set this GUC) for belt-and-braces enforcement of the shred path. See design-f6-real-cryptoshred §3 and Q-F6-6 resolution.';
+
+CREATE TRIGGER tenant_dek_shred_guard_trigger
+    BEFORE DELETE ON tenant_dek
+    FOR EACH ROW
+    EXECUTE FUNCTION tenant_dek_shred_guard();
+
+-- ----------------------------------------------------------------------
+-- 4. Grants — same pattern as tenant_key_material (V61 was pre-grants
+--    model; V68 era added the fabt_app role posture). tenant_dek is
+--    read/written by the app service; only the shred path needs DELETE.
+-- ----------------------------------------------------------------------
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON tenant_dek TO fabt_app;

--- a/backend/src/main/resources/db/migration/V84__tenant_fk_cascade.sql
+++ b/backend/src/main/resources/db/migration/V84__tenant_fk_cascade.sql
@@ -1,0 +1,126 @@
+-- V84 — multi-tenant-production-readiness Phase F task 7.8e
+-- design-f6-real-cryptoshred §6 + Appendix A (child-table CASCADE audit)
+--
+-- Flips 18 per-tenant child-table FKs from the implicit NO ACTION rule to
+-- ON DELETE CASCADE. With V82's CASCADE already in place for tenant_dek
+-- plus V61's CASCADE for tenant_key_material + kid_to_tenant_key plus
+-- V80's CASCADE for tenant_audit_chain_head, post-V84 every per-tenant
+-- child row gets destroyed by a single `DELETE FROM tenant WHERE id = ?`.
+--
+-- That single DELETE is what `TenantLifecycleService.hardDelete` will
+-- fire (task 7.8f). The CASCADE chain is what makes the §D11 crypto-
+-- shred claim verifiable — nothing per-tenant survives the parent row
+-- removal, which is also what the TDD anchor
+-- `CryptoShredGapIntegrationTest` will flip from @Disabled+red to
+-- @Enabled+green after task 7.8g.
+--
+-- ─── Why a DO-block instead of static ALTER TABLE per constraint ───
+--
+-- Warroom 2026-04-24 pass-2 Sam blocker: the original draft used
+-- `ALTER TABLE ... DROP CONSTRAINT <table>_<col>_fkey` — a hard-coded
+-- naming assumption that Postgres only honors for inline-FK creations
+-- in V2–V4. A future rename of any of these constraints would silently
+-- DROP the wrong thing. The DO-block looks up the actual `conname` from
+-- pg_constraint at migration time and fails loud (RAISE EXCEPTION) if
+-- zero or more-than-one match — catches name drift before it corrupts
+-- a migration.
+--
+-- ─── Why NOT VALID + VALIDATE CONSTRAINT ───
+--
+-- Sam pass-2 blocker #1: `ALTER TABLE ... ADD CONSTRAINT FOREIGN KEY`
+-- WITHOUT `NOT VALID` scans the child table to validate every existing
+-- row satisfies the FK, holding ACCESS EXCLUSIVE on the child table for
+-- the duration. On the pilot (≤hundreds of rows per table) that's sub-
+-- second; at real scale it blocks writes. `NOT VALID` makes the ADD
+-- catalog-only + instant; a separate `VALIDATE CONSTRAINT` pass then
+-- walks existing rows under SHARE UPDATE EXCLUSIVE (concurrent writes
+-- unblocked). All existing rows DO satisfy the FK at this point, so
+-- VALIDATE is a no-op-verify; the shape is future-scale-correct.
+--
+-- ─── Timeouts (V74 C-A5-N1 pattern) ───
+--
+-- SET LOCAL lock_timeout + statement_timeout prevents a stray background
+-- VACUUM or long-running read from pinning the migration indefinitely.
+-- 10s for lock acquisition, 60s per statement — generous at pilot scale,
+-- but bounded so a pathological test container doesn't hang CI forever.
+--
+-- ─── What's NOT flipped ───
+--
+-- audit_events (V57 added nullable tenant_id without a FK, deliberately,
+-- per Q-F6-5 Riley pass-1: preserves the shred-audit tombstone pattern —
+-- on hardDelete, the TENANT_HARD_DELETED row with NULL tenant_id outlives
+-- the tenant so compliance auditors can see "tenant X was deleted on Y
+-- by Z"). audit_events is on the MUST_NOT_FK_TO_TENANT allowlist in
+-- TenantChildCascadeAuditTest.
+--
+-- ─── Rollback path ───
+--
+-- No automated rollback. If a future deploy needs to revert CASCADE to
+-- RESTRICT (e.g., a bug surfaces in hardDelete that makes CASCADE
+-- dangerous), the operator writes a V85 migration that runs the inverse
+-- ALTERs. The runbook captures this per warroom pass-2 Riley
+-- recommendation (task 7.8i).
+
+SET LOCAL lock_timeout = '10s';
+SET LOCAL statement_timeout = '60s';
+
+DO $$
+DECLARE
+    -- Allowlist of (owning_table, intended_delete_rule=CASCADE).
+    -- Must stay in sync with
+    -- TenantChildCascadeAuditTest.MUST_CASCADE_FROM_TENANT — new per-tenant
+    -- child tables added post-V84 need BOTH an entry here AND in the CI
+    -- check's constant. Pair-enforcement catches drift at build time.
+    target_tables text[] := ARRAY[
+        'app_user', 'api_key', 'shelter', 'import_log',
+        'tenant_oauth2_provider', 'subscription', 'bed_availability',
+        'reservation', 'surge_event', 'referral_token',
+        'hmis_outbox', 'hmis_audit_log', 'bed_search_log',
+        'daily_utilization_summary', 'one_time_access_code',
+        'notification', 'password_reset_token', 'escalation_policy'
+    ];
+    tbl text;
+    cname text;
+    match_count int;
+BEGIN
+    FOREACH tbl IN ARRAY target_tables LOOP
+        -- Look up the FK's actual constraint name. tenant is confrelid,
+        -- tbl is conrelid. Zero or multiple matches = schema drift = fail.
+        SELECT COUNT(*), MIN(conname) INTO match_count, cname
+        FROM pg_catalog.pg_constraint
+        WHERE contype = 'f'
+          AND conrelid = format('public.%I', tbl)::regclass
+          AND confrelid = 'public.tenant'::regclass;
+
+        IF match_count = 0 THEN
+            RAISE EXCEPTION 'V84: no FK from %.tenant_id to tenant(id) found on table %', tbl, tbl;
+        ELSIF match_count > 1 THEN
+            RAISE EXCEPTION 'V84: multiple FKs from % to tenant(id) — ambiguous drop (count=%)', tbl, match_count;
+        END IF;
+
+        -- 1. DROP the existing FK. Catalog-only; fast; ACCESS EXCLUSIVE
+        --    for the metadata write, released on statement completion.
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', tbl, cname);
+
+        -- 2. ADD NOT VALID. Catalog-only (no row scan). New writes are
+        --    immediately blocked against the CASCADE rule; existing rows
+        --    aren't re-checked here — VALIDATE does that in step 3.
+        EXECUTE format(
+            'ALTER TABLE public.%I '
+            'ADD CONSTRAINT %I FOREIGN KEY (tenant_id) '
+            'REFERENCES public.tenant(id) ON DELETE CASCADE NOT VALID',
+            tbl, cname);
+
+        -- 3. VALIDATE. Scans existing rows under SHARE UPDATE EXCLUSIVE —
+        --    does NOT block concurrent reads/writes. All existing rows
+        --    already satisfy the FK (they passed the old NO ACTION check),
+        --    so this is a no-op-verify; runs full table scan anyway to
+        --    satisfy Postgres's catalog invariant that VALIDATE has run
+        --    before the constraint is marked CONVALIDATED.
+        EXECUTE format('ALTER TABLE public.%I VALIDATE CONSTRAINT %I', tbl, cname);
+    END LOOP;
+END;
+$$;
+
+COMMENT ON COLUMN tenant.id IS
+    'Parent of CASCADE FKs (V84 + V61 + V80 + V82). hardDelete(tenant_id) chain-removes every per-tenant child row in a single DELETE. audit_events preserves its tenant_id without FK per shred-auditability contract (Q-F6-5).';

--- a/backend/src/test/java/db/migration/V74ReencryptIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V74ReencryptIntegrationTest.java
@@ -225,6 +225,14 @@ class V74ReencryptIntegrationTest extends BaseIntegrationTest {
     void t11_keyPurposeEnumCoverage() {
         String plaintext = "round-trip-" + UUID.randomUUID();
         for (KeyPurpose purpose : KeyPurpose.values()) {
+            if (purpose == KeyPurpose.JWT_SIGN) {
+                // Post-F-6.0: JWT_SIGN is not a data-encryption purpose. JWT
+                // signing keys live in kid_to_tenant_key + tenant_key_material
+                // and rotate via JwtService, not SecretEncryptionService.
+                // tenant_dek's CHECK constraint excludes it; encryptForTenant
+                // throws IllegalArgumentException if called with it.
+                continue;
+            }
             String ciphertext = encryptionService.encryptForTenant(tenantA, purpose, plaintext);
             assertTrue(isV1(ciphertext),
                     purpose + " encrypt must produce v1 envelope");

--- a/backend/src/test/java/db/migration/V83MigrationIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V83MigrationIntegrationTest.java
@@ -1,0 +1,426 @@
+package db.migration;
+
+import java.nio.ByteBuffer;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.sql.Connection;
+import java.util.Base64;
+import java.util.UUID;
+
+import javax.crypto.Cipher;
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+import javax.crypto.spec.SecretKeySpec;
+import javax.sql.DataSource;
+
+import org.flywaydb.core.api.migration.Context;
+import org.fabt.Application;
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.shared.security.KeyPurpose;
+import org.fabt.shared.security.SecretEncryptionService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end integration test for V83 (F-6.0 task 7.8d, §11.6 of
+ * design-f6-real-cryptoshred). Pins three invariants Jordan's pass-2
+ * warroom strategy required:
+ *
+ * <ul>
+ *   <li><b>Completeness</b> — after V83, every v1 envelope in the 4
+ *       covered columns has its kid in {@code tenant_dek}, not in
+ *       {@code kid_to_tenant_key}-only.</li>
+ *   <li><b>Idempotency</b> — re-running V83 on already-migrated data
+ *       is a no-op (zero column rewrites, zero new DEK rows).</li>
+ *   <li><b>Rotation probe</b> — the Q-F6-4 fold-in exercises the atomic
+ *       rotation path before Phase H needs it. Runs on real data when
+ *       any tenant_dek row exists; skips gracefully on empty schemas.</li>
+ * </ul>
+ *
+ * Seeds v1-HKDF envelopes the way V74 would have produced them (inline
+ * helpers mirror V74's crypto paths), then invokes V83 directly against
+ * a Flyway Context stub. Same pattern as {@code V74ReencryptIntegrationTest}.
+ */
+@DisplayName("V83 re-encrypt migration (F-6.0 task 7.8d — design-f6-real-cryptoshred)")
+@SpringBootTest(classes = Application.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class V83MigrationIntegrationTest extends BaseIntegrationTest {
+
+    private static final String PLATFORM_KEY_B64 = "dGVzdC1vbmx5LXRvdHAtZW5jcnlwdGlvbi1rZXktMzI=";
+
+    @Autowired private DataSource dataSource;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private SecretEncryptionService encryption;
+
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    private UUID tenantA;
+
+    @BeforeEach
+    void setUp() {
+        tenantA = authHelper.setupSecondaryTenant("v83-" + UUID.randomUUID()).getId();
+        System.setProperty("fabt.encryption-key", PLATFORM_KEY_B64);
+    }
+
+    @AfterEach
+    void cleanup() {
+        System.clearProperty("fabt.encryption-key");
+    }
+
+    // ------------------------------------------------------------------
+    // T1 — Happy path: legacy v1-HKDF envelope → V83 migrates to v1-random
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T1: seeded v1-HKDF TOTP envelope is re-encrypted under tenant_dek; round-trip via decryptForTenant")
+    void t1_legacyV1Totp_migratedToTenantDek() throws Exception {
+        String plaintext = "totp-plain-" + UUID.randomUUID();
+        UUID userId = authHelper.createUserInTenant(tenantA,
+                "v83-t1-" + UUID.randomUUID() + "@test.fabt.org",
+                "V83 T1 User", new String[]{"OUTREACH_WORKER"}, false).getId();
+
+        // 1. Seed a v1-HKDF TOTP envelope (the output V74 would have produced).
+        UUID legacyKid = UUID.randomUUID();
+        registerLegacyKid(tenantA, legacyKid);
+        SecretKey hkdfDek = hkdfDeriveKey(tenantA, "totp");
+        String legacyEnvelope = encryptV1Envelope(hkdfDek, legacyKid, plaintext);
+        jdbc.update("UPDATE app_user SET totp_secret_encrypted = ? WHERE id = ?",
+                legacyEnvelope, userId);
+
+        // Sanity: envelope's kid is in kid_to_tenant_key, NOT tenant_dek.
+        assertThat(kidInKidToTenantKey(legacyKid)).isTrue();
+        assertThat(kidInTenantDek(legacyKid)).isFalse();
+
+        // 2. Run V83.
+        invokeV83();
+
+        // 3. Post-V83: column has a NEW envelope with a NEW kid in tenant_dek.
+        String migratedEnvelope = jdbc.queryForObject(
+                "SELECT totp_secret_encrypted FROM app_user WHERE id = ?",
+                String.class, userId);
+        assertThat(migratedEnvelope).isNotEqualTo(legacyEnvelope);
+
+        UUID migratedKid = extractKidFromV1Envelope(migratedEnvelope);
+        assertThat(migratedKid).isNotNull();
+        assertThat(kidInTenantDek(migratedKid))
+                .as("post-V83, envelope kid must exist in tenant_dek")
+                .isTrue();
+
+        // 4. Decryption via the refactored service round-trips cleanly.
+        String decrypted = encryption.decryptForTenant(tenantA, KeyPurpose.TOTP, migratedEnvelope);
+        assertThat(decrypted).isEqualTo(plaintext);
+    }
+
+    // ------------------------------------------------------------------
+    // T2 — Idempotency: second V83 run is a no-op
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T2: running V83 twice produces zero additional rewrites on the second pass")
+    void t2_idempotentReRun() throws Exception {
+        String plaintext = "idempotent-" + UUID.randomUUID();
+        UUID userId = authHelper.createUserInTenant(tenantA,
+                "v83-t2-" + UUID.randomUUID() + "@test.fabt.org",
+                "V83 T2 User", new String[]{"OUTREACH_WORKER"}, false).getId();
+
+        UUID legacyKid = UUID.randomUUID();
+        registerLegacyKid(tenantA, legacyKid);
+        SecretKey hkdfDek = hkdfDeriveKey(tenantA, "totp");
+        String legacyEnvelope = encryptV1Envelope(hkdfDek, legacyKid, plaintext);
+        jdbc.update("UPDATE app_user SET totp_secret_encrypted = ? WHERE id = ?",
+                legacyEnvelope, userId);
+
+        invokeV83();
+        String afterFirst = jdbc.queryForObject(
+                "SELECT totp_secret_encrypted FROM app_user WHERE id = ?",
+                String.class, userId);
+        int dekRowsAfterFirst = countTenantDekRowsForTenant(tenantA);
+
+        invokeV83();
+        String afterSecond = jdbc.queryForObject(
+                "SELECT totp_secret_encrypted FROM app_user WHERE id = ?",
+                String.class, userId);
+        int dekRowsAfterSecond = countTenantDekRowsForTenant(tenantA);
+
+        assertThat(afterSecond)
+                .as("second V83 run must not rewrite already-migrated column")
+                .isEqualTo(afterFirst);
+        assertThat(dekRowsAfterSecond)
+                .as("second V83 run must not create additional tenant_dek rows")
+                .isEqualTo(dekRowsAfterFirst);
+    }
+
+    // ------------------------------------------------------------------
+    // T3 — Completeness: no orphan v1-HKDF envelopes remain
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T3: post-V83, no v1 envelope in the 4 covered columns has an HKDF-only kid")
+    void t3_noOrphanV1HkdfEnvelopes() throws Exception {
+        // Seed one legacy envelope for each of the 4 purposes to simulate V74's output.
+        String totpPlain = "totp-" + UUID.randomUUID();
+        UUID userId = authHelper.createUserInTenant(tenantA,
+                "v83-t3-" + UUID.randomUUID() + "@test.fabt.org",
+                "V83 T3 User", new String[]{"OUTREACH_WORKER"}, false).getId();
+        seedLegacyEnvelope("app_user", "totp_secret_encrypted", "id", userId,
+                "totp", tenantA, totpPlain);
+
+        // Webhook: seed a subscription row with callback_secret_hash legacy envelope.
+        String webhookPlain = "webhook-" + UUID.randomUUID();
+        UUID subId = UUID.randomUUID();
+        // Subscription schema uses `status` (VARCHAR, default 'ACTIVE') not `active` BOOLEAN.
+        jdbc.update("INSERT INTO subscription (id, tenant_id, event_type, callback_url, "
+                + "callback_secret_hash) VALUES (?, ?, ?, ?, ?)",
+                subId, tenantA, "RESERVATION_CREATED", "https://example.test/hook", "placeholder");
+        seedLegacyEnvelope("subscription", "callback_secret_hash", "id", subId,
+                "webhook-secret", tenantA, webhookPlain);
+
+        invokeV83();
+
+        // Every v1 envelope across the 4 columns must now have a kid in tenant_dek.
+        assertAllV1KidsInTenantDek("app_user", "totp_secret_encrypted", tenantA);
+        assertAllV1KidsInTenantDek("subscription", "callback_secret_hash", tenantA);
+        assertAllV1KidsInTenantDek("tenant_oauth2_provider", "client_secret_encrypted", tenantA);
+    }
+
+    // ------------------------------------------------------------------
+    // T4 — Rotation probe: runs + reports passed when data exists
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T4: when tenant_dek has rows, the rotation probe runs and reports 'passed' in the audit")
+    void t4_rotationProbeRuns() throws Exception {
+        // Ensure at least one legacy envelope so V83 creates tenant_dek rows.
+        UUID userId = authHelper.createUserInTenant(tenantA,
+                "v83-t4-" + UUID.randomUUID() + "@test.fabt.org",
+                "V83 T4 User", new String[]{"OUTREACH_WORKER"}, false).getId();
+        seedLegacyEnvelope("app_user", "totp_secret_encrypted", "id", userId,
+                "totp", tenantA, "probe-plaintext-" + UUID.randomUUID());
+
+        invokeV83();
+
+        String probeResult = readLatestV83AuditField("rotation_probe_result");
+        assertThat(probeResult)
+                .as("rotation probe must run against live tenant_dek rows")
+                .isEqualTo("passed");
+
+        // Post-probe state: tenant_dek has exactly the original rows — probe
+        // reverted its gen=2 changes and restored gen=1 to active.
+        Integer activeCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ? "
+                + "AND purpose = 'TOTP' AND active = TRUE",
+                Integer.class, tenantA);
+        assertThat(activeCount).isEqualTo(1);
+
+        Integer totalRows = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ? AND purpose = 'TOTP'",
+                Integer.class, tenantA);
+        assertThat(totalRows).as("probe must not leave gen=2 row behind").isEqualTo(1);
+    }
+
+    // ------------------------------------------------------------------
+    // T5 — Audit row present with correct structure
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("T5: V83 writes exactly one SYSTEM_MIGRATION_V83_TENANT_DEK audit row per invocation")
+    void t5_auditRowWritten() throws Exception {
+        long before = countV83AuditRows();
+        invokeV83();
+        long afterOne = countV83AuditRows();
+        assertThat(afterOne).as("first invocation increments audit count by 1")
+                .isEqualTo(before + 1);
+
+        invokeV83();
+        long afterTwo = countV83AuditRows();
+        assertThat(afterTwo).as("second invocation increments again (even if no rewrites)")
+                .isEqualTo(before + 2);
+
+        String flywayRole = readLatestV83AuditField("flyway_role");
+        assertThat(flywayRole).as("audit row captures session role diagnostic").isNotEmpty();
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Helpers
+    // ──────────────────────────────────────────────────────────────────
+
+    private void seedLegacyEnvelope(String table, String column, String pkColumn, UUID pk,
+                                     String hkdfPurpose, UUID tenantId, String plaintext) throws Exception {
+        UUID legacyKid = UUID.randomUUID();
+        registerLegacyKid(tenantId, legacyKid);
+        SecretKey dek = hkdfDeriveKey(tenantId, hkdfPurpose);
+        String legacyEnvelope = encryptV1Envelope(dek, legacyKid, plaintext);
+        jdbc.update(String.format("UPDATE %s SET %s = ? WHERE %s = ?", table, column, pkColumn),
+                legacyEnvelope, pk);
+    }
+
+    /** Inserts a tenant_key_material + kid_to_tenant_key pair so the
+     *  seeded v1-HKDF envelope has a registered kid (matches V74 output). */
+    private void registerLegacyKid(UUID tenantId, UUID kid) {
+        org.fabt.testsupport.WithTenantContext.doAs(tenantId, () -> {
+            jdbc.update("INSERT INTO tenant_key_material (tenant_id, generation, active) "
+                    + "VALUES (?, 1, TRUE) ON CONFLICT DO NOTHING", tenantId);
+            jdbc.update("INSERT INTO kid_to_tenant_key (kid, tenant_id, generation) "
+                    + "VALUES (?, ?, 1) ON CONFLICT DO NOTHING", kid, tenantId);
+        });
+    }
+
+    private void assertAllV1KidsInTenantDek(String table, String column, UUID tenantId) {
+        var rows = jdbc.queryForList(
+                String.format("SELECT %s AS env FROM %s WHERE tenant_id = ? AND %s IS NOT NULL",
+                        column, table, column),
+                tenantId);
+        for (var row : rows) {
+            String stored = (String) row.get("env");
+            if (stored == null || stored.isBlank() || !isV1(stored)) continue;
+            UUID kid = extractKidFromV1Envelope(stored);
+            assertThat(kid).isNotNull();
+            assertThat(kidInTenantDek(kid))
+                    .as("%s.%s kid %s must be in tenant_dek post-V83", table, column, kid)
+                    .isTrue();
+        }
+    }
+
+    private boolean kidInTenantDek(UUID kid) {
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM tenant_dek WHERE kid = ?", Integer.class, kid);
+        return count != null && count > 0;
+    }
+
+    private boolean kidInKidToTenantKey(UUID kid) {
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM kid_to_tenant_key WHERE kid = ?", Integer.class, kid);
+        return count != null && count > 0;
+    }
+
+    private int countTenantDekRowsForTenant(UUID tenantId) {
+        Integer count = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ?", Integer.class, tenantId);
+        return count == null ? 0 : count;
+    }
+
+    private long countV83AuditRows() {
+        Long count = org.fabt.testsupport.WithTenantContext.readAsSystem(() ->
+                jdbc.queryForObject(
+                        "SELECT COUNT(*) FROM audit_events WHERE action = 'SYSTEM_MIGRATION_V83_TENANT_DEK'",
+                        Long.class));
+        return count == null ? 0L : count;
+    }
+
+    private String readLatestV83AuditField(String jsonKey) {
+        return org.fabt.testsupport.WithTenantContext.readAsSystem(() ->
+                jdbc.queryForObject(
+                        "SELECT details->>? FROM audit_events "
+                        + "WHERE action = 'SYSTEM_MIGRATION_V83_TENANT_DEK' "
+                        + "ORDER BY timestamp DESC LIMIT 1",
+                        String.class, jsonKey));
+    }
+
+    private void invokeV83() throws Exception {
+        try (Connection conn = dataSource.getConnection()) {
+            conn.setAutoCommit(false);
+            var migration = new V83__reencrypt_v1_envelopes_under_tenant_dek();
+            migration.migrate(new StubContext(conn));
+            conn.commit();
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Inline crypto helpers (mirror KeyDerivationService + V74 primitives)
+    // ------------------------------------------------------------------
+
+    private SecretKey hkdfDeriveKey(UUID tenantId, String purpose) throws Exception {
+        byte[] masterKek = Base64.getDecoder().decode(PLATFORM_KEY_B64);
+        byte[] salt = uuidToBytes(tenantId);
+        String context = "fabt:v1:" + tenantId + ":" + purpose;
+        byte[] info = context.getBytes(StandardCharsets.UTF_8);
+        byte[] derived = hkdfSha256(masterKek, salt, info, 32);
+        return new SecretKeySpec(derived, "AES");
+    }
+
+    private String encryptV1Envelope(SecretKey dek, UUID kid, String plaintext) throws Exception {
+        byte[] iv = new byte[12];
+        secureRandom.nextBytes(iv);
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.ENCRYPT_MODE, dek, new GCMParameterSpec(128, iv));
+        byte[] ct = cipher.doFinal(plaintext.getBytes(StandardCharsets.UTF_8));
+
+        ByteBuffer buf = ByteBuffer.allocate(4 + 1 + 16 + 12 + ct.length);
+        buf.put(new byte[]{0x46, 0x41, 0x42, 0x54});
+        buf.put((byte) 0x01);
+        buf.putLong(kid.getMostSignificantBits());
+        buf.putLong(kid.getLeastSignificantBits());
+        buf.put(iv);
+        buf.put(ct);
+        return Base64.getEncoder().encodeToString(buf.array());
+    }
+
+    private static boolean isV1(String stored) {
+        try {
+            byte[] d = Base64.getDecoder().decode(stored);
+            return d.length >= 5 && d[0] == 0x46 && d[1] == 0x41 && d[2] == 0x42 && d[3] == 0x54 && d[4] == 0x01;
+        } catch (IllegalArgumentException badBase64) {
+            return false;
+        }
+    }
+
+    private static UUID extractKidFromV1Envelope(String stored) {
+        try {
+            byte[] d = Base64.getDecoder().decode(stored);
+            if (d.length < 33) return null;
+            ByteBuffer buf = ByteBuffer.wrap(d);
+            buf.position(5);
+            return new UUID(buf.getLong(), buf.getLong());
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static byte[] uuidToBytes(UUID uuid) {
+        ByteBuffer buf = ByteBuffer.allocate(16);
+        buf.putLong(uuid.getMostSignificantBits());
+        buf.putLong(uuid.getLeastSignificantBits());
+        return buf.array();
+    }
+
+    private static byte[] hkdfSha256(byte[] ikm, byte[] salt, byte[] info, int outLen) throws Exception {
+        final int OUT = 32;
+        byte[] eff = (salt == null || salt.length == 0) ? new byte[OUT] : salt;
+        Mac extract = Mac.getInstance("HmacSHA256");
+        extract.init(new SecretKeySpec(eff, "HmacSHA256"));
+        byte[] prk = extract.doFinal(ikm);
+        Mac expand = Mac.getInstance("HmacSHA256");
+        expand.init(new SecretKeySpec(prk, "HmacSHA256"));
+        byte[] result = new byte[outLen];
+        byte[] prev = new byte[0];
+        int written = 0;
+        for (int i = 1; written < outLen; i++) {
+            expand.reset();
+            expand.update(prev);
+            expand.update(info);
+            expand.update((byte) i);
+            prev = expand.doFinal();
+            int copy = Math.min(OUT, outLen - written);
+            System.arraycopy(prev, 0, result, written, copy);
+            written += copy;
+        }
+        return result;
+    }
+
+    private static final class StubContext implements Context {
+        private final Connection conn;
+        StubContext(Connection conn) { this.conn = conn; }
+        @Override public org.flywaydb.core.api.configuration.Configuration getConfiguration() { return null; }
+        @Override public Connection getConnection() { return conn; }
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/CryptoShredArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/architecture/CryptoShredArchitectureTest.java
@@ -1,0 +1,173 @@
+package org.fabt.architecture;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.stream.Stream;
+
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * ArchUnit Family F — defends the F-6.0 crypto-shred property by pinning
+ * the two privileged call-sites that, if misused, would reopen the gap
+ * the warroom signed off on closing.
+ *
+ * <h2>Rule 7.8h — {@code deriveKekWrappingKey} caller pin</h2>
+ *
+ * {@link org.fabt.shared.security.KeyDerivationService#deriveKekWrappingKey}
+ * returns the AES-KWP wrapping key that sits at the top of the shred
+ * surface — anyone who can call this method and read a
+ * {@code tenant_dek.wrapped_dek} row can recover the plaintext DEK.
+ * Access is package-private; this rule additionally forbids any class
+ * outside {@link org.fabt.shared.security.TenantDekService} from calling
+ * it, preventing "I just needed a per-tenant key for my unrelated feature"
+ * privilege drift.
+ *
+ * <h2>Rule 7.8j — {@code fabt.shred_in_progress} GUC caller pin</h2>
+ *
+ * The V82 {@code tenant_dek_shred_guard} trigger on {@code tenant_dek}
+ * DELETEs gates on a session-local GUC named {@code fabt.shred_in_progress}.
+ * Only {@link org.fabt.tenant.service.TenantLifecycleService#hardDelete}
+ * and the {@code db.migration.V83__*} rotation-probe flip-back may set it.
+ * Any other caller with the ability to write that GUC defeats the trigger
+ * guard and re-enables ad-hoc {@code tenant_dek} DELETEs. ArchUnit cannot
+ * match against SQL string contents inside a JDBC call, so this rule
+ * scans production source files directly (same technique as
+ * {@link MigrationLintTest}).
+ */
+@DisplayName("ArchUnit Family F — crypto-shred call-site pins (F-6.0 tasks 7.8h + 7.8j)")
+class CryptoShredArchitectureTest {
+
+    // ──────────────────────────────────────────────────────────────────
+    // Rule 7.8h — deriveKekWrappingKey caller pin
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("7.8h — only TenantDekService may call KeyDerivationService.deriveKekWrappingKey")
+    void deriveKekWrappingKey_onlyCallableFromTenantDekService() {
+        var classes = new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("org.fabt..", "db.migration..");
+
+        ArchRule rule = noClasses()
+                .that().doNotHaveFullyQualifiedName(
+                        "org.fabt.shared.security.TenantDekService")
+                .should().callMethod(
+                        "org.fabt.shared.security.KeyDerivationService",
+                        "deriveKekWrappingKey",
+                        "java.util.UUID")
+                .because("the AES-KWP wrapping key is the privileged output "
+                        + "of KeyDerivationService — anyone who can call this "
+                        + "method and read a tenant_dek.wrapped_dek row can "
+                        + "recover the plaintext DEK. TenantDekService is the "
+                        + "SINGLE legitimate caller. If a new caller emerges "
+                        + "(e.g., a Vault Transit adapter for the regulated "
+                        + "tier), add it to this rule's doNotHaveFullyQualifiedName "
+                        + "list AND document the warroom approval that allowed it.");
+
+        rule.check(classes);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Rule 7.8j — fabt.shred_in_progress GUC caller pin (source scan)
+    // ──────────────────────────────────────────────────────────────────
+
+    private static final Path JAVA_MAIN =
+            Paths.get("src", "main", "java");
+
+    /**
+     * Allowlist of fully-qualified class names that may reference the
+     * {@code fabt.shred_in_progress} GUC. Additions require a warroom
+     * citation + design-doc reference in the comment.
+     *
+     * <ul>
+     *   <li>{@code TenantLifecycleService} — hardDelete binds the GUC
+     *       before the CASCADE {@code DELETE FROM tenant} fires so the
+     *       V82 trigger guard lets the tenant_dek CASCADE through. Sole
+     *       production caller (design-f6-real-cryptoshred §5, Q-F6-6
+     *       warroom pass-2).</li>
+     *   <li>{@code V83__reencrypt_v1_envelopes_under_tenant_dek} — the
+     *       V83 migration's rotation-readiness probe's flip-back step
+     *       DELETEs the probe's gen=2 row, which fires the trigger.
+     *       Legitimate: the migration IS the privileged context here.</li>
+     * </ul>
+     */
+    private static final Set<String> SHRED_GUC_ALLOWLIST = Set.of(
+            "TenantLifecycleService.java",
+            "V83__reencrypt_v1_envelopes_under_tenant_dek.java"
+    );
+
+    /**
+     * Pattern that matches a literal occurrence of the GUC name in
+     * CODE (not comments). Comments get stripped first so a class
+     * that merely documents the GUC in its javadoc (e.g.,
+     * {@code TenantDekService}) isn't flagged — only actual writes
+     * via {@code set_config('fabt.shred_in_progress', ...)} are.
+     */
+    private static final Pattern SHRED_GUC = Pattern.compile(
+            "fabt\\.shred_in_progress");
+
+    /** Line comments: {@code // ... EOL}. */
+    private static final Pattern LINE_COMMENT = Pattern.compile("//[^\\n]*");
+    /** Block + Javadoc comments: {@code /* ... *&#47;}. */
+    private static final Pattern BLOCK_COMMENT = Pattern.compile("/\\*.*?\\*/", Pattern.DOTALL);
+
+    @Test
+    @DisplayName("7.8j — only TenantLifecycleService and V83 may reference fabt.shred_in_progress")
+    void shredInProgressGuc_onlyReferencedByAllowlist() throws IOException {
+        List<String> violations = new ArrayList<>();
+
+        try (Stream<Path> stream = Files.walk(JAVA_MAIN)) {
+            stream.filter(Files::isRegularFile)
+                    .filter(p -> p.toString().endsWith(".java"))
+                    .forEach(p -> scanForShredGuc(p, violations));
+        }
+
+        assertThat(violations)
+                .as("Only TenantLifecycleService.hardDelete and V83's rotation "
+                    + "probe may write the fabt.shred_in_progress GUC. Any "
+                    + "other caller defeats the V82 tenant_dek_shred_guard "
+                    + "trigger. If a new legitimate caller emerges, add its "
+                    + "file name to SHRED_GUC_ALLOWLIST with a warroom "
+                    + "citation — do NOT just silence the rule.")
+                .isEmpty();
+    }
+
+    private void scanForShredGuc(Path file, List<String> violations) {
+        String name = file.getFileName().toString();
+        if (SHRED_GUC_ALLOWLIST.contains(name)) {
+            return;
+        }
+        String content;
+        try {
+            content = Files.readString(file, StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            violations.add(file + " — could not read: " + e.getMessage());
+            return;
+        }
+        // Strip comments before scanning — documenting the GUC in a
+        // javadoc is not a violation, only actual code writes are.
+        String stripped = BLOCK_COMMENT.matcher(content).replaceAll("");
+        stripped = LINE_COMMENT.matcher(stripped).replaceAll("");
+
+        Matcher m = SHRED_GUC.matcher(stripped);
+        while (m.find()) {
+            violations.add(name + " — references fabt.shred_in_progress in CODE "
+                    + "(comments stripped before scan)");
+        }
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
+++ b/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
@@ -56,8 +56,14 @@ class MigrationLintTest {
      * the {@code SECURITY DEFINER} attribute.
      */
     private static final List<String> SECURITY_DEFINER_ALLOWLIST = List.of(
-            // No entries as of v0.45.0. Add here with a comment:
-            // "VNN__migration_name.sql  // warroom ref: ..."
+            // V82 trigger function `tenant_dek_shred_guard()` — reads the session
+            // GUC `fabt.shred_in_progress` in a BEFORE DELETE trigger. Must be
+            // SECURITY DEFINER to read the GUC regardless of the invoking role's
+            // search_path (attacker could override). Body is 3 lines of pure SQL,
+            // no expansion surface. See:
+            //   openspec/changes/multi-tenant-production-readiness/design-f6-real-cryptoshred.md §3 Q-F6-6
+            //   warroom 2026-04-24 pass-2 (GUC-over-role resolution)
+            "V82__tenant_dek_schema.sql"
     );
 
     private static final Pattern SECURITY_DEFINER = Pattern.compile(

--- a/backend/src/test/java/org/fabt/architecture/TenantChildCascadeAuditTest.java
+++ b/backend/src/test/java/org/fabt/architecture/TenantChildCascadeAuditTest.java
@@ -1,0 +1,197 @@
+package org.fabt.architecture;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.fabt.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Flyway CI check — §11.5 of design-f6-real-cryptoshred. Pins the child-
+ * table CASCADE invariant that {@code TenantLifecycleService.hardDelete}
+ * (task 7.8f) relies on to crypto-shred a tenant via a single
+ * {@code DELETE FROM tenant WHERE id = ?}.
+ *
+ * <p>The test scans {@code pg_catalog.pg_constraint} for every FK that
+ * references {@code tenant(id)} and compares against two allowlists
+ * derived from Appendix A of the design doc:
+ *
+ * <ul>
+ *   <li>{@link #MUST_CASCADE_FROM_TENANT} — tables whose per-tenant rows
+ *       must be destroyed alongside the tenant row. Their FK
+ *       {@code confdeltype} must be {@code 'c'} (CASCADE).</li>
+ *   <li>{@link #MUST_NOT_FK_TO_TENANT} — tables that must NOT have a FK
+ *       to tenant, by design. Currently just {@code audit_events} per
+ *       Q-F6-5 Riley: its nullable {@code tenant_id} column survives
+ *       hard-delete as a platform-owned tombstone.</li>
+ * </ul>
+ *
+ * <p>Uses {@code pg_catalog} (not {@code information_schema}) deliberately
+ * per Jordan pass-2: {@code information_schema.referential_constraints}
+ * filters rows by current-user grants and can miss entries under RLS;
+ * {@code pg_catalog.pg_constraint} sees every constraint regardless of
+ * privilege.
+ *
+ * <p><b>Failure modes this test catches:</b>
+ *
+ * <ul>
+ *   <li>A future developer adds a new per-tenant child table with a FK
+ *       to tenant but forgets the CASCADE clause — caught at build time,
+ *       not at the first prod shred.</li>
+ *   <li>A future migration flips one of the existing 18 CASCADE FKs back
+ *       to RESTRICT — caught the instant the regression hits main.</li>
+ *   <li>A future developer adds a tenant FK to {@code audit_events} —
+ *       caught; the tombstone contract explicitly forbids it.</li>
+ * </ul>
+ *
+ * <p>Adding a new per-tenant child table post-V84:
+ *
+ * <ol>
+ *   <li>Add the new table in its own migration with
+ *       {@code REFERENCES tenant(id) ON DELETE CASCADE} inline.</li>
+ *   <li>Add the table name to {@link #MUST_CASCADE_FROM_TENANT}.</li>
+ *   <li>Also add to V84's DO-block's {@code target_tables} array IF the
+ *       new migration forgot CASCADE (the test will catch this too,
+ *       with a diff-style error message).</li>
+ * </ol>
+ *
+ * @see org.fabt.architecture.MigrationLintTest
+ * @see <a href="file:../../../main/resources/db/migration/V84__tenant_fk_cascade.sql">V84__tenant_fk_cascade.sql</a>
+ */
+@DisplayName("Tenant child-table CASCADE audit (F-6.0 task 7.8e — design-f6-real-cryptoshred §11.5)")
+class TenantChildCascadeAuditTest extends BaseIntegrationTest {
+
+    @Autowired private JdbcTemplate jdbc;
+
+    /**
+     * Tables whose per-tenant rows MUST cascade on tenant row removal.
+     * Synced with V84's {@code target_tables} array + V61 (tenant_key_material,
+     * kid_to_tenant_key) + V80 (tenant_audit_chain_head) + V82 (tenant_dek).
+     *
+     * <p>Adding a per-tenant child table post-V84 requires adding it here
+     * AND ensuring the migration uses {@code ON DELETE CASCADE}.
+     */
+    private static final Set<String> MUST_CASCADE_FROM_TENANT = Set.of(
+            // V84 flipped these 18 from NO ACTION → CASCADE
+            "app_user", "api_key", "shelter", "import_log",
+            "tenant_oauth2_provider", "subscription", "bed_availability",
+            "reservation", "surge_event", "referral_token",
+            "hmis_outbox", "hmis_audit_log", "bed_search_log",
+            "daily_utilization_summary", "one_time_access_code",
+            "notification", "password_reset_token", "escalation_policy",
+            // V61 + V80 + V82 landed CASCADE in their own schema migrations
+            "tenant_key_material", "kid_to_tenant_key",
+            "tenant_audit_chain_head", "tenant_dek"
+    );
+
+    /**
+     * Tables that MUST NOT have a FK to tenant — their {@code tenant_id}
+     * column (if any) is deliberately FK-less to preserve rows across
+     * hard-delete. Currently just audit_events per Q-F6-5 Riley: the
+     * shred tombstone row lives here with NULL tenant_id after the
+     * parent tenant is deleted, so compliance auditors can prove
+     * "tenant X was deleted on Y by Z" post-shred.
+     */
+    private static final Set<String> MUST_NOT_FK_TO_TENANT = Set.of(
+            "audit_events"
+    );
+
+    @Test
+    @DisplayName("Every FK to tenant(id) is CASCADE; audit_events has no FK to tenant")
+    void allTenantChildFksMustCascade() {
+        List<Map<String, Object>> rows = jdbc.queryForList(
+                "SELECT "
+                + "    conname, "
+                + "    conrelid::regclass::text AS owning_table, "
+                + "    confdeltype "
+                + "FROM pg_catalog.pg_constraint "
+                + "WHERE confrelid = 'public.tenant'::regclass "
+                + "  AND contype = 'f' "
+                + "ORDER BY owning_table");
+
+        Map<String, String> actual = new HashMap<>();
+        for (Map<String, Object> row : rows) {
+            // conrelid cast yields "public.<table>" or just "<table>" depending on
+            // search_path. Strip the schema prefix for allowlist comparison.
+            String owningTable = ((String) row.get("owning_table")).replaceFirst("^public\\.", "");
+            String deleteRule = row.get("confdeltype").toString();  // 'c', 'r', 'a', 'n', 'd'
+            actual.put(owningTable, deleteRule);
+        }
+
+        // ─── Check 1: every MUST_CASCADE entry has confdeltype = 'c' ───
+        Map<String, String> nonCascadeViolations = new HashMap<>();
+        Set<String> missingFks = new HashSet<>();
+        for (String expectedTable : MUST_CASCADE_FROM_TENANT) {
+            String actualRule = actual.get(expectedTable);
+            if (actualRule == null) {
+                missingFks.add(expectedTable);
+            } else if (!"c".equals(actualRule)) {
+                nonCascadeViolations.put(expectedTable, humanReadableRule(actualRule));
+            }
+        }
+
+        // ─── Check 2: no MUST_NOT_FK table has a FK to tenant ───
+        Set<String> forbiddenFks = new HashSet<>();
+        for (String forbiddenTable : MUST_NOT_FK_TO_TENANT) {
+            if (actual.containsKey(forbiddenTable)) {
+                forbiddenFks.add(forbiddenTable);
+            }
+        }
+
+        // ─── Check 3: every FK we observed is on one of our two lists ───
+        //    Catches the "developer added a new per-tenant child table but
+        //    forgot to update the test" case — drift the other direction.
+        Set<String> undeclaredFks = new HashSet<>(actual.keySet());
+        undeclaredFks.removeAll(MUST_CASCADE_FROM_TENANT);
+        undeclaredFks.removeAll(MUST_NOT_FK_TO_TENANT);
+
+        // ─── Assertions with actionable error messages ───
+        assertThat(missingFks)
+                .as("These tables are on MUST_CASCADE_FROM_TENANT but have NO FK to tenant(id) in pg_constraint. "
+                    + "Either the table was dropped (remove from the test constant) or its migration forgot "
+                    + "REFERENCES tenant(id) — fix the migration.")
+                .isEmpty();
+
+        assertThat(nonCascadeViolations)
+                .as("These tables have a FK to tenant(id) but NOT with ON DELETE CASCADE. "
+                    + "hardDelete's single-statement shred will fail on the FK. "
+                    + "Fix: write a new migration with ALTER TABLE <table> DROP/ADD CONSTRAINT to flip it to CASCADE.")
+                .isEmpty();
+
+        assertThat(forbiddenFks)
+                .as("These tables are on MUST_NOT_FK_TO_TENANT but now HAVE a FK to tenant(id). "
+                    + "Adding such a FK breaks the shred-tombstone contract from Q-F6-5 (audit trail "
+                    + "must survive hard-delete). Fix: drop the FK; keep the tenant_id column nullable.")
+                .isEmpty();
+
+        assertThat(undeclaredFks)
+                .as("These tables have a FK to tenant(id) but are not declared in either allowlist. "
+                    + "Decide whether per-tenant data in this table should cascade on hard-delete: "
+                    + "YES → add the table to MUST_CASCADE_FROM_TENANT and ensure the FK is CASCADE. "
+                    + "NO (platform-level, like audit_events) → drop the FK and add to MUST_NOT_FK_TO_TENANT.")
+                .isEmpty();
+    }
+
+    /**
+     * Translates {@code pg_constraint.confdeltype} codes to human-readable
+     * SQL names for error messages.
+     */
+    private static String humanReadableRule(String code) {
+        return switch (code) {
+            case "a" -> "NO ACTION";
+            case "r" -> "RESTRICT";
+            case "c" -> "CASCADE";
+            case "n" -> "SET NULL";
+            case "d" -> "SET DEFAULT";
+            default -> "UNKNOWN(" + code + ")";
+        };
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/TenantGuardArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/architecture/TenantGuardArchitectureTest.java
@@ -26,6 +26,7 @@ import org.fabt.notification.repository.EscalationPolicyRepository;
 import org.fabt.notification.repository.NotificationRepository;
 import org.fabt.referral.repository.ReferralTokenRepository;
 import org.fabt.reservation.repository.ReservationRepository;
+import org.fabt.shared.security.TenantInternal;
 import org.fabt.shared.security.TenantUnscoped;
 import org.fabt.shelter.repository.ShelterConstraintsRepository;
 import org.fabt.shelter.repository.ShelterRepository;
@@ -180,6 +181,45 @@ class TenantGuardArchitectureTest {
                             + "exceptions (warroom 2026-04-15). See design D11.");
 
     // ------------------------------------------------------------------
+    // Family D — tenant-state guard (F-3)
+    // ------------------------------------------------------------------
+    //
+    // Phase F slice F-3 gates request-bound reads behind tenant.state='ACTIVE'.
+    // Six Tier-1 repositories gained a findByIdAndActiveTenantId(id, tenantId)
+    // variant that INNER JOINs to tenant WHERE state='ACTIVE'. Request-bound
+    // callers MUST use that variant; the plain findByIdAndTenantId is reserved
+    // for @TenantInternal call sites (lifecycle service, batch sweeps,
+    // platform-admin cross-tenant operations where the target is intentionally
+    // non-ACTIVE — e.g. offboard export reading an OFFBOARDING tenant's data).
+    //
+    // This rule catches accidental regressions where a new service/controller
+    // method calls the plain variant without the escape hatch annotation.
+    // Design-f §F-3 + warroom Marcus pre-F-3 commit review.
+
+    private static final Set<String> F3_TIER1_REPO_NAMES = Set.of(
+            ApiKeyRepository.class.getName(),
+            TenantOAuth2ProviderRepository.class.getName(),
+            SubscriptionRepository.class.getName(),
+            ReferralTokenRepository.class.getName(),
+            ReservationRepository.class.getName(),
+            SurgeEventRepository.class.getName()
+    );
+
+    @ArchTest
+    static final ArchRule no_plain_findByIdAndTenantId_on_tier1_repos =
+            methods()
+                    .that().areDeclaredInClassesThat().resideInAnyPackage("..service..", "..api..")
+                    .and().areNotAnnotatedWith(TenantInternal.class)
+                    .and().areNotAnnotatedWith(TenantUnscoped.class)
+                    .should(notCallPlainFindByIdAndTenantIdOnTier1Repo())
+                    .as("Service/controller methods calling tenant-owned Tier-1 repos must use "
+                            + "findByIdAndActiveTenantId (F-3 §D3 tenant-state guard). To call the "
+                            + "plain findByIdAndTenantId, annotate the method with "
+                            + "@TenantInternal(\"justification\") — used for lifecycle transitions, "
+                            + "batch sweeps, and platform-admin cross-tenant ops where the target "
+                            + "tenant is intentionally non-ACTIVE.");
+
+    // ------------------------------------------------------------------
     // Caller-scoping rules (D7)
     // ------------------------------------------------------------------
 
@@ -325,5 +365,29 @@ class TenantGuardArchitectureTest {
 
     private static boolean isTenantOwnedRepo(JavaClass cls) {
         return TENANT_OWNED_REPO_NAMES.stream().anyMatch(cls::isAssignableTo);
+    }
+
+    private static boolean isF3Tier1Repo(JavaClass cls) {
+        return F3_TIER1_REPO_NAMES.stream().anyMatch(cls::isAssignableTo);
+    }
+
+    private static ArchCondition<JavaMethod> notCallPlainFindByIdAndTenantIdOnTier1Repo() {
+        return new ArchCondition<>(
+                "not call findByIdAndTenantId on F-3 Tier-1 repos without @TenantInternal") {
+            @Override
+            public void check(JavaMethod method, ConditionEvents events) {
+                for (JavaMethodCall call : method.getMethodCallsFromSelf()) {
+                    if (!"findByIdAndTenantId".equals(call.getName())) continue;
+                    JavaClass owner = call.getTargetOwner();
+                    if (!isF3Tier1Repo(owner)) continue;
+                    events.add(SimpleConditionEvent.violated(method,
+                            method.getFullName() + " calls plain findByIdAndTenantId on F-3 Tier-1 "
+                                    + owner.getSimpleName() + " at " + call.getSourceCodeLocation()
+                                    + " — swap to findByIdAndActiveTenantId OR annotate the method "
+                                    + "with @TenantInternal(\"reason\") if the call intentionally "
+                                    + "needs to read across non-ACTIVE tenant states."));
+                }
+            }
+        };
     }
 }

--- a/backend/src/test/java/org/fabt/architecture/TenantGuardUnitTest.java
+++ b/backend/src/test/java/org/fabt/architecture/TenantGuardUnitTest.java
@@ -62,13 +62,13 @@ class TenantGuardUnitTest {
         var provider = new TenantOAuth2Provider();
         provider.setId(ENTITY_ID);
         provider.setTenantId(TENANT_ID);
-        when(providerRepo.findByIdAndTenantId(ENTITY_ID, TENANT_ID))
+        when(providerRepo.findByIdAndActiveTenantId(ENTITY_ID, TENANT_ID))
                 .thenReturn(Optional.of(provider));
 
         var service = new TenantOAuth2ProviderService(providerRepo, urlValidator, encryptionService);
         TenantContext.runWithContext(TENANT_ID, false, () -> service.delete(ENTITY_ID));
 
-        verify(providerRepo).findByIdAndTenantId(eq(ENTITY_ID), eq(TENANT_ID));
+        verify(providerRepo).findByIdAndActiveTenantId(eq(ENTITY_ID), eq(TENANT_ID));
     }
 
     @Test
@@ -77,7 +77,7 @@ class TenantGuardUnitTest {
         var provider = new TenantOAuth2Provider();
         provider.setId(ENTITY_ID);
         provider.setTenantId(TENANT_ID);
-        when(providerRepo.findByIdAndTenantId(ENTITY_ID, TENANT_ID))
+        when(providerRepo.findByIdAndActiveTenantId(ENTITY_ID, TENANT_ID))
                 .thenReturn(Optional.of(provider));
         when(providerRepo.save(any())).thenReturn(provider);
 
@@ -85,7 +85,7 @@ class TenantGuardUnitTest {
         TenantContext.runWithContext(TENANT_ID, false, () ->
                 service.update(ENTITY_ID, null, null, null, null));
 
-        verify(providerRepo).findByIdAndTenantId(eq(ENTITY_ID), eq(TENANT_ID));
+        verify(providerRepo).findByIdAndActiveTenantId(eq(ENTITY_ID), eq(TENANT_ID));
     }
 
     @Test
@@ -148,14 +148,14 @@ class TenantGuardUnitTest {
         key.setTenantId(TENANT_ID);
         key.setKeyHash("old-hash");
         key.setActive(true);
-        when(apiKeyRepo.findByIdAndTenantId(ENTITY_ID, TENANT_ID))
+        when(apiKeyRepo.findByIdAndActiveTenantId(ENTITY_ID, TENANT_ID))
                 .thenReturn(Optional.of(key));
         when(apiKeyRepo.save(any())).thenReturn(key);
 
         var service = new ApiKeyService(apiKeyRepo, apiKeyJdbc);
         TenantContext.runWithContext(TENANT_ID, false, () -> service.rotate(ENTITY_ID));
 
-        verify(apiKeyRepo).findByIdAndTenantId(eq(ENTITY_ID), eq(TENANT_ID));
+        verify(apiKeyRepo).findByIdAndActiveTenantId(eq(ENTITY_ID), eq(TENANT_ID));
     }
 
     @Test
@@ -164,14 +164,14 @@ class TenantGuardUnitTest {
         var key = new ApiKey();
         key.setId(ENTITY_ID);
         key.setTenantId(TENANT_ID);
-        when(apiKeyRepo.findByIdAndTenantId(ENTITY_ID, TENANT_ID))
+        when(apiKeyRepo.findByIdAndActiveTenantId(ENTITY_ID, TENANT_ID))
                 .thenReturn(Optional.of(key));
         when(apiKeyRepo.save(any())).thenReturn(key);
 
         var service = new ApiKeyService(apiKeyRepo, apiKeyJdbc);
         TenantContext.runWithContext(TENANT_ID, false, () -> service.deactivate(ENTITY_ID));
 
-        verify(apiKeyRepo).findByIdAndTenantId(eq(ENTITY_ID), eq(TENANT_ID));
+        verify(apiKeyRepo).findByIdAndActiveTenantId(eq(ENTITY_ID), eq(TENANT_ID));
     }
 
     // ------------------------------------------------------------------
@@ -190,7 +190,7 @@ class TenantGuardUnitTest {
         sub.setId(ENTITY_ID);
         sub.setTenantId(TENANT_ID);
         sub.setStatus("ACTIVE");
-        when(subRepo.findByIdAndTenantId(ENTITY_ID, TENANT_ID))
+        when(subRepo.findByIdAndActiveTenantId(ENTITY_ID, TENANT_ID))
                 .thenReturn(Optional.of(sub));
         when(subRepo.save(any())).thenReturn(sub);
 
@@ -198,6 +198,6 @@ class TenantGuardUnitTest {
                 encryptionService, subUrlValidator, objectMapper);
         TenantContext.runWithContext(TENANT_ID, false, () -> service.delete(ENTITY_ID));
 
-        verify(subRepo).findByIdAndTenantId(eq(ENTITY_ID), eq(TENANT_ID));
+        verify(subRepo).findByIdAndActiveTenantId(eq(ENTITY_ID), eq(TENANT_ID));
     }
 }

--- a/backend/src/test/java/org/fabt/architecture/TenantGuardUnitTest.java
+++ b/backend/src/test/java/org/fabt/architecture/TenantGuardUnitTest.java
@@ -137,6 +137,7 @@ class TenantGuardUnitTest {
     // ------------------------------------------------------------------
 
     @Mock ApiKeyRepository apiKeyRepo;
+    @Mock org.springframework.jdbc.core.JdbcTemplate apiKeyJdbc;
     @Mock SecretEncryptionService encryptionService;
 
     @Test
@@ -151,7 +152,7 @@ class TenantGuardUnitTest {
                 .thenReturn(Optional.of(key));
         when(apiKeyRepo.save(any())).thenReturn(key);
 
-        var service = new ApiKeyService(apiKeyRepo);
+        var service = new ApiKeyService(apiKeyRepo, apiKeyJdbc);
         TenantContext.runWithContext(TENANT_ID, false, () -> service.rotate(ENTITY_ID));
 
         verify(apiKeyRepo).findByIdAndTenantId(eq(ENTITY_ID), eq(TENANT_ID));
@@ -167,7 +168,7 @@ class TenantGuardUnitTest {
                 .thenReturn(Optional.of(key));
         when(apiKeyRepo.save(any())).thenReturn(key);
 
-        var service = new ApiKeyService(apiKeyRepo);
+        var service = new ApiKeyService(apiKeyRepo, apiKeyJdbc);
         TenantContext.runWithContext(TENANT_ID, false, () -> service.deactivate(ENTITY_ID));
 
         verify(apiKeyRepo).findByIdAndTenantId(eq(ENTITY_ID), eq(TENANT_ID));

--- a/backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java
@@ -1,0 +1,228 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.Base64;
+import java.util.UUID;
+
+import javax.crypto.Cipher;
+import javax.crypto.SecretKey;
+import javax.crypto.spec.GCMParameterSpec;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * F-6 TDD ANCHOR — pins the crypto-shred gap.
+ *
+ * <p><b>Why this test exists:</b> the Phase F §D11 design claims tenant hard-delete
+ * provides "crypto-shredding" of all per-tenant secrets. Warroom 2026-04-24 found
+ * that claim is false against the current derivation scheme:
+ *
+ * <ul>
+ *   <li>{@link KeyDerivationService} computes DEKs as
+ *       {@code HKDF-SHA256(master_KEK, tenantId_bytes, "fabt:v1:<tenantId>:<purpose>")}
+ *       — a pure function with zero persisted state.</li>
+ *   <li>The "crypto-shred" step as designed deletes {@code tenant_key_material} +
+ *       {@code kid_to_tenant_key}. That closes the happy-path decrypt
+ *       ({@link SecretEncryptionService#decryptForTenant} rejects unknown kids
+ *       per C-A3-1) but deletes nothing that an adversary actually needs.</li>
+ *   <li>An adversary with (a) the {@code FABT_ENCRYPTION_KEY} env value
+ *       (pg_dump + leaked .env, insider-threat, or process-dump scenario) and
+ *       (b) a copy of any pre-shred ciphertext can skip the envelope/kid
+ *       layer entirely, rederive the DEK via public HKDF, and recover the
+ *       plaintext in milliseconds. No registry row was needed.</li>
+ * </ul>
+ *
+ * <p><b>What this test asserts:</b> the adversary must NOT be able to recover
+ * the canary plaintext post-shred. This fails on current main because the
+ * derivation is deterministic; it will pass once F-6.0 implementation lands
+ * the per-tenant random DEK stored in {@code tenant_dek} + wrapped under a
+ * master-KEK-derived wrapping key (Option A — see 2026-04-24 warroom
+ * decision). At that point "delete the wrapped DEK row" actually destroys
+ * the only copy of the DEK and this test flips green.
+ *
+ * <p><b>Why {@code @Disabled}:</b> we want the test committed on main to
+ * document the gap (so any future reader of {@code shared/security} sees the
+ * red-state anchor in the test tree), but enabled on main it would break CI.
+ * Remove the annotation as part of the F-6.0 implementation commit that
+ * lands the real shred; the assertion will flip green at the same moment.
+ *
+ * <p><b>Run locally:</b>
+ * <pre>
+ *   mvn -q test -Dtest=CryptoShredGapIntegrationTest -DfailIfNoTests=false \
+ *       -pl backend -Dsurefire.skipAfterFailureCount=0 -Djunit.jupiter.conditions.deactivate=*
+ * </pre>
+ * The {@code conditions.deactivate=*} flag ignores the {@code @Disabled}
+ * annotation so the anchor actually runs. Confirm the "CRYPTO-SHRED GAP"
+ * assertion fires with the adversary-recovered canary in the failure message.
+ */
+@Disabled("""
+    F-6 TDD anchor — fails on main by design.
+    Removing this annotation is the last step of the F-6.0 implementation commit
+    that introduces per-tenant random DEKs stored in `tenant_dek`. At that point
+    the adversary's direct-HKDF path no longer recovers plaintext and the
+    assertion flips green. Keep this test disabled on main until then so CI
+    stays healthy; enable it locally with
+    -Djunit.jupiter.conditions.deactivate=* to verify the gap exists.
+    Verified red-state 2026-04-24 — assertion fires with recovered canary in
+    the failure message. See openspec/changes/multi-tenant-production-readiness
+    §D11, warroom 2026-04-24.
+    """)
+class CryptoShredGapIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private SecretEncryptionService encryption;
+    @Autowired private KeyDerivationService keyDerivation;
+    @Autowired private KidRegistryService kidRegistry;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    @Test
+    void cryptoShred_plaintextMustBeUnrecoverable_evenByDirectHkdfAdversary() throws Exception {
+        // ──────────────────────────────────────────────────────────────────
+        // 1. Seed a tenant, encrypt a canary under the v1 per-tenant path.
+        //    Uses TOTP purpose — the choice is arbitrary; every KeyPurpose
+        //    resolves through the same deterministic HKDF and has the same
+        //    gap.
+        // ──────────────────────────────────────────────────────────────────
+        UUID tenantId = authHelper.setupSecondaryTenant(
+                "shred-gap-" + UUID.randomUUID()).getId();
+        String canary = "SHRED-CANARY-" + UUID.randomUUID();
+
+        String ciphertext = encryption.encryptForTenant(tenantId, KeyPurpose.TOTP, canary);
+
+        // Pre-shred sanity: the happy path works.
+        String roundTripped = encryption.decryptForTenant(tenantId, KeyPurpose.TOTP, ciphertext);
+        assertThat(roundTripped)
+            .as("baseline: decryptForTenant must round-trip pre-shred")
+            .isEqualTo(canary);
+
+        // ──────────────────────────────────────────────────────────────────
+        // 2. Simulate the §D11 crypto-shred as designed today: drop every
+        //    registry row that ties kids to this tenant and evict the caches
+        //    that held the resolution. This is the exact set of writes
+        //    TenantLifecycleService.hardDelete will perform per the current
+        //    design draft.
+        // ──────────────────────────────────────────────────────────────────
+        UUID kidBeforeShred = kidRegistry.findOrCreateActiveKid(tenantId);
+
+        // RLS note: tenant_key_material + kid_to_tenant_key carry V68 row-level
+        // security. A bare DELETE from an unbound connection affects 0 rows —
+        // the RLS policies filter them out before the command runs. Bind
+        // app.tenant_id in a short tx so the DELETE matches what a privileged
+        // hardDelete() would do (the real service will use DB-owner
+        // credentials, but same net effect: rows must actually go away, not
+        // be silently hidden).
+        TransactionTemplate shredTx = new TransactionTemplate(transactionManager);
+        shredTx.executeWithoutResult(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantId.toString());
+            jdbc.update("DELETE FROM kid_to_tenant_key WHERE tenant_id = ?", tenantId);
+            jdbc.update("DELETE FROM tenant_key_material WHERE tenant_id = ?", tenantId);
+        });
+        kidRegistry.invalidateTenantActiveKid(tenantId);
+        kidRegistry.invalidateKidResolution(kidBeforeShred);
+
+        // ──────────────────────────────────────────────────────────────────
+        // 3. Happy-path decrypt is blocked — envelope check rejects the
+        //    now-unknown kid. This is what the §D11 design relied on to
+        //    claim crypto-shred. It IS a real protection for any caller
+        //    going through SecretEncryptionService.
+        // ──────────────────────────────────────────────────────────────────
+        assertThatThrownBy(() ->
+                encryption.decryptForTenant(tenantId, KeyPurpose.TOTP, ciphertext))
+            .as("post-shred: happy-path decrypt must fail at kid lookup")
+            .isInstanceOf(CrossTenantCiphertextException.class);
+
+        // ──────────────────────────────────────────────────────────────────
+        // 4. ADVERSARY SIMULATION — the real gap.
+        //
+        //    Model: attacker with access to FABT_ENCRYPTION_KEY (env dump,
+        //    .env file in a backup, process memory) and a pre-shred DB
+        //    backup containing `ciphertext`. Skips SecretEncryptionService
+        //    entirely; reconstructs the DEK directly from public inputs
+        //    (tenantId + purpose, both recoverable — tenantId lives in the
+        //    envelope's kid lookup or the backup's other tables; purpose
+        //    is implicit in which column the ciphertext came from).
+        //
+        //    Every piece of state the adversary uses here is either:
+        //      - public (envelope wire format, purpose string)
+        //      - in the backup (tenantId, ciphertext bytes)
+        //      - on the running host (master KEK)
+        //    None of it is in tenant_key_material or kid_to_tenant_key.
+        //    Deleting those rows therefore shreds nothing.
+        // ──────────────────────────────────────────────────────────────────
+        String adversaryRecovered = adversaryDirectHkdfDecrypt(tenantId, ciphertext);
+
+        // THE FAILING ASSERTION — the crypto-shred claim's core invariant.
+        //
+        // On current main: `adversaryRecovered` equals the canary → this
+        // assertion FAILS → the test body proves the gap with a concrete
+        // recovered string in the failure message.
+        //
+        // After F-6.0 Option A: the adversary's raw-HKDF path yields a
+        // key that doesn't match the ciphertext's real DEK (which now
+        // lives only in tenant_dek, wrapped, and was deleted during
+        // shred). The GCM auth tag fails, adversaryDirectHkdfDecrypt
+        // throws, the assertThatThrownBy variant would catch it — but
+        // to preserve the narrative symmetry, we assert the positive
+        // form: plaintext is not recoverable, regardless of whether
+        // that's via tag failure or any other mechanism.
+        assertThat(adversaryRecovered)
+            .as("""
+                CRYPTO-SHRED GAP: adversary recovered `%s` post-shred.
+                Current derivation is a pure function of master_KEK + tenantId
+                + purpose — none of which was destroyed by deleting
+                tenant_key_material + kid_to_tenant_key. See F-6.0 warroom
+                2026-04-24 for the per-tenant-random-DEK (Option A) fix.
+                """.formatted(canary))
+            .isNotEqualTo(canary);
+    }
+
+    // ─── Adversary helper ────────────────────────────────────────────────
+
+    /**
+     * Bypasses every layer of {@link SecretEncryptionService} and recovers
+     * plaintext from the v1 envelope using only:
+     * <ul>
+     *   <li>the master KEK (via the autowired {@link KeyDerivationService})</li>
+     *   <li>the tenantId (known to the adversary — lives in DB backups)</li>
+     *   <li>the purpose tag (here: "totp", a public string in
+     *       {@link KeyPurpose})</li>
+     *   <li>the envelope's own IV + ciphertext+tag</li>
+     * </ul>
+     * The adversary does NOT touch kid_to_tenant_key, tenant_key_material,
+     * or {@code SecretEncryptionService.decryptForTenant}. If this method
+     * returns the canary, the §D11 crypto-shred claim is false.
+     */
+    private String adversaryDirectHkdfDecrypt(UUID tenantId, String storedCiphertext)
+            throws Exception {
+        byte[] decoded = Base64.getDecoder().decode(storedCiphertext);
+        if (!EncryptionEnvelope.isV1Envelope(decoded)) {
+            throw new IllegalStateException(
+                    "test precondition: expected v1 envelope from encryptForTenant");
+        }
+        EncryptionEnvelope envelope = EncryptionEnvelope.decode(storedCiphertext);
+
+        // Raw HKDF — KeyPurpose.TOTP resolves to deriveTotpKey; using the
+        // typed accessor rather than reflection to keep the adversary's
+        // attack realistic: they don't need internals, they need the
+        // public derivation contract, which is documented in the class
+        // javadoc and stable across versions.
+        SecretKey directlyDerivedDek = keyDerivation.deriveTotpKey(tenantId);
+
+        Cipher cipher = Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(Cipher.DECRYPT_MODE, directlyDerivedDek,
+                new GCMParameterSpec(128, envelope.iv()));
+        byte[] plaintext = cipher.doFinal(envelope.ciphertextWithTag());
+        return new String(plaintext, java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java
@@ -12,7 +12,6 @@ import javax.crypto.spec.GCMParameterSpec;
 
 import org.fabt.BaseIntegrationTest;
 import org.fabt.TestAuthHelper;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
@@ -20,68 +19,39 @@ import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
 
 /**
- * F-6 TDD ANCHOR — pins the crypto-shred gap.
+ * F-6 CRYPTO-SHRED ANCHOR — pins the crypto-shred property.
  *
- * <p><b>Why this test exists:</b> the Phase F §D11 design claims tenant hard-delete
- * provides "crypto-shredding" of all per-tenant secrets. Warroom 2026-04-24 found
- * that claim is false against the current derivation scheme:
+ * <p><b>History:</b> this test started life (commit {@code b5672da}) as a
+ * red-state TDD anchor pinning the gap in the Phase A HKDF-DEK derivation:
+ * deleting {@code tenant_key_material} + {@code kid_to_tenant_key} closed
+ * the happy-path decrypt but destroyed nothing the adversary needed. An
+ * attacker with {@code FABT_ENCRYPTION_KEY} and any pre-shred ciphertext
+ * could rederive the DEK via public HKDF and recover plaintext in ms.
  *
- * <ul>
- *   <li>{@link KeyDerivationService} computes DEKs as
- *       {@code HKDF-SHA256(master_KEK, tenantId_bytes, "fabt:v1:<tenantId>:<purpose>")}
- *       — a pure function with zero persisted state.</li>
- *   <li>The "crypto-shred" step as designed deletes {@code tenant_key_material} +
- *       {@code kid_to_tenant_key}. That closes the happy-path decrypt
- *       ({@link SecretEncryptionService#decryptForTenant} rejects unknown kids
- *       per C-A3-1) but deletes nothing that an adversary actually needs.</li>
- *   <li>An adversary with (a) the {@code FABT_ENCRYPTION_KEY} env value
- *       (pg_dump + leaked .env, insider-threat, or process-dump scenario) and
- *       (b) a copy of any pre-shred ciphertext can skip the envelope/kid
- *       layer entirely, rederive the DEK via public HKDF, and recover the
- *       plaintext in milliseconds. No registry row was needed.</li>
- * </ul>
+ * <p><b>Post-F-6.0:</b> with V82 ({@code tenant_dek}) + V83 (re-encrypt) +
+ * V84 (CASCADE chain) + the {@code SecretEncryptionService} refactor +
+ * {@code TenantLifecycleService.hardDelete} all shipped, the test now
+ * PINS the property instead of pinning the gap. Adversary's raw-HKDF
+ * derivation path produces a key that doesn't match the ciphertext's
+ * real (random) DEK; GCM auth tag fails; plaintext is unrecoverable.
  *
- * <p><b>What this test asserts:</b> the adversary must NOT be able to recover
- * the canary plaintext post-shred. This fails on current main because the
- * derivation is deterministic; it will pass once F-6.0 implementation lands
- * the per-tenant random DEK stored in {@code tenant_dek} + wrapped under a
- * master-KEK-derived wrapping key (Option A — see 2026-04-24 warroom
- * decision). At that point "delete the wrapped DEK row" actually destroys
- * the only copy of the DEK and this test flips green.
+ * <p><b>What this test guards against:</b> a regression that puts the
+ * data-encryption path back on deterministic HKDF derivation. If
+ * {@code encryptForTenant} ever routes through {@link KeyDerivationService}
+ * directly again (bypassing {@link TenantDekService}), the adversary's
+ * path would start recovering canaries and this assertion fires with the
+ * recovered plaintext in the failure message.
  *
- * <p><b>Why {@code @Disabled}:</b> we want the test committed on main to
- * document the gap (so any future reader of {@code shared/security} sees the
- * red-state anchor in the test tree), but enabled on main it would break CI.
- * Remove the annotation as part of the F-6.0 implementation commit that
- * lands the real shred; the assertion will flip green at the same moment.
- *
- * <p><b>Run locally:</b>
- * <pre>
- *   mvn -q test -Dtest=CryptoShredGapIntegrationTest -DfailIfNoTests=false \
- *       -pl backend -Dsurefire.skipAfterFailureCount=0 -Djunit.jupiter.conditions.deactivate=*
- * </pre>
- * The {@code conditions.deactivate=*} flag ignores the {@code @Disabled}
- * annotation so the anchor actually runs. Confirm the "CRYPTO-SHRED GAP"
- * assertion fires with the adversary-recovered canary in the failure message.
+ * <p>See {@code openspec/changes/multi-tenant-production-readiness/design-f6-real-cryptoshred.md}
+ * §2 (threat model) + §11.1 (test strategy).
  */
-@Disabled("""
-    F-6 TDD anchor — fails on main by design.
-    Removing this annotation is the last step of the F-6.0 implementation commit
-    that introduces per-tenant random DEKs stored in `tenant_dek`. At that point
-    the adversary's direct-HKDF path no longer recovers plaintext and the
-    assertion flips green. Keep this test disabled on main until then so CI
-    stays healthy; enable it locally with
-    -Djunit.jupiter.conditions.deactivate=* to verify the gap exists.
-    Verified red-state 2026-04-24 — assertion fires with recovered canary in
-    the failure message. See openspec/changes/multi-tenant-production-readiness
-    §D11, warroom 2026-04-24.
-    """)
 class CryptoShredGapIntegrationTest extends BaseIntegrationTest {
 
     @Autowired private TestAuthHelper authHelper;
     @Autowired private SecretEncryptionService encryption;
     @Autowired private KeyDerivationService keyDerivation;
     @Autowired private KidRegistryService kidRegistry;
+    @Autowired private TenantDekService tenantDekService;
     @Autowired private JdbcTemplate jdbc;
     @Autowired private PlatformTransactionManager transactionManager;
 
@@ -106,30 +76,40 @@ class CryptoShredGapIntegrationTest extends BaseIntegrationTest {
             .isEqualTo(canary);
 
         // ──────────────────────────────────────────────────────────────────
-        // 2. Simulate the §D11 crypto-shred as designed today: drop every
-        //    registry row that ties kids to this tenant and evict the caches
-        //    that held the resolution. This is the exact set of writes
-        //    TenantLifecycleService.hardDelete will perform per the current
-        //    design draft.
+        // 2. Simulate the post-F-6.0 crypto-shred: destroy everything
+        //    TenantLifecycleService.hardDelete destroys. Under Option A
+        //    (V82+V83+V84) the shred surface is tenant_dek — the random
+        //    per-tenant DEK wrapped under an HKDF-derived key lives there
+        //    and nowhere else. Deleting the row destroys the only copy of
+        //    the DEK. The pre-F-6 registry rows (kid_to_tenant_key,
+        //    tenant_key_material) are also cleared to mirror the full
+        //    CASCADE chain a real `DELETE FROM tenant` would fire.
         // ──────────────────────────────────────────────────────────────────
         UUID kidBeforeShred = kidRegistry.findOrCreateActiveKid(tenantId);
 
-        // RLS note: tenant_key_material + kid_to_tenant_key carry V68 row-level
-        // security. A bare DELETE from an unbound connection affects 0 rows —
-        // the RLS policies filter them out before the command runs. Bind
-        // app.tenant_id in a short tx so the DELETE matches what a privileged
-        // hardDelete() would do (the real service will use DB-owner
-        // credentials, but same net effect: rows must actually go away, not
-        // be silently hidden).
+        // RLS + trigger guard: tenant_dek has both the V68-style RESTRICTIVE
+        // DELETE policy (requires app.tenant_id = tenant_id) AND a BEFORE
+        // DELETE trigger that requires fabt.shred_in_progress = tenant_id.
+        // Bind both GUCs in the same tx so the DELETE matches the exact
+        // posture hardDelete's CASCADE path provides.
         TransactionTemplate shredTx = new TransactionTemplate(transactionManager);
         shredTx.executeWithoutResult(status -> {
             jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
                 String.class, tenantId.toString());
+            jdbc.queryForObject("SELECT set_config('fabt.shred_in_progress', ?, true)",
+                String.class, tenantId.toString());
+            // Option A's shred surface — this is what carries the crypto-shred
+            // guarantee. Deleting these rows renders the wrapped DEKs
+            // unrecoverable.
+            jdbc.update("DELETE FROM tenant_dek WHERE tenant_id = ?", tenantId);
+            // Legacy registry rows — no longer hold data-encryption keys
+            // but still part of the CASCADE chain real hardDelete fires.
             jdbc.update("DELETE FROM kid_to_tenant_key WHERE tenant_id = ?", tenantId);
             jdbc.update("DELETE FROM tenant_key_material WHERE tenant_id = ?", tenantId);
         });
         kidRegistry.invalidateTenantActiveKid(tenantId);
         kidRegistry.invalidateKidResolution(kidBeforeShred);
+        tenantDekService.invalidateTenantDeks(tenantId);
 
         // ──────────────────────────────────────────────────────────────────
         // 3. Happy-path decrypt is blocked — envelope check rejects the
@@ -157,32 +137,40 @@ class CryptoShredGapIntegrationTest extends BaseIntegrationTest {
         //      - public (envelope wire format, purpose string)
         //      - in the backup (tenantId, ciphertext bytes)
         //      - on the running host (master KEK)
-        //    None of it is in tenant_key_material or kid_to_tenant_key.
-        //    Deleting those rows therefore shreds nothing.
+        //    Under Option A, the DEK lives only in tenant_dek (now deleted)
+        //    AND was random (not HKDF-derived). The adversary's HKDF-derive
+        //    path recomputes a DIFFERENT key than the ciphertext was
+        //    encrypted under — the GCM auth tag fails.
         // ──────────────────────────────────────────────────────────────────
-        String adversaryRecovered = adversaryDirectHkdfDecrypt(tenantId, ciphertext);
+        String adversaryRecovered;
+        try {
+            adversaryRecovered = adversaryDirectHkdfDecrypt(tenantId, ciphertext);
+        } catch (Exception tagFailure) {
+            // Under Option A the GCM tag check fails when the adversary's
+            // HKDF-derived key is applied to a ciphertext that was encrypted
+            // under a DIFFERENT (random) DEK. That IS the crypto-shred
+            // guarantee we want. Represent as a sentinel so the assertion
+            // below still uses the same shape (positive form: NOT the
+            // canary), and the failure message stays informative if
+            // something regresses.
+            adversaryRecovered = "(unrecoverable: " + tagFailure.getClass().getSimpleName() + ")";
+        }
 
-        // THE FAILING ASSERTION — the crypto-shred claim's core invariant.
+        // THE ANCHOR ASSERTION — the crypto-shred claim's core invariant.
         //
-        // On current main: `adversaryRecovered` equals the canary → this
-        // assertion FAILS → the test body proves the gap with a concrete
-        // recovered string in the failure message.
-        //
-        // After F-6.0 Option A: the adversary's raw-HKDF path yields a
-        // key that doesn't match the ciphertext's real DEK (which now
-        // lives only in tenant_dek, wrapped, and was deleted during
-        // shred). The GCM auth tag fails, adversaryDirectHkdfDecrypt
-        // throws, the assertThatThrownBy variant would catch it — but
-        // to preserve the narrative symmetry, we assert the positive
-        // form: plaintext is not recoverable, regardless of whether
-        // that's via tag failure or any other mechanism.
+        // Pre-Option A: adversaryRecovered == canary (gap). Now that V82 +
+        // V83 + V84 + TenantDekService are live, the shred actually destroys
+        // the DEK material and the adversary's HKDF-derive path hits a
+        // ciphertext it cannot decrypt.
         assertThat(adversaryRecovered)
             .as("""
-                CRYPTO-SHRED GAP: adversary recovered `%s` post-shred.
-                Current derivation is a pure function of master_KEK + tenantId
-                + purpose — none of which was destroyed by deleting
-                tenant_key_material + kid_to_tenant_key. See F-6.0 warroom
-                2026-04-24 for the per-tenant-random-DEK (Option A) fix.
+                CRYPTO-SHRED ANCHOR: adversary recovered `%s` post-shred.
+                Under Option A the data-encryption DEK was random (not HKDF),
+                lived only in tenant_dek, and was destroyed by the simulated
+                shred. If this assertion fails the recovered canary is the
+                regression signal — the gap has reopened. See
+                openspec/changes/multi-tenant-production-readiness/design-f6-real-cryptoshred.md
+                §2 threat model + §11.1 test strategy.
                 """.formatted(canary))
             .isNotEqualTo(canary);
     }

--- a/backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java
@@ -145,15 +145,17 @@ class CryptoShredGapIntegrationTest extends BaseIntegrationTest {
         String adversaryRecovered;
         try {
             adversaryRecovered = adversaryDirectHkdfDecrypt(tenantId, ciphertext);
-        } catch (Exception tagFailure) {
+        } catch (javax.crypto.BadPaddingException | javax.crypto.IllegalBlockSizeException gcmFailure) {
             // Under Option A the GCM tag check fails when the adversary's
             // HKDF-derived key is applied to a ciphertext that was encrypted
             // under a DIFFERENT (random) DEK. That IS the crypto-shred
-            // guarantee we want. Represent as a sentinel so the assertion
-            // below still uses the same shape (positive form: NOT the
-            // canary), and the failure message stays informative if
-            // something regresses.
-            adversaryRecovered = "(unrecoverable: " + tagFailure.getClass().getSimpleName() + ")";
+            // guarantee we want. BadPaddingException covers AEADBadTagException
+            // (subclass); IllegalBlockSizeException covers the padding-alignment
+            // failure path. Any OTHER exception (NPE from a refactor,
+            // Testcontainer timeout, etc.) is a genuine test bug and should
+            // propagate as an ERROR, not be silently coerced to "passed."
+            // Warroom pass-3 Jordan blocker fix.
+            adversaryRecovered = "(unrecoverable: " + gcmFailure.getClass().getSimpleName() + ")";
         }
 
         // THE ANCHOR ASSERTION — the crypto-shred claim's core invariant.

--- a/backend/src/test/java/org/fabt/shared/security/NTenantCanaryShredTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/NTenantCanaryShredTest.java
@@ -1,0 +1,219 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NoSuchElementException;
+import java.util.Random;
+import java.util.Set;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.tenant.service.TenantLifecycleService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * §11.2 of design-f6-real-cryptoshred — property-style crypto-shred
+ * regression suite.
+ *
+ * <p>On each of 10 seeds: create N tenants × 4 purposes (400 ciphertexts
+ * total), pick K random tenants to hard-delete, assert K × 4 ciphertexts
+ * are unrecoverable and (N−K) × 4 remain intact. N=10, K=2 per seed to
+ * keep CI under ~2 minutes while still exercising the distributional
+ * property Jordan's pass-1 warroom requested.
+ *
+ * <p>"Unrecoverable" here means: the happy-path decrypt via
+ * {@link SecretEncryptionService#decryptForTenant} throws, AND the
+ * adversary-bypass path (raw HKDF re-derivation + AES-GCM) throws on
+ * GCM auth-tag failure. Both conditions together prove that:
+ *
+ * <ul>
+ *   <li>The cache + envelope + RLS layers correctly filter the shredded
+ *       tenant's ciphertexts.</li>
+ *   <li>The underlying random DEK is actually destroyed — the adversary
+ *       with {@code master_KEK} + ciphertext cannot recompute a working
+ *       key, because the real DEK was random (not HKDF-derived) and
+ *       lived only in {@code tenant_dek} (now CASCADE-deleted).</li>
+ * </ul>
+ *
+ * <p>The 10-seed fan-out catches correlations that a single-path test
+ * would miss — e.g., a bug where shred of tenant A inadvertently deletes
+ * tenant B's DEK via some query-builder path, or where the adversary
+ * path succeeds only for specific tenantId bit patterns.
+ *
+ * <p>Retention-days=0 for the same reason as
+ * {@code TenantLifecycleHardDeleteIntegrationTest}: we're testing the
+ * crypto property, not the 30-day gate.
+ */
+@TestPropertySource(properties = {
+        "fabt.tenant.lifecycle.enabled=true",
+        "fabt.tenant.hard-delete.retention-days=0"
+})
+@DisplayName("N-tenant property-style crypto-shred regression (F-6.0 §11.2)")
+class NTenantCanaryShredTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private TenantLifecycleService lifecycleService;
+    @Autowired private TenantDekService tenantDekService;
+    @Autowired private SecretEncryptionService encryption;
+    @Autowired private KeyDerivationService keyDerivation;
+
+    /**
+     * 10 distinct PRNG seeds. Each run creates a fresh set of tenants
+     * + canaries, so cross-run state isn't a concern; the seed only
+     * controls which tenants get shredded.
+     */
+    @ParameterizedTest(name = "seed={0}")
+    @ValueSource(longs = {1L, 2L, 3L, 5L, 8L, 13L, 21L, 34L, 55L, 89L})
+    void shreddedTenants_areUnrecoverable_survivorsRoundTrip(long seed) throws Exception {
+        // N and K chosen so the test runs in ~10s per seed; adjust if CI
+        // budget tightens. The property-shape invariants hold for any
+        // N > K >= 1; the specific values exist only to bound wall-clock.
+        final int N = 10;
+        final int K = 2;
+        Random rng = new Random(seed);
+
+        List<UUID> tenants = new ArrayList<>();
+        // ciphertexts[tenantIndex][purposeOrdinal] = envelope string
+        Map<UUID, Map<KeyPurpose, String>> ciphertexts = new LinkedHashMap<>();
+        Map<UUID, Map<KeyPurpose, String>> canaries = new LinkedHashMap<>();
+        // purposes to exercise — the 4 data-encryption purposes (JWT_SIGN is
+        // rejected at the service boundary and has its own separate test).
+        KeyPurpose[] dataPurposes = {
+                KeyPurpose.TOTP, KeyPurpose.WEBHOOK_SECRET,
+                KeyPurpose.OAUTH2_CLIENT_SECRET, KeyPurpose.HMIS_API_KEY
+        };
+
+        for (int i = 0; i < N; i++) {
+            UUID tenantId = lifecycleService.create(
+                    "N-tenant-canary seed=" + seed + " idx=" + i,
+                    "ncanary-" + seed + "-" + i + "-" + UUID.randomUUID(),
+                    UUID.randomUUID()).getId();
+            tenants.add(tenantId);
+            Map<KeyPurpose, String> tenantCiphertexts = new LinkedHashMap<>();
+            Map<KeyPurpose, String> tenantCanaries = new LinkedHashMap<>();
+            for (KeyPurpose purpose : dataPurposes) {
+                String canary = "canary-" + seed + "-" + i + "-" + purpose + "-" + UUID.randomUUID();
+                tenantCanaries.put(purpose, canary);
+                tenantCiphertexts.put(purpose,
+                        encryption.encryptForTenant(tenantId, purpose, canary));
+            }
+            ciphertexts.put(tenantId, tenantCiphertexts);
+            canaries.put(tenantId, tenantCanaries);
+        }
+
+        // Pre-shred sanity: every tenant round-trips (catches encryption-
+        // refactor regressions before the shred step masks them).
+        for (UUID tenantId : tenants) {
+            for (KeyPurpose purpose : dataPurposes) {
+                String roundTripped = encryption.decryptForTenant(
+                        tenantId, purpose, ciphertexts.get(tenantId).get(purpose));
+                assertThat(roundTripped)
+                        .as("pre-shred: canary round-trips for tenant %s purpose %s",
+                                tenantId, purpose)
+                        .isEqualTo(canaries.get(tenantId).get(purpose));
+            }
+        }
+
+        // Pick K random tenants to shred. Use the seeded RNG so the
+        // specific failing-seed case is reproducible in CI logs.
+        List<UUID> shuffled = new ArrayList<>(tenants);
+        Collections.shuffle(shuffled, rng);
+        Set<UUID> victims = new HashSet<>(shuffled.subList(0, K));
+
+        UUID actor = UUID.randomUUID();
+        for (UUID victim : victims) {
+            lifecycleService.offboard(victim, actor, "n-tenant-canary-test");
+            lifecycleService.archive(victim, actor, "n-tenant-canary-test");
+            lifecycleService.hardDelete(victim, actor, "n-tenant-canary-test");
+        }
+
+        // ─── Invariant 1: victim ciphertexts unrecoverable ────────────────
+        // Both happy-path and adversary-bypass must fail for every
+        // (victim, purpose) combination.
+        for (UUID victim : victims) {
+            for (KeyPurpose purpose : dataPurposes) {
+                String ciphertext = ciphertexts.get(victim).get(purpose);
+
+                // Happy path — must throw. Under Option A post-shred this is
+                // NoSuchElementException-wrapped-as-CrossTenantCiphertextException
+                // (kid not in tenant_dek anymore) OR a RuntimeException if a
+                // downstream path differs; either way, not a clean decrypt.
+                assertThatThrownBy(() ->
+                        encryption.decryptForTenant(victim, purpose, ciphertext))
+                        .as("post-shred happy-path decrypt MUST throw for victim %s purpose %s seed=%d",
+                                victim, purpose, seed);
+
+                // Adversary path — raw HKDF re-derive + AES-GCM. Under
+                // Option A the random tenant_dek DEK was the actual
+                // encryption key; HKDF yields a DIFFERENT key, GCM tag
+                // fails with BadPaddingException (or subclass
+                // AEADBadTagException).
+                assertThatThrownBy(() -> adversaryHkdfDecrypt(victim, purpose, ciphertext))
+                        .as("post-shred adversary HKDF-bypass MUST throw for victim %s purpose %s seed=%d",
+                                victim, purpose, seed)
+                        .isInstanceOfAny(javax.crypto.BadPaddingException.class,
+                                javax.crypto.IllegalBlockSizeException.class);
+            }
+        }
+
+        // ─── Invariant 2: survivor ciphertexts still round-trip ──────────
+        // The shred must be surgical — only victims' DEKs destroyed, not
+        // survivors'. If a bug deleted the wrong DEK rows, survivor
+        // round-trips would fail here.
+        for (UUID tenantId : tenants) {
+            if (victims.contains(tenantId)) continue;
+            for (KeyPurpose purpose : dataPurposes) {
+                String ciphertext = ciphertexts.get(tenantId).get(purpose);
+                String roundTripped = encryption.decryptForTenant(
+                        tenantId, purpose, ciphertext);
+                assertThat(roundTripped)
+                        .as("post-shred: survivor %s purpose %s must still round-trip (seed=%d)",
+                                tenantId, purpose, seed)
+                        .isEqualTo(canaries.get(tenantId).get(purpose));
+            }
+        }
+    }
+
+    /**
+     * Adversary helper — bypasses {@link SecretEncryptionService} entirely
+     * and attempts raw HKDF-derive + AES-GCM decrypt against the v1 envelope.
+     * Models a pg_dump + leaked-env-var attacker. Under Option A this path
+     * FAILS because the real encryption DEK was random (not HKDF), and lived
+     * only in the tenant_dek row that was CASCADE-deleted.
+     */
+    private String adversaryHkdfDecrypt(UUID tenantId, KeyPurpose purpose,
+                                         String storedCiphertext) throws Exception {
+        byte[] decoded = Base64.getDecoder().decode(storedCiphertext);
+        if (!EncryptionEnvelope.isV1Envelope(decoded)) {
+            throw new IllegalStateException(
+                    "test precondition: encryptForTenant should have produced v1 envelope");
+        }
+        EncryptionEnvelope envelope = EncryptionEnvelope.decode(storedCiphertext);
+        javax.crypto.SecretKey hkdfKey = switch (purpose) {
+            case TOTP -> keyDerivation.deriveTotpKey(tenantId);
+            case WEBHOOK_SECRET -> keyDerivation.deriveWebhookSecretKey(tenantId);
+            case OAUTH2_CLIENT_SECRET -> keyDerivation.deriveOauth2ClientSecretKey(tenantId);
+            case HMIS_API_KEY -> keyDerivation.deriveHmisApiKey(tenantId);
+            case JWT_SIGN -> throw new IllegalStateException(
+                    "JWT_SIGN is not a data-encryption purpose");
+        };
+        javax.crypto.Cipher cipher = javax.crypto.Cipher.getInstance("AES/GCM/NoPadding");
+        cipher.init(javax.crypto.Cipher.DECRYPT_MODE, hkdfKey,
+                new javax.crypto.spec.GCMParameterSpec(128, envelope.iv()));
+        byte[] plaintext = cipher.doFinal(envelope.ciphertextWithTag());
+        return new String(plaintext, java.nio.charset.StandardCharsets.UTF_8);
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/NTenantCanaryShredTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/NTenantCanaryShredTest.java
@@ -19,10 +19,15 @@ import org.fabt.BaseIntegrationTest;
 import org.fabt.TestAuthHelper;
 import org.fabt.tenant.service.TenantLifecycleService;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
+
+import java.nio.file.Path;
 
 /**
  * §11.2 of design-f6-real-cryptoshred — property-style crypto-shred
@@ -63,6 +68,19 @@ import org.springframework.test.context.TestPropertySource;
 })
 @DisplayName("N-tenant property-style crypto-shred regression (F-6.0 §11.2)")
 class NTenantCanaryShredTest extends BaseIntegrationTest {
+
+    // Override fabt.tenant.offboard.export-path so each test run writes to
+    // an OS-appropriate tmpdir instead of the prod default /var/fabt/exports
+    // (which on a Linux CI runner requires root to create). Matches the
+    // pattern in TenantLifecycleHardDeleteIntegrationTest + TenantLifecycle-
+    // OffboardArchiveIntegrationTest.
+    @TempDir
+    static Path tempExportRoot;
+
+    @DynamicPropertySource
+    static void exportPath(DynamicPropertyRegistry registry) {
+        registry.add("fabt.tenant.offboard.export-path", () -> tempExportRoot.toString());
+    }
 
     @Autowired private TestAuthHelper authHelper;
     @Autowired private TenantLifecycleService lifecycleService;

--- a/backend/src/test/java/org/fabt/shared/security/PerTenantEncryptionIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/PerTenantEncryptionIntegrationTest.java
@@ -215,17 +215,23 @@ class PerTenantEncryptionIntegrationTest extends BaseIntegrationTest {
     // ------------------------------------------------------------------
 
     @Test
-    @DisplayName("T6 — encrypting under one purpose and decrypting under another fails on GCM auth tag")
+    @DisplayName("T6 — encrypting under one purpose and decrypting under another throws PurposeMismatchException")
     void purposeMismatchFailsCleanly() {
         String plaintext = "tag-protection-" + UUID.randomUUID();
         String stored = encryption.encryptForTenant(tenantA, KeyPurpose.TOTP, plaintext);
 
-        // Same tenant, same kid in the envelope, but different purpose -> different DEK
-        // -> GCM auth tag fails -> RuntimeException ("Failed to decrypt v1 ciphertext...")
-        RuntimeException ex = assertThrows(RuntimeException.class,
+        // Same tenant, envelope kid resolves to this tenant's TOTP DEK. Decrypting
+        // with WEBHOOK_SECRET would have used a different DEK under Option A — the
+        // refactored decryptForTenant catches this upstream of the GCM tag check
+        // and raises PurposeMismatchException with the expected vs actual purposes.
+        // Pre-F-6 this surfaced as a generic RuntimeException from GCM tag failure.
+        PurposeMismatchException ex = assertThrows(PurposeMismatchException.class,
                 () -> encryption.decryptForTenant(tenantA, KeyPurpose.WEBHOOK_SECRET, stored));
-        assertTrue(ex.getMessage().contains("Failed to decrypt"),
-                "must be a decrypt-side failure, was: " + ex.getMessage());
+        assertEquals(KeyPurpose.WEBHOOK_SECRET, ex.getExpectedPurpose(),
+                "expectedPurpose is what the caller asked for");
+        assertEquals(KeyPurpose.TOTP, ex.getActualPurpose(),
+                "actualPurpose is the tenant_dek row's recorded purpose");
+        assertEquals(tenantA, ex.getTenantId(), "tenantId carried for forensics");
     }
 
     // ------------------------------------------------------------------

--- a/backend/src/test/java/org/fabt/shared/security/TenantDekRlsTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/TenantDekRlsTest.java
@@ -1,0 +1,205 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * §11.4 of design-f6-real-cryptoshred — pins the PERMISSIVE+RESTRICTIVE
+ * RLS policy pair on {@code tenant_dek} (V82) plus the BEFORE DELETE
+ * trigger guard (V82 §3 Q-F6-6).
+ *
+ * <p>Six assertions, one per cross-tenant write path + the trigger
+ * negative case:
+ *
+ * <ol>
+ *   <li>PERMISSIVE SELECT is not tenant-scoped — binding A can SELECT
+ *       B's rows. Safe because tenant_dek.kid is opaque (UUID);
+ *       enumeration yields no tenant-identifying information, and
+ *       decrypt path needs to read BEFORE TenantContext binds.</li>
+ *   <li>INSERT with tenant_id=B while bound to A is REJECTED
+ *       (RESTRICTIVE INSERT gates on fabt_current_tenant_id).</li>
+ *   <li>UPDATE of B's rows while bound to A affects 0 rows
+ *       (RESTRICTIVE UPDATE narrows the USING clause).</li>
+ *   <li>DELETE of B's rows while bound to A affects 0 rows
+ *       (RESTRICTIVE DELETE narrows the USING clause). Note: even
+ *       before the RESTRICTIVE narrow, the trigger guard would raise
+ *       too — this test proves the RLS layer filters first.</li>
+ *   <li>DELETE of A's rows without {@code app.tenant_id} bound
+ *       affects 0 rows (RESTRICTIVE DELETE's USING evaluates
+ *       fabt_current_tenant_id as NULL → policy rejects).</li>
+ *   <li>DELETE of A's rows with app.tenant_id bound BUT without the
+ *       shred GUC raises the trigger guard (SQLSTATE P0001).</li>
+ * </ol>
+ *
+ * <p>Test isolation via per-test unique tenants (setupSecondaryTenant
+ * with UUID-suffixed slug) so other test classes in the shared
+ * Testcontainer can't pollute the assertions.
+ */
+@DisplayName("tenant_dek RLS + trigger guard (F-6.0 §11.4)")
+class TenantDekRlsTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private TenantDekService tenantDekService;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private UUID tenantA;
+    private UUID tenantB;
+    private UUID tenantAKid;
+
+    @BeforeEach
+    void setUp() {
+        tenantA = authHelper.setupSecondaryTenant("dek-rls-a-" + UUID.randomUUID()).getId();
+        tenantB = authHelper.setupSecondaryTenant("dek-rls-b-" + UUID.randomUUID()).getId();
+        // Seed both tenants with a TOTP DEK so every RLS check has a target row.
+        tenantAKid = tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP).kid();
+        tenantDekService.getOrCreateActiveDek(tenantB, KeyPurpose.TOTP);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 1 — PERMISSIVE SELECT: bound to A, can still SELECT B
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("1. PERMISSIVE SELECT — bound to tenant A, SELECT of tenant B's rows returns rows")
+    void permissiveSelect_visibleAcrossTenants() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        Integer countB = tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantA.toString());
+            return jdbc.queryForObject(
+                "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ?",
+                Integer.class, tenantB);
+        });
+        assertThat(countB)
+            .as("PERMISSIVE SELECT policy lets bound-tenant A see tenant B rows "
+                + "— kids are opaque UUIDs, no enumeration risk")
+            .isGreaterThanOrEqualTo(1);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 2 — RESTRICTIVE INSERT: bound to A, INSERT with tenant_id=B rejected
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("2. RESTRICTIVE INSERT — bound to tenant A, INSERT of tenant B row rejected")
+    void restrictiveInsert_rejectsCrossTenantRow() {
+        UUID newKid = UUID.randomUUID();
+        byte[] fakeWrapped = new byte[40];  // 32-byte DEK → 40-byte AES-KWP output
+
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        assertThatThrownBy(() -> tx.executeWithoutResult(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantA.toString());
+            jdbc.update(
+                "INSERT INTO tenant_dek (kid, tenant_id, purpose, generation, wrapped_dek, active) "
+                + "VALUES (?, ?, 'WEBHOOK_SECRET', 1, ?, TRUE)",
+                newKid, tenantB, fakeWrapped);
+        }))
+            .as("RESTRICTIVE INSERT policy must reject tenant_id=B when bound to A — "
+                + "Spring surfaces SQLSTATE 42501 / RLS rejection as a DataAccessException "
+                + "(BadSqlGrammarException on Postgres driver)")
+            .isInstanceOf(org.springframework.dao.DataAccessException.class);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 3 — RESTRICTIVE UPDATE: bound to A, UPDATE of B's rows affects 0
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("3. RESTRICTIVE UPDATE — bound to tenant A, UPDATE of tenant B rows affects 0 rows")
+    void restrictiveUpdate_narrowsToBoundTenant() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        Integer rowsAffected = tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantA.toString());
+            return jdbc.update(
+                "UPDATE tenant_dek SET rotated_at = clock_timestamp() "
+                + "WHERE tenant_id = ? AND active = FALSE",  // active=FALSE so CHECK is consistent
+                tenantB);
+        });
+        assertThat(rowsAffected)
+            .as("RESTRICTIVE UPDATE narrows to rows where tenant_id = fabt_current_tenant_id()")
+            .isEqualTo(0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 4 — RESTRICTIVE DELETE: bound to A, DELETE of B's rows affects 0
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("4. RESTRICTIVE DELETE — bound to tenant A, DELETE of tenant B rows affects 0 rows")
+    void restrictiveDelete_narrowsToBoundTenant() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        Integer rowsAffected = tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantA.toString());
+            // Also set shred GUC to B — the trigger would pass IF the RLS
+            // DELETE policy let the row through. The RLS narrow should filter
+            // it out first, so we never reach the trigger. 0 rows affected.
+            jdbc.queryForObject("SELECT set_config('fabt.shred_in_progress', ?, true)",
+                String.class, tenantB.toString());
+            return jdbc.update("DELETE FROM tenant_dek WHERE tenant_id = ?", tenantB);
+        });
+        assertThat(rowsAffected)
+            .as("RESTRICTIVE DELETE filters before the trigger fires — 0 rows affected")
+            .isEqualTo(0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 5 — Unbound DELETE: no app.tenant_id, RESTRICTIVE narrows to 0
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("5. Unbound DELETE — no app.tenant_id, DELETE of A's rows affects 0 rows")
+    void unboundDelete_affectsZeroRows() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        Integer rowsAffected = tx.execute(status -> {
+            // Explicit empty binding — matches the posture of an unbound
+            // session (fabt_current_tenant_id() returns NULL per V67).
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', '', true)",
+                String.class);
+            return jdbc.update("DELETE FROM tenant_dek WHERE tenant_id = ?", tenantA);
+        });
+        assertThat(rowsAffected)
+            .as("RESTRICTIVE DELETE's USING evaluates fabt_current_tenant_id() as NULL "
+                + "(app.tenant_id unset) — no row matches, 0 rows affected")
+            .isEqualTo(0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 6 — Trigger guard: bound to A, DELETE A's row without shred GUC raises
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("6. Trigger guard — DELETE of A's rows with app.tenant_id bound but no shred GUC raises P0001")
+    void triggerGuard_raisesWhenShredGucMissing() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        assertThatThrownBy(() -> tx.executeWithoutResult(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantA.toString());
+            // Deliberately DO NOT set fabt.shred_in_progress. The RLS
+            // RESTRICTIVE DELETE now lets the row through (tenant_id matches
+            // bound tenant), so the trigger fires and raises.
+            jdbc.update("DELETE FROM tenant_dek WHERE tenant_id = ?", tenantA);
+        }))
+            .as("BEFORE DELETE trigger must raise when fabt.shred_in_progress is unset")
+            .isInstanceOfAny(DataIntegrityViolationException.class,
+                org.springframework.jdbc.UncategorizedSQLException.class,
+                org.springframework.dao.DataAccessException.class)
+            .hasMessageContaining("tenant_dek row deletion attempted outside hardDelete");
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/TenantDekServiceIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/TenantDekServiceIntegrationTest.java
@@ -1,0 +1,290 @@
+package org.fabt.shared.security;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.UUID;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * End-to-end tests for {@link TenantDekService} against the V82 {@code tenant_dek}
+ * table. Exercises the Option A crypto-shred foundation: random DEK generation,
+ * AES-KWP wrap/unwrap, race-safe first-encrypt, cache behavior, and tenant
+ * invalidation.
+ *
+ * <p>This is a subset of the §11 test suite (Jordan's 7-test minimum) — the
+ * parts that can be verified with just V82 + {@code TenantDekService} in
+ * place. The downstream tests ({@code NTenantCanaryShredTest},
+ * {@code TenantDekRlsTest}, {@code TenantDekShredGuardTest}) land alongside
+ * their dependent components in tasks 11.2 / 11.4 / 11.7.
+ */
+class TenantDekServiceIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private TenantDekService tenantDekService;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private UUID tenantA;
+    private UUID tenantB;
+
+    @BeforeEach
+    void setUp() {
+        // Each test gets fresh, isolated tenants. The suite runs in a shared
+        // Testcontainer and other tests (within this class and elsewhere) can
+        // leave state in tenant_dek for the default "test-tenant" slug —
+        // see feedback_isolated_test_data. Per-test UUIDs eliminate cross-test
+        // pollution entirely.
+        tenantA = authHelper.setupSecondaryTenant("dek-it-a-" + UUID.randomUUID()).getId();
+        tenantB = authHelper.setupSecondaryTenant("dek-it-b-" + UUID.randomUUID()).getId();
+    }
+
+    // ------------------------------------------------------------------
+    // T1 — first call creates row; DEK is random + wrapped on disk
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getOrCreateActiveDek inserts a tenant_dek row on first call; wrapped_dek is 40 bytes")
+    void firstEncryptCreatesRow() {
+        TenantDekService.ActiveDek active =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP);
+
+        assertThat(active.kid()).isNotNull();
+        assertThat(active.generation()).isEqualTo(1);
+        assertThat(active.dek()).isNotNull();
+        assertThat(active.dek().getEncoded()).hasSize(32);  // AES-256
+
+        // Row present in DB. wrapped_dek size = 40 bytes for a 32-byte DEK per RFC 5649.
+        Integer wrappedLen = jdbc.queryForObject(
+            "SELECT length(wrapped_dek) FROM tenant_dek WHERE kid = ?",
+            Integer.class, active.kid());
+        assertThat(wrappedLen).as("AES-KWP output for 32-byte DEK is 40 bytes").isEqualTo(40);
+
+        String purpose = jdbc.queryForObject(
+            "SELECT purpose FROM tenant_dek WHERE kid = ?",
+            String.class, active.kid());
+        assertThat(purpose).isEqualTo("TOTP");
+    }
+
+    // ------------------------------------------------------------------
+    // T2 — idempotent: second call for same (tenant, purpose) returns same kid
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("getOrCreateActiveDek is idempotent — second call returns same kid + same DEK bytes")
+    void idempotentForSameTenantPurpose() {
+        TenantDekService.ActiveDek first =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP);
+        TenantDekService.ActiveDek second =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP);
+
+        assertThat(second.kid()).isEqualTo(first.kid());
+        assertThat(second.generation()).isEqualTo(first.generation());
+        assertThat(second.dek().getEncoded()).containsExactly(first.dek().getEncoded());
+
+        // Exactly one row in DB — not two rows with same kid collided through some path.
+        Integer rowCount = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ? AND purpose = ?",
+            Integer.class, tenantA, "TOTP");
+        assertThat(rowCount).isEqualTo(1);
+    }
+
+    // ------------------------------------------------------------------
+    // T3 — different purposes get different DEKs + different kids for same tenant
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("different purposes yield different kids + different DEKs for same tenant")
+    void purposesIsolatedPerTenant() {
+        TenantDekService.ActiveDek totp =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP);
+        TenantDekService.ActiveDek webhook =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.WEBHOOK_SECRET);
+        TenantDekService.ActiveDek oauth =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.OAUTH2_CLIENT_SECRET);
+        TenantDekService.ActiveDek hmis =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.HMIS_API_KEY);
+
+        // All 4 kids distinct
+        assertThat(List.of(totp.kid(), webhook.kid(), oauth.kid(), hmis.kid()))
+            .doesNotHaveDuplicates();
+
+        // All 4 DEK byte arrays distinct (random — not HKDF-derived)
+        assertThat(totp.dek().getEncoded()).isNotEqualTo(webhook.dek().getEncoded());
+        assertThat(totp.dek().getEncoded()).isNotEqualTo(oauth.dek().getEncoded());
+        assertThat(totp.dek().getEncoded()).isNotEqualTo(hmis.dek().getEncoded());
+        assertThat(webhook.dek().getEncoded()).isNotEqualTo(oauth.dek().getEncoded());
+    }
+
+    // ------------------------------------------------------------------
+    // T4 — different tenants get different DEKs for same purpose
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("different tenants yield different kids + different DEKs for same purpose")
+    void tenantsIsolated() {
+        TenantDekService.ActiveDek a =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP);
+        TenantDekService.ActiveDek b =
+            tenantDekService.getOrCreateActiveDek(tenantB, KeyPurpose.TOTP);
+
+        assertThat(a.kid()).isNotEqualTo(b.kid());
+        assertThat(a.dek().getEncoded()).isNotEqualTo(b.dek().getEncoded());
+    }
+
+    // ------------------------------------------------------------------
+    // T5 — resolveDek returns correct ResolvedDek + same DEK bytes
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("resolveDek returns the same tenant, purpose, generation, and DEK bytes as getOrCreateActiveDek")
+    void resolveDekRoundTrip() {
+        TenantDekService.ActiveDek active =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.OAUTH2_CLIENT_SECRET);
+
+        TenantDekService.ResolvedDek resolved =
+            tenantDekService.resolveDek(active.kid());
+
+        assertThat(resolved.kid()).isEqualTo(active.kid());
+        assertThat(resolved.tenantId()).isEqualTo(tenantA);
+        assertThat(resolved.purpose()).isEqualTo(KeyPurpose.OAUTH2_CLIENT_SECRET);
+        assertThat(resolved.generation()).isEqualTo(1);
+        assertThat(resolved.dek().getEncoded()).containsExactly(active.dek().getEncoded());
+    }
+
+    // ------------------------------------------------------------------
+    // T6 — resolveDek throws NoSuchElementException for unknown kid
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("resolveDek throws NoSuchElementException for an unregistered kid")
+    void resolveDekThrowsForUnknownKid() {
+        UUID neverRegistered = UUID.randomUUID();
+
+        assertThatThrownBy(() -> tenantDekService.resolveDek(neverRegistered))
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessageContaining(neverRegistered.toString());
+    }
+
+    // ------------------------------------------------------------------
+    // T7 — invalidateTenantDeks evicts both caches
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("invalidateTenantDeks evicts both activeDek and resolvedDek caches for the tenant")
+    void invalidateTenantDeksEvictsBothCaches() {
+        // 1. Prime both caches for tenantA
+        TenantDekService.ActiveDek active =
+            tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP);
+        tenantDekService.resolveDek(active.kid());
+
+        // 2. Also prime tenantB — we want to assert tenantB's caches are NOT touched
+        TenantDekService.ActiveDek activeB =
+            tenantDekService.getOrCreateActiveDek(tenantB, KeyPurpose.WEBHOOK_SECRET);
+        tenantDekService.resolveDek(activeB.kid());
+
+        // 3. DELETE tenantA's row out of band so the next cache-bypassing read
+        //    would throw. All three statements (set_config × 2 + DELETE)
+        //    must live in ONE transaction so the tx-local GUCs are visible
+        //    to the DELETE — set_config(..., true) is wiped at commit, and
+        //    JdbcTemplate runs each call in its own auto-commit tx by default.
+        //    V82's RESTRICTIVE DELETE policy needs app.tenant_id bound; the
+        //    trigger guard needs fabt.shred_in_progress bound to the same id.
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        Integer deleted = tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantA.toString());
+            jdbc.queryForObject("SELECT set_config('fabt.shred_in_progress', ?, true)",
+                String.class, tenantA.toString());
+            return jdbc.update("DELETE FROM tenant_dek WHERE tenant_id = ?", tenantA);
+        });
+        assertThat(deleted).as("out-of-band DELETE must succeed under bound GUCs").isEqualTo(1);
+
+        // 4. WITHOUT invalidation: cache still serves stale resolved entry
+        //    (demonstrates the cache DOES cache — otherwise the next test
+        //    step wouldn't be meaningful).
+        TenantDekService.ResolvedDek stillCached =
+            tenantDekService.resolveDek(active.kid());
+        assertThat(stillCached.tenantId())
+            .as("stale-cache demonstration: cache still returns the ResolvedDek pre-invalidation")
+            .isEqualTo(tenantA);
+
+        // 5. Invalidate tenantA only.
+        tenantDekService.invalidateTenantDeks(tenantA);
+
+        // 6. tenantA's resolveDek now misses the cache, tries the DB, fails.
+        assertThatThrownBy(() -> tenantDekService.resolveDek(active.kid()))
+            .as("post-invalidation, resolveDek misses cache and raises on missing row")
+            .isInstanceOf(NoSuchElementException.class);
+
+        // 7. tenantB's cache must remain intact (invalidation was tenant-scoped).
+        TenantDekService.ResolvedDek resolvedB =
+            tenantDekService.resolveDek(activeB.kid());
+        assertThat(resolvedB.tenantId()).isEqualTo(tenantB);
+    }
+
+    // ------------------------------------------------------------------
+    // T8 — race safety: concurrent first-encrypts converge on one row
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("10 concurrent first-encrypts on a fresh tenant+purpose converge on exactly one tenant_dek row")
+    void raceSafetyOnFirstEncrypt() throws Exception {
+        UUID freshTenant = authHelper.setupSecondaryTenant(
+            "dek-race-" + UUID.randomUUID()).getId();
+
+        int threads = 10;
+        ExecutorService pool = Executors.newFixedThreadPool(threads);
+        CountDownLatch ready = new CountDownLatch(threads);
+        CountDownLatch start = new CountDownLatch(1);
+        List<UUID> observedKids = java.util.Collections.synchronizedList(new ArrayList<>());
+
+        for (int i = 0; i < threads; i++) {
+            pool.submit(() -> {
+                ready.countDown();
+                try {
+                    start.await();
+                    TenantDekService.ActiveDek a = tenantDekService.getOrCreateActiveDek(
+                        freshTenant, KeyPurpose.WEBHOOK_SECRET);
+                    observedKids.add(a.kid());
+                } catch (InterruptedException ie) {
+                    Thread.currentThread().interrupt();
+                }
+            });
+        }
+        ready.await();
+        start.countDown();
+        pool.shutdown();
+        assertThat(pool.awaitTermination(15, TimeUnit.SECONDS))
+            .as("race threads finish within 15s")
+            .isTrue();
+
+        assertThat(observedKids).hasSize(threads);
+        UUID convergedKid = observedKids.get(0);
+        assertThat(observedKids)
+            .as("all 10 threads must converge on the same kid via ON CONFLICT DO NOTHING")
+            .containsOnly(convergedKid);
+
+        // Exactly one row in tenant_dek for (freshTenant, WEBHOOK_SECRET)
+        Integer rowCount = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ? AND purpose = ?",
+            Integer.class, freshTenant, "WEBHOOK_SECRET");
+        assertThat(rowCount).isEqualTo(1);
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/TenantDekShredGuardTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/TenantDekShredGuardTest.java
@@ -1,0 +1,164 @@
+package org.fabt.shared.security;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.service.TenantLifecycleService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * §11.7 of design-f6-real-cryptoshred — trigger-guard semantics for
+ * {@code tenant_dek_shred_guard} (V82 §3).
+ *
+ * <p>Three cases:
+ *
+ * <ol>
+ *   <li><b>Positive</b> — {@code hardDelete} succeeds: tenant row deleted,
+ *       CASCADE fires, trigger guard allows the tenant_dek DELETE because
+ *       hardDelete bound {@code fabt.shred_in_progress} before firing.</li>
+ *   <li><b>No GUC</b> — DELETE attempted as {@code fabt_app} without
+ *       setting {@code fabt.shred_in_progress}: trigger raises SQLSTATE
+ *       {@code P0001} with the expected message.</li>
+ *   <li><b>Cross-tenant GUC poisoning</b> — attacker sets
+ *       {@code fabt.shred_in_progress} to tenant A but tries to DELETE
+ *       tenant B's rows: trigger's {@code IS DISTINCT FROM} equality check
+ *       still raises.</li>
+ * </ol>
+ *
+ * <p>The happy-path already has coverage via
+ * {@link org.fabt.tenant.service.TenantLifecycleHardDeleteIntegrationTest}
+ * T1 — this class focuses on the adversarial paths Jordan's pass-2
+ * warroom flagged.
+ *
+ * <p>Retention window overridden to 0 days so the positive case can exercise
+ * a complete lifecycle without time-travel.
+ */
+@TestPropertySource(properties = {
+        "fabt.tenant.lifecycle.enabled=true",
+        "fabt.tenant.hard-delete.retention-days=0"
+})
+@DisplayName("tenant_dek trigger-guard — positive + no-GUC + cross-tenant-poisoning (F-6.0 §11.7)")
+class TenantDekShredGuardTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private TenantLifecycleService lifecycleService;
+    @Autowired private TenantDekService tenantDekService;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    private UUID tenantA;
+    private UUID tenantB;
+
+    @BeforeEach
+    void setUp() {
+        tenantA = authHelper.setupSecondaryTenant(
+            "dek-guard-a-" + UUID.randomUUID()).getId();
+        tenantB = authHelper.setupSecondaryTenant(
+            "dek-guard-b-" + UUID.randomUUID()).getId();
+        // Seed a DEK for each so every case has a row to operate on.
+        tenantDekService.getOrCreateActiveDek(tenantA, KeyPurpose.TOTP);
+        tenantDekService.getOrCreateActiveDek(tenantB, KeyPurpose.TOTP);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 1 — Positive: hardDelete succeeds, CASCADE fires through the guard
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("1. POSITIVE — hardDelete binds fabt.shred_in_progress, CASCADE to tenant_dek passes the guard")
+    void positive_hardDelete_cascadeFiresThroughGuard() {
+        // Build tenant C (fresh per-test) and drive through the full
+        // lifecycle. tenantA / tenantB are seeded for negative cases only;
+        // we don't want to delete them here.
+        UUID tenantC = lifecycleService.create("Shred Guard Positive", "guard-" + UUID.randomUUID(), UUID.randomUUID()).getId();
+        UUID actor = UUID.randomUUID();
+
+        tenantDekService.getOrCreateActiveDek(tenantC, KeyPurpose.TOTP);
+        assertThat(countTenantDekRows(tenantC)).isGreaterThanOrEqualTo(1);
+
+        lifecycleService.offboard(tenantC, actor, "test-offboard");
+        lifecycleService.archive(tenantC, actor, "test-archive");
+        lifecycleService.hardDelete(tenantC, actor, "test-shred");
+
+        // Trigger allowed the CASCADE; rows are gone.
+        assertThat(countTenantDekRows(tenantC))
+            .as("positive path: trigger guard permits CASCADE DELETE when "
+                + "fabt.shred_in_progress matches OLD.tenant_id")
+            .isEqualTo(0);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 2 — No GUC: bound to A, DELETE A's row without shred GUC → P0001
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("2. NO-GUC — bound to A, DELETE A's tenant_dek row without shred GUC raises P0001")
+    void negative_noShredGuc_raisesP0001() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        assertThatThrownBy(() -> tx.executeWithoutResult(status -> {
+            // Bind app.tenant_id so the RLS RESTRICTIVE DELETE allows the row
+            // through. WITHOUT binding fabt.shred_in_progress, the trigger
+            // should raise when it fires BEFORE DELETE.
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantA.toString());
+            // Shred GUC explicitly left unset here.
+            jdbc.update("DELETE FROM tenant_dek WHERE tenant_id = ?", tenantA);
+        }))
+            .as("trigger must raise when fabt.shred_in_progress is unset "
+                + "even though RLS would otherwise permit the DELETE")
+            .hasMessageContaining("tenant_dek row deletion attempted outside hardDelete");
+
+        // Tenant A's row must still exist — the tx rolled back on the raise.
+        assertThat(countTenantDekRows(tenantA))
+            .as("failed DELETE must not remove the row")
+            .isGreaterThanOrEqualTo(1);
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // 3 — Cross-tenant GUC poisoning: shred GUC=A, DELETE B → P0001
+    // ──────────────────────────────────────────────────────────────────
+
+    @Test
+    @DisplayName("3. CROSS-TENANT GUC POISONING — shred GUC set to A but DELETE of B's row still raises")
+    void negative_crossTenantGucPoisoning_raisesP0001() {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        assertThatThrownBy(() -> tx.executeWithoutResult(status -> {
+            // Bind RLS to B so the RESTRICTIVE DELETE lets B's row through.
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantB.toString());
+            // But set the shred GUC to A (the poisoning). Trigger's
+            // IS DISTINCT FROM equality check must reject because
+            // current_setting('fabt.shred_in_progress') != OLD.tenant_id.
+            jdbc.queryForObject("SELECT set_config('fabt.shred_in_progress', ?, true)",
+                String.class, tenantA.toString());
+            jdbc.update("DELETE FROM tenant_dek WHERE tenant_id = ?", tenantB);
+        }))
+            .as("trigger must raise when fabt.shred_in_progress is set to a "
+                + "different tenant than OLD.tenant_id (cross-tenant GUC poisoning)")
+            .hasMessageContaining("tenant_dek row deletion attempted outside hardDelete");
+
+        // Tenant B's row must still exist.
+        assertThat(countTenantDekRows(tenantB))
+            .as("failed DELETE must not remove the row")
+            .isGreaterThanOrEqualTo(1);
+    }
+
+    private int countTenantDekRows(UUID tenantId) {
+        Integer c = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ?",
+            Integer.class, tenantId);
+        return c == null ? 0 : c;
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/security/TenantDekShredGuardTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/TenantDekShredGuardTest.java
@@ -12,11 +12,16 @@ import org.fabt.tenant.service.TenantLifecycleService;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionTemplate;
+
+import java.nio.file.Path;
 
 /**
  * §11.7 of design-f6-real-cryptoshred — trigger-guard semantics for
@@ -51,6 +56,20 @@ import org.springframework.transaction.support.TransactionTemplate;
 })
 @DisplayName("tenant_dek trigger-guard — positive + no-GUC + cross-tenant-poisoning (F-6.0 §11.7)")
 class TenantDekShredGuardTest extends BaseIntegrationTest {
+
+    // Override fabt.tenant.offboard.export-path so each test run writes to
+    // an OS-appropriate tmpdir instead of the prod default /var/fabt/exports
+    // (which on a Linux CI runner requires root to create). The positive
+    // case drives a tenant through offboard → archive → hardDelete which
+    // invokes TenantOffboardExportService.exportTenant(). Matches the
+    // pattern in TenantLifecycleHardDeleteIntegrationTest.
+    @TempDir
+    static Path tempExportRoot;
+
+    @DynamicPropertySource
+    static void exportPath(DynamicPropertyRegistry registry) {
+        registry.add("fabt.tenant.offboard.export-path", () -> tempExportRoot.toString());
+    }
 
     @Autowired private TestAuthHelper authHelper;
     @Autowired private TenantLifecycleService lifecycleService;

--- a/backend/src/test/java/org/fabt/tenant/TenantLifecycleFeatureFlagEnabledIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/TenantLifecycleFeatureFlagEnabledIntegrationTest.java
@@ -1,0 +1,33 @@
+package org.fabt.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.tenant.service.TenantLifecycleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * Companion to {@link TenantStatePersistenceIntegrationTest}: asserts that flipping
+ * the {@code fabt.tenant.lifecycle.enabled} flag to {@code true} wires up the
+ * {@link TenantLifecycleService} bean. The flag-off case is covered in the persistence
+ * test (cheap — no extra context). This test is in its own class because
+ * {@code @TestPropertySource} produces a separate Spring application context, and we
+ * want the cost of that second context to be visible and isolated rather than
+ * blended into an unrelated test class.
+ */
+@TestPropertySource(properties = "fabt.tenant.lifecycle.enabled=true")
+class TenantLifecycleFeatureFlagEnabledIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired(required = false)
+    private TenantLifecycleService tenantLifecycleService;
+
+    @Test
+    void tenantLifecycleServiceBeanIsWiredWhenFeatureFlagIsTrue() {
+        assertThat(tenantLifecycleService)
+            .as("fabt.tenant.lifecycle.enabled=true must cause Spring to instantiate "
+                + "TenantLifecycleService via @ConditionalOnProperty")
+            .isNotNull();
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/TenantStatePersistenceIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/TenantStatePersistenceIntegrationTest.java
@@ -1,0 +1,124 @@
+package org.fabt.tenant;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.shared.config.JsonString;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.repository.TenantRepository;
+import org.fabt.tenant.service.TenantLifecycleService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * End-to-end persistence test for the V79 {@code tenant.state} VARCHAR+CHECK column.
+ * Proves that Spring Data JDBC 4.x's default {@code Enum.name()} conversion flows
+ * cleanly through the Postgres VARCHAR(32) column AND that the CHECK constraint
+ * rejects out-of-band values at the database layer.
+ *
+ * <p>The warroom reviewer flagged this as the highest-leverage missing test in F-1:
+ * without it, the "Spring converts enums to VARCHAR automatically" claim rests on
+ * the migration comment alone. With it, the claim is ground truth.</p>
+ *
+ * <p>Also asserts that {@link TenantLifecycleService} is NOT wired when the
+ * {@code fabt.tenant.lifecycle.enabled} flag is absent (the default). The flag-on
+ * case lives in a sibling test class to avoid paying for a second Spring context
+ * in the common path.</p>
+ */
+class TenantStatePersistenceIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private TenantRepository tenantRepository;
+
+    @Autowired
+    private ApplicationContext applicationContext;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Test
+    void everyTenantStateValueRoundTripsThroughVARCHAR() {
+        // Each of the 5 enum values must write AND read back identically.
+        for (TenantState state : TenantState.values()) {
+            Tenant saved = tenantRepository.save(newTenant(state));
+
+            Optional<Tenant> loaded = tenantRepository.findById(saved.getId());
+
+            assertThat(loaded)
+                .as("tenant with state=%s must be retrievable", state)
+                .isPresent();
+            assertThat(loaded.get().getState())
+                .as("state must round-trip as %s", state)
+                .isEqualTo(state);
+        }
+    }
+
+    @Test
+    void stateUpdateViaRepositoryPersists() {
+        Tenant saved = tenantRepository.save(newTenant(TenantState.ACTIVE));
+
+        saved.setState(TenantState.SUSPENDED);
+        tenantRepository.save(saved);
+
+        Tenant reloaded = tenantRepository.findById(saved.getId()).orElseThrow();
+        assertThat(reloaded.getState()).isEqualTo(TenantState.SUSPENDED);
+    }
+
+    @Test
+    void dbCheckConstraintRejectsValuesOutsideTheAllowedSet() {
+        // Bypass the Java enum by writing a raw SQL insert with an invalid state
+        // value. The CHECK constraint added in V79 must reject.
+        UUID id = UUID.randomUUID();
+        assertThatThrownBy(() -> jdbc.update(
+                "INSERT INTO tenant (id, name, slug, config, state) VALUES (?, ?, ?, '{}'::jsonb, ?)",
+                id, "Bad State", "bad-state-" + id, "BOGUS_STATE"))
+            .isInstanceOf(DataIntegrityViolationException.class);
+    }
+
+    @Test
+    void dbDefaultForStateIsActiveWhenNotSupplied() {
+        // Insert without specifying state. Column default (SET DEFAULT 'ACTIVE' in
+        // V79) must kick in.
+        UUID id = UUID.randomUUID();
+        jdbc.update(
+            "INSERT INTO tenant (id, name, slug, config) VALUES (?, ?, ?, '{}'::jsonb)",
+            id, "Default State", "default-state-" + id);
+
+        String state = jdbc.queryForObject(
+            "SELECT state FROM tenant WHERE id = ?", String.class, id);
+        assertThat(state).isEqualTo("ACTIVE");
+    }
+
+    @Test
+    void tenantLifecycleServiceBeanIsAbsentWhenFeatureFlagOff() {
+        // With fabt.tenant.lifecycle.enabled absent from application-test.yml
+        // (it is; default matchIfMissing=false), the @ConditionalOnProperty guard
+        // must suppress bean creation. An accidental flag-flip in prod config
+        // would be caught by this assertion in CI.
+        assertThatThrownBy(() -> applicationContext.getBean(TenantLifecycleService.class))
+            .isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+
+    private static Tenant newTenant(TenantState state) {
+        Tenant t = new Tenant();
+        t.setName("Round-trip Tenant " + state);
+        // Slug must be unique across the whole test class; embed state + UUID.
+        t.setSlug("rt-" + state.name().toLowerCase() + "-" + UUID.randomUUID());
+        t.setConfig(JsonString.empty());
+        t.setState(state);
+        Instant now = Instant.now();
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return t;
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/api/TenantStateHandlerInterceptorUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/api/TenantStateHandlerInterceptorUnitTest.java
@@ -1,0 +1,97 @@
+package org.fabt.tenant.api;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.util.UUID;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+
+import org.fabt.shared.web.TenantContext;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.domain.TenantStateGuardException;
+import org.fabt.tenant.service.TenantStateGuard;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link TenantStateHandlerInterceptor}. Pins the skip-vs-enforce contract
+ * so future regressions to the interceptor don't silently turn it into a no-op (which
+ * would eliminate the whole F-3.3 defense-in-depth layer without breaking any test
+ * elsewhere).
+ */
+@ExtendWith(MockitoExtension.class)
+class TenantStateHandlerInterceptorUnitTest {
+
+    @Mock
+    TenantStateGuard tenantStateGuard;
+
+    @Mock
+    HttpServletRequest request;
+
+    @Mock
+    HttpServletResponse response;
+
+    @Test
+    void preHandle_noTenantContext_skipsGuard_returnsTrue() {
+        TenantStateHandlerInterceptor interceptor = new TenantStateHandlerInterceptor(tenantStateGuard);
+
+        boolean result = interceptor.preHandle(request, response, new Object());
+
+        assertThat(result).isTrue();
+        verify(tenantStateGuard, never()).requireActive(any());
+    }
+
+    @Test
+    void preHandle_systemTenantId_skipsGuard_returnsTrue() {
+        TenantStateHandlerInterceptor interceptor = new TenantStateHandlerInterceptor(tenantStateGuard);
+
+        Boolean result = TenantContext.callWithContext(
+            TenantContext.SYSTEM_TENANT_ID, false,
+            () -> interceptor.preHandle(request, response, new Object()));
+
+        assertThat(result).isTrue();
+        verify(tenantStateGuard, never()).requireActive(any());
+    }
+
+    @Test
+    void preHandle_activeTenant_callsRequireActive_returnsTrue() {
+        TenantStateHandlerInterceptor interceptor = new TenantStateHandlerInterceptor(tenantStateGuard);
+        UUID tenantId = UUID.randomUUID();
+
+        Boolean result = TenantContext.callWithContext(tenantId, false,
+            () -> interceptor.preHandle(request, response, new Object()));
+
+        assertThat(result).isTrue();
+        verify(tenantStateGuard, times(1)).requireActive(tenantId);
+    }
+
+    @Test
+    void preHandle_suspendedTenant_guardThrows_exceptionPropagates() {
+        // TenantLifecycleExceptionAdvice maps the exception to 404/503; the
+        // interceptor does NOT swallow. Verify the throw propagates past
+        // preHandle so the advice can fire.
+        TenantStateHandlerInterceptor interceptor = new TenantStateHandlerInterceptor(tenantStateGuard);
+        UUID tenantId = UUID.randomUUID();
+        TenantStateGuardException suspended = TenantStateGuardException.nonActive(
+            tenantId, TenantState.SUSPENDED);
+        doThrow(suspended).when(tenantStateGuard).requireActive(tenantId);
+
+        assertThatThrownBy(() -> TenantContext.callWithContext(tenantId, false,
+            () -> interceptor.preHandle(request, response, new Object())))
+            .isInstanceOf(TenantStateGuardException.class)
+            .satisfies(ex -> {
+                TenantStateGuardException typed = (TenantStateGuardException) ex;
+                assertThat(typed.kind()).isEqualTo(TenantStateGuardException.Kind.NON_ACTIVE);
+                assertThat(typed.observedState()).isEqualTo(TenantState.SUSPENDED);
+            });
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/domain/TenantStateTransitionTest.java
+++ b/backend/src/test/java/org/fabt/tenant/domain/TenantStateTransitionTest.java
@@ -1,0 +1,149 @@
+package org.fabt.tenant.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+/**
+ * Full-matrix unit test for the {@link TenantState} FSM. Every (from, to) pair must
+ * either be in the allowed set (design §D8) or throw {@link IllegalStateTransitionException}.
+ *
+ * <p>A regression that relaxes the matrix (e.g. allowing {@code ARCHIVED -> ACTIVE})
+ * would silently land without this test — §D8 is the only guard between a hard-deleted
+ * tenant and an attacker who wants to re-activate it.</p>
+ */
+class TenantStateTransitionTest {
+
+    private static final Set<Pair> ALLOWED = new HashSet<>();
+
+    static {
+        ALLOWED.add(Pair.of(TenantState.ACTIVE, TenantState.SUSPENDED));
+        ALLOWED.add(Pair.of(TenantState.ACTIVE, TenantState.OFFBOARDING));
+        ALLOWED.add(Pair.of(TenantState.SUSPENDED, TenantState.ACTIVE));
+        ALLOWED.add(Pair.of(TenantState.SUSPENDED, TenantState.OFFBOARDING));
+        ALLOWED.add(Pair.of(TenantState.OFFBOARDING, TenantState.ARCHIVED));
+        ALLOWED.add(Pair.of(TenantState.ARCHIVED, TenantState.DELETED));
+    }
+
+    @ParameterizedTest(name = "{0} -> (each other state)")
+    @EnumSource(TenantState.class)
+    @DisplayName("every (from, to) pair matches the §D8 matrix")
+    void matrix(TenantState from) {
+        for (TenantState to : TenantState.values()) {
+            if (ALLOWED.contains(Pair.of(from, to))) {
+                assertThat(from.canTransitionTo(to))
+                    .as("%s -> %s should be allowed", from, to)
+                    .isTrue();
+                // No throw on assertTransition
+                TenantState.assertTransition(from, to);
+            } else {
+                assertThat(from.canTransitionTo(to))
+                    .as("%s -> %s should be disallowed", from, to)
+                    .isFalse();
+                assertThatThrownBy(() -> TenantState.assertTransition(from, to))
+                    .as("%s -> %s should throw", from, to)
+                    .isInstanceOf(IllegalStateTransitionException.class);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("exactly 6 allowed pairs across the whole matrix (§D8 invariant)")
+    void allowedMatrixIsExactlyTheSixDesignD8Pairs() {
+        // Defense against lockstep edits: if someone relaxes TenantState AND
+        // the ALLOWED set in this test file together (e.g. adding ARCHIVED ->
+        // ACTIVE in both), the parameterized matrix test still passes because
+        // both sides "agree." This assertion counts allowed pairs directly
+        // from the enum — no shared fixture — so it fails when the matrix
+        // grows or shrinks from the §D8-specified 6.
+        int allowedCount = 0;
+        for (TenantState from : TenantState.values()) {
+            for (TenantState to : TenantState.values()) {
+                if (from.canTransitionTo(to)) {
+                    allowedCount++;
+                }
+            }
+        }
+        assertThat(allowedCount)
+            .as("§D8 specifies exactly 6 allowed transitions: "
+                + "ACTIVE->SUSPENDED, ACTIVE->OFFBOARDING, SUSPENDED->ACTIVE, "
+                + "SUSPENDED->OFFBOARDING, OFFBOARDING->ARCHIVED, ARCHIVED->DELETED")
+            .isEqualTo(6);
+    }
+
+    @Test
+    @DisplayName("DELETED is terminal (no outgoing transitions)")
+    void deletedIsTerminal() {
+        assertThat(TenantState.DELETED.allowedNext()).isEmpty();
+    }
+
+    @Test
+    @DisplayName("ARCHIVED cannot return to ACTIVE (§D8: re-onboarding is a fresh create)")
+    void archivedCannotRevive() {
+        assertThatThrownBy(() -> TenantState.assertTransition(TenantState.ARCHIVED, TenantState.ACTIVE))
+            .isInstanceOf(IllegalStateTransitionException.class)
+            .hasMessageContaining("ARCHIVED")
+            .hasMessageContaining("ACTIVE");
+    }
+
+    @Test
+    @DisplayName("self-transition always throws (idempotency is caller's concern)")
+    void selfTransitionThrows() {
+        for (TenantState s : TenantState.values()) {
+            assertThatThrownBy(() -> TenantState.assertTransition(s, s))
+                .isInstanceOf(IllegalStateTransitionException.class)
+                .hasMessageContaining("self-transition");
+        }
+    }
+
+    @Test
+    @DisplayName("null args throw IllegalArgumentException (not IllegalStateTransitionException)")
+    void nullArgsRejected() {
+        assertThatThrownBy(() -> TenantState.assertTransition(null, TenantState.ACTIVE))
+            .isInstanceOf(IllegalArgumentException.class);
+        assertThatThrownBy(() -> TenantState.assertTransition(TenantState.ACTIVE, null))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    @DisplayName("ACTIVE has exactly two successors: SUSPENDED + OFFBOARDING")
+    void activeSuccessors() {
+        assertThat(TenantState.ACTIVE.allowedNext())
+            .containsExactlyInAnyOrder(TenantState.SUSPENDED, TenantState.OFFBOARDING);
+    }
+
+    @Test
+    @DisplayName("SUSPENDED has exactly two successors: ACTIVE + OFFBOARDING")
+    void suspendedSuccessors() {
+        assertThat(TenantState.SUSPENDED.allowedNext())
+            .containsExactlyInAnyOrder(TenantState.ACTIVE, TenantState.OFFBOARDING);
+    }
+
+    @Test
+    @DisplayName("OFFBOARDING has exactly one successor: ARCHIVED")
+    void offboardingSuccessors() {
+        assertThat(TenantState.OFFBOARDING.allowedNext())
+            .containsExactly(TenantState.ARCHIVED);
+    }
+
+    @Test
+    @DisplayName("ARCHIVED has exactly one successor: DELETED")
+    void archivedSuccessors() {
+        assertThat(TenantState.ARCHIVED.allowedNext())
+            .containsExactly(TenantState.DELETED);
+    }
+
+    private record Pair(TenantState from, TenantState to) {
+        static Pair of(TenantState from, TenantState to) {
+            return new Pair(from, to);
+        }
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleCreateIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleCreateIntegrationTest.java
@@ -1,0 +1,162 @@
+package org.fabt.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.repository.TenantRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * End-to-end Testcontainers test for F-4: {@code TenantLifecycleService.create}
+ * bootstraps a new tenant atomically with key material, an audit_chain_head row,
+ * and a {@code TENANT_CREATED} audit event — all visible in the DB after the
+ * single {@code @Transactional} commits.
+ */
+@TestPropertySource(properties = "fabt.tenant.lifecycle.enabled=true")
+class TenantLifecycleCreateIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private TenantLifecycleService lifecycleService;
+    @Autowired private TenantRepository tenantRepository;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    @Test
+    void create_landsTenantKeyMaterialChainHeadAndAuditInOneTransaction() {
+        String slug = "f4-create-" + UUID.randomUUID();
+        UUID actor = UUID.randomUUID();
+
+        Tenant created = lifecycleService.create("F-4 Create CoC", slug, actor);
+        UUID tenantId = created.getId();
+
+        // Tenant row
+        assertThat(tenantRepository.findById(tenantId))
+            .as("tenant row persisted with ACTIVE state")
+            .isPresent()
+            .get()
+            .satisfies(t -> {
+                assertThat(t.getState()).isEqualTo(TenantState.ACTIVE);
+                assertThat(t.getSlug()).isEqualTo(slug);
+            });
+
+        // Key material — gen 1 active row exists
+        Integer gen = jdbc.queryForObject(
+            "SELECT generation FROM tenant_key_material WHERE tenant_id = ? AND active = TRUE",
+            Integer.class, tenantId);
+        assertThat(gen)
+            .as("eager bootstrap must produce gen-1 key material")
+            .isEqualTo(1);
+
+        // Kid registry — exactly one kid for this tenant at gen 1
+        Integer kidCount = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM kid_to_tenant_key WHERE tenant_id = ? AND generation = 1",
+            Integer.class, tenantId);
+        assertThat(kidCount).isEqualTo(1);
+
+        // audit_chain_head — one row, 32 zero bytes
+        Integer chainHeadCount = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_audit_chain_head WHERE tenant_id = ?",
+            Integer.class, tenantId);
+        assertThat(chainHeadCount).isEqualTo(1);
+
+        byte[] hash = jdbc.queryForObject(
+            "SELECT last_hash FROM tenant_audit_chain_head WHERE tenant_id = ?",
+            byte[].class, tenantId);
+        assertThat(hash)
+            .as("chain head seeded with 32 zero bytes (chain-start sentinel)")
+            .hasSize(32)
+            .containsOnly((byte) 0);
+
+        // TENANT_CREATED audit row — query under tenant context so RLS admits it
+        List<String> actions = queryAuditActionsForTenant(tenantId, actor);
+        assertThat(actions)
+            .as("TENANT_CREATED audit lands in the same tx as the tenant + key material")
+            .contains(AuditEventTypes.TENANT_CREATED);
+    }
+
+    @Test
+    void create_duplicateSlug_rejectedWithoutKeyMaterialOrAuditLeak() {
+        String slug = "f4-dup-" + UUID.randomUUID();
+        UUID firstActor = UUID.randomUUID();
+        Tenant first = lifecycleService.create("First", slug, firstActor);
+
+        // Record key-material + chain-head count BEFORE the failing second create
+        int keyMaterialCountBefore = countKeyMaterialRows();
+        int chainHeadCountBefore = countChainHeadRows();
+
+        UUID secondActor = UUID.randomUUID();
+        assertThatThrownBy(() -> lifecycleService.create("Second", slug, secondActor))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(slug);
+
+        // No second key_material row, no second chain_head row, no TENANT_CREATED
+        // audit for the rejected attempt (slug-check fires BEFORE any of that work).
+        assertThat(countKeyMaterialRows()).isEqualTo(keyMaterialCountBefore);
+        assertThat(countChainHeadRows()).isEqualTo(chainHeadCountBefore);
+
+        // The FIRST actor's audit row still exists; the second actor's has nothing.
+        // Query by secondActor to isolate.
+        List<String> secondActorActions = queryAuditActionsForTenant(first.getId(), secondActor);
+        assertThat(secondActorActions)
+            .as("second actor's failed create has no audit rows")
+            .doesNotContain(AuditEventTypes.TENANT_CREATED);
+    }
+
+    @Test
+    void create_bootstrapsAreIndependentAcrossTenants() {
+        // Create two tenants back-to-back; each must land its own key-material
+        // row, chain-head row, and audit row. Regression guard for a bug class
+        // where a cached kid from tenant A leaks into tenant B's bootstrap.
+        UUID actor = UUID.randomUUID();
+        Tenant a = lifecycleService.create("Alpha", "f4-alpha-" + UUID.randomUUID(), actor);
+        Tenant b = lifecycleService.create("Beta",  "f4-beta-"  + UUID.randomUUID(), actor);
+
+        assertThat(a.getId()).isNotEqualTo(b.getId());
+
+        UUID kidA = jdbc.queryForObject(
+            "SELECT kid FROM kid_to_tenant_key WHERE tenant_id = ? AND generation = 1",
+            UUID.class, a.getId());
+        UUID kidB = jdbc.queryForObject(
+            "SELECT kid FROM kid_to_tenant_key WHERE tenant_id = ? AND generation = 1",
+            UUID.class, b.getId());
+        assertThat(kidA).isNotEqualTo(kidB);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private List<String> queryAuditActionsForTenant(UUID tenantId, UUID actor) {
+        // audit_events is FORCE-RLS'd; bind tenant context so the SELECT admits
+        // the tenant's own rows.
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        return tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantId.toString());
+            return jdbc.queryForList(
+                "SELECT action FROM audit_events WHERE actor_user_id = ? AND tenant_id = ?",
+                String.class, actor, tenantId);
+        });
+    }
+
+    private int countKeyMaterialRows() {
+        Integer count = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_key_material", Integer.class);
+        return count == null ? 0 : count;
+    }
+
+    private int countChainHeadRows() {
+        Integer count = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_audit_chain_head", Integer.class);
+        return count == null ? 0 : count;
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleHardDeleteIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleHardDeleteIntegrationTest.java
@@ -1,0 +1,317 @@
+package org.fabt.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.time.temporal.ChronoUnit;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.security.KeyPurpose;
+import org.fabt.shared.security.SecretEncryptionService;
+import org.fabt.shared.security.TenantDekService;
+import org.fabt.shared.web.TenantContext;
+import org.fabt.tenant.domain.IllegalStateTransitionException;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.repository.TenantRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import java.nio.file.Path;
+
+/**
+ * End-to-end test for F-6.0 task 7.8f: {@code TenantLifecycleService.hardDelete}.
+ *
+ * <p>Pins the crypto-shred post-commit invariants the warroom pass-2 ship
+ * checklist (§12) gates on:
+ *
+ * <ul>
+ *   <li>FSM: only ARCHIVED → DELETED is permitted; other states reject with
+ *       {@link IllegalStateTransitionException} and emit a
+ *       {@code TENANT_HARD_DELETE_REJECTED} attempt-audit.</li>
+ *   <li>Retention gate: {@code archived_at + retentionDays} must be in the past.</li>
+ *   <li>CASCADE: the single {@code DELETE FROM tenant} destroys every child
+ *       row — tenant_dek, tenant_key_material, shelter, app_user, everything.</li>
+ *   <li>Audit tombstone: a platform-owned {@code TENANT_HARD_DELETED} row lands in
+ *       audit_events with the deleted tenant's UUID + terminal chain hash
+ *       embedded in the details JSONB.</li>
+ *   <li>Cache invalidation: {@link TenantDekService} resolveDek throws
+ *       post-shred — the DEK is gone from DB AND from the JVM cache.</li>
+ * </ul>
+ *
+ * <p>Retention window is overridden to 0 days for this test harness via
+ * {@code fabt.tenant.hard-delete.retention-days=0} — production default is 30.
+ */
+@TestPropertySource(properties = {
+        "fabt.tenant.lifecycle.enabled=true",
+        "fabt.tenant.hard-delete.retention-days=0"
+})
+class TenantLifecycleHardDeleteIntegrationTest extends BaseIntegrationTest {
+
+    @TempDir
+    static Path tempExportRoot;
+
+    @DynamicPropertySource
+    static void exportPath(DynamicPropertyRegistry registry) {
+        registry.add("fabt.tenant.offboard.export-path", () -> tempExportRoot.toString());
+    }
+
+    @Autowired private TenantLifecycleService lifecycleService;
+    @Autowired private TenantRepository tenantRepository;
+    @Autowired private TenantDekService tenantDekService;
+    @Autowired private SecretEncryptionService encryption;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PlatformTransactionManager transactionManager;
+
+    // ------------------------------------------------------------------
+    // T1 — Happy path: full lifecycle, shred destroys everything
+    // ------------------------------------------------------------------
+
+    @Test
+    void hardDelete_destroysTenantAndAllChildRows_writesTombstone_invalidatesCaches() {
+        // 1. Full lifecycle: CREATE → SUSPEND → OFFBOARD → ARCHIVE → hardDelete
+        UUID actor = UUID.randomUUID();
+        String slug = "hardDelete-happy-" + UUID.randomUUID();
+        Tenant created = lifecycleService.create("Shred Happy CoC", slug, actor);
+        UUID tenantId = created.getId();
+
+        // 2. Seed per-tenant rows across several CASCADE-bound tables. Each must
+        //    vanish after the single DELETE FROM tenant fires.
+        TenantDekService.ActiveDek dek =
+            tenantDekService.getOrCreateActiveDek(tenantId, KeyPurpose.TOTP);
+        UUID dekKid = dek.kid();
+        String canaryEncrypted = encryption.encryptForTenant(
+            tenantId, KeyPurpose.WEBHOOK_SECRET, "shred-canary-" + UUID.randomUUID());
+        assertThat(canaryEncrypted).isNotBlank();
+
+        // Round-trip prove the ciphertext decrypts cleanly PRE-shred.
+        String roundTripped = encryption.decryptForTenant(
+            tenantId, KeyPurpose.WEBHOOK_SECRET, canaryEncrypted);
+        assertThat(roundTripped).startsWith("shred-canary-");
+
+        // 3. Drive through OFFBOARDING → ARCHIVED. Offboard writes the export
+        //    receipt; archive stamps archived_at.
+        lifecycleService.offboard(tenantId, actor, "tenant-requested");
+        Tenant archived = lifecycleService.archive(tenantId, actor, "retention-start");
+        assertThat(archived.getState()).isEqualTo(TenantState.ARCHIVED);
+        assertThat(archived.getArchivedAt()).isNotNull();
+
+        // Pre-shred sanity: counts of child rows for this tenant.
+        int dekRowsBefore = countTenantDekRows(tenantId);
+        int keyMaterialRowsBefore = countTenantKeyMaterialRows(tenantId);
+        int sheltersBefore = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM shelter WHERE tenant_id = ?", Integer.class, tenantId);
+        assertThat(dekRowsBefore).as("tenant has at least one DEK row").isGreaterThanOrEqualTo(2);
+        assertThat(keyMaterialRowsBefore).isGreaterThanOrEqualTo(1);
+
+        // Prime the kid-resolution cache so we can later prove it was invalidated.
+        TenantDekService.ResolvedDek resolvedPre = tenantDekService.resolveDek(dekKid);
+        assertThat(resolvedPre.tenantId()).isEqualTo(tenantId);
+
+        // 4. hardDelete.
+        long tombstonesBefore = countTombstones(tenantId);
+        lifecycleService.hardDelete(tenantId, actor, "pilot-exit");
+
+        // 5. Assertions — destruction on commit.
+        assertThat(tenantRepository.findById(tenantId))
+            .as("tenant row must be gone post-shred").isEmpty();
+        assertThat(countTenantDekRows(tenantId))
+            .as("tenant_dek CASCADE must destroy all per-tenant DEKs").isEqualTo(0);
+        assertThat(countTenantKeyMaterialRows(tenantId))
+            .as("tenant_key_material CASCADE must destroy rows").isEqualTo(0);
+        assertThat(jdbc.queryForObject(
+                "SELECT COUNT(*) FROM shelter WHERE tenant_id = ?", Integer.class, tenantId))
+            .as("shelter CASCADE must destroy rows").isEqualTo(0);
+
+        // 6. Cache invalidation: resolveDek on the pre-shred kid must now throw
+        //    NoSuchElementException (the row was CASCADE-deleted AND the cache
+        //    was evicted by the AFTER_COMMIT listener).
+        assertThatThrownBy(() -> tenantDekService.resolveDek(dekKid))
+            .as("resolveDek must throw post-shred — cache evicted + row gone")
+            .isInstanceOf(java.util.NoSuchElementException.class);
+
+        // 7. Tombstone present in audit_events under SYSTEM_TENANT_ID with the
+        //    deleted tenant's UUID embedded in details.
+        List<Map<String, Object>> tombstones = queryTombstonesAsSystem(tenantId);
+        assertThat(tombstones)
+            .as("exactly one TENANT_HARD_DELETED tombstone should exist for this tenant")
+            .hasSize(1);
+        Map<String, Object> tombstone = tombstones.get(0);
+        // Postgres JSONB reformats with a space after each colon on storage,
+        // so contains-match on unspaced tokens would fail. Check the keys
+        // and values independently instead of a single glued substring.
+        String details = tombstone.get("details").toString();
+        assertThat(details).contains("\"deleted_tenant_id\"");
+        assertThat(details).contains(tenantId.toString());
+        assertThat(details).contains("\"last_audit_chain_hash\"");
+        assertThat(details).contains("\"previous_state\"");
+        assertThat(details).contains("\"ARCHIVED\"");
+
+        assertThat(countTombstones(tenantId)).isEqualTo(tombstonesBefore + 1);
+    }
+
+    // ------------------------------------------------------------------
+    // T2 — FSM: non-ARCHIVED states must reject
+    // ------------------------------------------------------------------
+
+    @Test
+    void hardDelete_fromActiveState_rejectsWithFsmException_emitsRejectedAudit() {
+        UUID actor = UUID.randomUUID();
+        String slug = "hardDelete-fsm-reject-" + UUID.randomUUID();
+        Tenant created = lifecycleService.create("Shred Reject CoC", slug, actor);
+        UUID tenantId = created.getId();
+
+        assertThatThrownBy(() -> lifecycleService.hardDelete(tenantId, actor, "skip-archive"))
+            .as("ACTIVE → DELETED is NOT an allowed transition per §D8")
+            .isInstanceOf(IllegalStateTransitionException.class);
+
+        // Tenant row must still exist — FSM rejection rolls back.
+        Tenant reloaded = tenantRepository.findById(tenantId).orElseThrow();
+        assertThat(reloaded.getState()).isEqualTo(TenantState.ACTIVE);
+
+        // Attempt-audit: a TENANT_HARD_DELETE_REJECTED row must be present
+        // (detached persister survives the outer rollback).
+        long rejectedCount = countAuditRowsForActor(
+            AuditEventTypes.TENANT_HARD_DELETE_REJECTED, actor, tenantId);
+        assertThat(rejectedCount)
+            .as("FSM rejection must emit attempt-audit via REQUIRES_NEW detached persister")
+            .isEqualTo(1L);
+    }
+
+    // ------------------------------------------------------------------
+    // T3 — Retention gate: archived recently must reject
+    // ------------------------------------------------------------------
+
+    @Test
+    void hardDelete_withinRetentionWindow_rejectsWithIllegalStateException() {
+        // Override retention to 3650 days for this test only (via JDBC — we
+        // set archived_at to very recent past + assert the retention check
+        // fires). Uses a subclass-free approach: manipulate archived_at
+        // directly post-archive.
+        UUID actor = UUID.randomUUID();
+        String slug = "hardDelete-retention-" + UUID.randomUUID();
+        Tenant created = lifecycleService.create("Shred Retention CoC", slug, actor);
+        UUID tenantId = created.getId();
+
+        lifecycleService.offboard(tenantId, actor, "tenant-requested");
+        lifecycleService.archive(tenantId, actor, "retention-start");
+
+        // Rewind archived_at to "just now" but override the retention-days
+        // property via a helper: simplest path is to override tenant's
+        // archived_at to the future, making even a 0-day retention fail.
+        Instant tomorrow = Instant.now().plus(1, ChronoUnit.DAYS);
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        tx.executeWithoutResult(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantId.toString());
+            jdbc.update("UPDATE tenant SET archived_at = ? WHERE id = ?",
+                java.sql.Timestamp.from(tomorrow), tenantId);
+        });
+
+        assertThatThrownBy(() -> lifecycleService.hardDelete(tenantId, actor, "too-early"))
+            .as("retention window not elapsed — hardDelete must reject")
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("retention");
+
+        // Tenant must still exist.
+        assertThat(tenantRepository.findById(tenantId)).isPresent();
+    }
+
+    // ------------------------------------------------------------------
+    // T4 — Idempotency of re-run: second hardDelete on same tenant fails
+    //      (tenant doesn't exist anymore, so findById throws NoSuchElement).
+    // ------------------------------------------------------------------
+
+    @Test
+    void hardDelete_calledTwice_secondCallThrowsNoSuchElement() {
+        UUID actor = UUID.randomUUID();
+        String slug = "hardDelete-twice-" + UUID.randomUUID();
+        Tenant created = lifecycleService.create("Shred Twice CoC", slug, actor);
+        UUID tenantId = created.getId();
+
+        lifecycleService.offboard(tenantId, actor, "tenant-requested");
+        lifecycleService.archive(tenantId, actor, "retention-start");
+        lifecycleService.hardDelete(tenantId, actor, "first-call");
+
+        assertThatThrownBy(() -> lifecycleService.hardDelete(tenantId, actor, "second-call"))
+            .as("second hardDelete on a gone tenant must throw NoSuchElementException")
+            .isInstanceOf(java.util.NoSuchElementException.class);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────
+
+    private int countTenantDekRows(UUID tenantId) {
+        Integer c = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = ?", Integer.class, tenantId);
+        return c == null ? 0 : c;
+    }
+
+    private int countTenantKeyMaterialRows(UUID tenantId) {
+        Integer c = jdbc.queryForObject(
+            "SELECT COUNT(*) FROM tenant_key_material WHERE tenant_id = ?",
+            Integer.class, tenantId);
+        return c == null ? 0 : c;
+    }
+
+    /**
+     * Counts tombstone rows for the given deleted tenant. Must read under
+     * SYSTEM_TENANT_ID because the tombstone is owned by SYSTEM_TENANT_ID
+     * per V57 RLS semantics.
+     */
+    private long countTombstones(UUID deletedTenantId) {
+        return org.fabt.testsupport.WithTenantContext.readAsSystem(() -> {
+            Long c = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM audit_events "
+                + "WHERE action = ? "
+                + "  AND details ->> 'deleted_tenant_id' = ? "
+                + "  AND tenant_id = ?",
+                Long.class,
+                AuditEventTypes.TENANT_HARD_DELETED,
+                deletedTenantId.toString(),
+                TenantContext.SYSTEM_TENANT_ID);
+            return c == null ? 0L : c;
+        });
+    }
+
+    private List<Map<String, Object>> queryTombstonesAsSystem(UUID deletedTenantId) {
+        return org.fabt.testsupport.WithTenantContext.readAsSystem(() ->
+            jdbc.queryForList(
+                "SELECT action, details::text AS details FROM audit_events "
+                + "WHERE action = ? "
+                + "  AND details ->> 'deleted_tenant_id' = ? "
+                + "  AND tenant_id = ?",
+                AuditEventTypes.TENANT_HARD_DELETED,
+                deletedTenantId.toString(),
+                TenantContext.SYSTEM_TENANT_ID));
+    }
+
+    /**
+     * Counts attempt-audit rows for a failed FSM transition. The row is
+     * owned by the deleted-tenant context (not SYSTEM), so we bind
+     * app.tenant_id to tenantId to read under RLS.
+     */
+    private long countAuditRowsForActor(String action, UUID actor, UUID tenantId) {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        return tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantId.toString());
+            Long c = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM audit_events "
+                + "WHERE action = ? AND actor_user_id = ? AND tenant_id = ?",
+                Long.class, action, actor, tenantId);
+            return c == null ? 0L : c;
+        });
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleOffboardArchiveIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleOffboardArchiveIntegrationTest.java
@@ -1,0 +1,197 @@
+package org.fabt.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import tools.jackson.databind.JsonNode;
+import tools.jackson.databind.ObjectMapper;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.auth.domain.ApiKey;
+import org.fabt.auth.repository.ApiKeyRepository;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.repository.TenantRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
+
+/**
+ * End-to-end integration test for F-5: offboard writes a schema'd JSON export to
+ * disk + stores the receipt URI + audits; archive requires the receipt and stamps
+ * {@code archived_at}; full round-trip verifies JSON parses and contains the
+ * expected top-level keys + seed data counts.
+ */
+@TestPropertySource(properties = "fabt.tenant.lifecycle.enabled=true")
+class TenantLifecycleOffboardArchiveIntegrationTest extends BaseIntegrationTest {
+
+    @TempDir
+    static Path tempExportRoot;
+
+    @DynamicPropertySource
+    static void exportPath(DynamicPropertyRegistry registry) {
+        registry.add("fabt.tenant.offboard.export-path", () -> tempExportRoot.toString());
+    }
+
+    @Autowired private TenantLifecycleService lifecycleService;
+    @Autowired private TenantRepository tenantRepository;
+    @Autowired private ApiKeyRepository apiKeyRepository;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PlatformTransactionManager transactionManager;
+    @Autowired private ObjectMapper objectMapper;
+
+    @Test
+    void offboard_writesExportFile_storesReceiptUri_emitsAudit() throws IOException {
+        // Seed: create tenant via lifecycle (F-4 atomic bootstrap), add one API
+        // key so the export has a non-trivial row to include.
+        String slug = "f5-off-" + UUID.randomUUID();
+        Tenant created = lifecycleService.create("F-5 Off CoC", slug, UUID.randomUUID());
+        seedActiveApiKey(created.getId());
+
+        UUID actor = UUID.randomUUID();
+        Tenant offboarded = lifecycleService.offboard(created.getId(), actor, "tenant-request");
+
+        // State + receipt URI persisted
+        assertThat(offboarded.getState()).isEqualTo(TenantState.OFFBOARDING);
+        assertThat(offboarded.getOffboardExportReceiptUri())
+            .as("receipt URI stamped on tenant row")
+            .isNotBlank()
+            .startsWith(tempExportRoot.toString());
+
+        // File exists on disk and is parseable JSON
+        Path exportFile = Path.of(offboarded.getOffboardExportReceiptUri());
+        assertThat(exportFile).exists();
+        JsonNode root = objectMapper.readTree(exportFile.toFile());
+
+        // Envelope fields
+        assertThat(root.get("schemaVersion").asString()).isEqualTo("1.0.0");
+        assertThat(root.get("tenantId").asString()).isEqualTo(created.getId().toString());
+        assertThat(root.get("exportedAt")).isNotNull();
+
+        // Required top-level tables present (F-5 schema contract)
+        for (String table : TenantOffboardExportService.EXPORT_TABLES) {
+            assertThat(root.has(table))
+                .as("export envelope contains %s", table)
+                .isTrue();
+            assertThat(root.get(table).isArray())
+                .as("%s is an array", table)
+                .isTrue();
+        }
+
+        // Bidirectional drift guard: no top-level key in the envelope exists
+        // outside {envelope metadata} ∪ EXPORT_TABLES. Catches the reverse
+        // regression where someone adds writeTable(gen, "incidents", ...) but
+        // forgets to append to EXPORT_TABLES — envelope and the single-source-
+        // of-truth constant drift apart silently otherwise.
+        java.util.Set<String> envelopeMetaKeys = java.util.Set.of(
+            "schemaVersion", "tenantId", "exportedAt");
+        java.util.Set<String> declaredTables = java.util.Set.of(TenantOffboardExportService.EXPORT_TABLES);
+        java.util.Set<String> foundKeys = new java.util.HashSet<>();
+        root.propertyNames().forEach(foundKeys::add);
+        foundKeys.removeAll(envelopeMetaKeys);
+        foundKeys.removeAll(declaredTables);
+        assertThat(foundKeys)
+            .as("no undeclared top-level keys — every envelope key must appear in "
+                + "TenantOffboardExportService.EXPORT_TABLES or the metadata set")
+            .isEmpty();
+
+        // Seed data present: tenant row = 1, api_keys row = 1
+        assertThat(root.get("tenant").size()).isEqualTo(1);
+        assertThat(root.get("api_keys").size()).isEqualTo(1);
+        // api_keys export deliberately excludes key_hash + old_key_hash
+        JsonNode apiKeyRow = root.get("api_keys").get(0);
+        assertThat(apiKeyRow.has("key_hash"))
+            .as("key_hash deliberately excluded from export (secret)")
+            .isFalse();
+        assertThat(apiKeyRow.has("old_key_hash"))
+            .as("old_key_hash deliberately excluded from export (secret)")
+            .isFalse();
+
+        // TENANT_OFFBOARDING_STARTED audit row
+        List<String> actions = queryAuditActionsForTenant(created.getId(), actor);
+        assertThat(actions).contains(AuditEventTypes.TENANT_OFFBOARDING_STARTED);
+    }
+
+    @Test
+    void archive_requiresExportReceipt_stampsArchivedAt() {
+        String slug = "f5-arc-" + UUID.randomUUID();
+        Tenant created = lifecycleService.create("F-5 Arc CoC", slug, UUID.randomUUID());
+        lifecycleService.offboard(created.getId(), UUID.randomUUID(), "export");
+
+        UUID actor = UUID.randomUUID();
+        Instant beforeArchive = Instant.now();
+        Tenant archived = lifecycleService.archive(created.getId(), actor, "retention-start");
+
+        assertThat(archived.getState()).isEqualTo(TenantState.ARCHIVED);
+        assertThat(archived.getArchivedAt())
+            .as("archived_at stamped within the request window")
+            .isBetween(beforeArchive.minusSeconds(1), Instant.now().plusSeconds(1));
+        assertThat(archived.getOffboardExportReceiptUri())
+            .as("archive preserves the offboard receipt — forensic link to the export file")
+            .isNotBlank();
+
+        // TENANT_ARCHIVED audit row
+        List<String> actions = queryAuditActionsForTenant(created.getId(), actor);
+        assertThat(actions).contains(AuditEventTypes.TENANT_ARCHIVED);
+    }
+
+    @Test
+    void archive_withoutOffboardFirst_fails_withoutStateFlip() {
+        // §D8 allows ACTIVE -> SUSPENDED -> OFFBOARDING -> ARCHIVED but NOT
+        // ACTIVE -> ARCHIVED directly. The FSM assertion catches this before
+        // the receipt check fires — but either way, the state must NOT advance.
+        String slug = "f5-direct-" + UUID.randomUUID();
+        Tenant created = lifecycleService.create("F-5 Direct", slug, UUID.randomUUID());
+
+        assertThatThrownBy(() ->
+                lifecycleService.archive(created.getId(), UUID.randomUUID(), "skip-offboard"))
+            .isInstanceOf(org.fabt.tenant.domain.IllegalStateTransitionException.class);
+
+        Tenant reloaded = tenantRepository.findById(created.getId()).orElseThrow();
+        assertThat(reloaded.getState())
+            .as("failed archive must not advance state")
+            .isEqualTo(TenantState.ACTIVE);
+        assertThat(reloaded.getArchivedAt())
+            .as("no archived_at stamp on failed archive")
+            .isNull();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private UUID seedActiveApiKey(UUID tenantId) {
+        ApiKey k = new ApiKey();
+        k.setTenantId(tenantId);
+        k.setKeyHash("f5-sim-" + UUID.randomUUID());
+        k.setKeySuffix(UUID.randomUUID().toString().substring(0, 4));
+        k.setLabel("f5-export-seed");
+        k.setRole("COC_ADMIN");
+        k.setActive(true);
+        k.setCreatedAt(Instant.now());
+        return apiKeyRepository.save(k).getId();
+    }
+
+    private List<String> queryAuditActionsForTenant(UUID tenantId, UUID actor) {
+        TransactionTemplate tx = new TransactionTemplate(transactionManager);
+        return tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantId.toString());
+            return jdbc.queryForList(
+                "SELECT action FROM audit_events WHERE actor_user_id = ? AND tenant_id = ?",
+                String.class, actor, tenantId);
+        });
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceIntegrationTest.java
@@ -95,15 +95,19 @@ class TenantLifecycleServiceIntegrationTest extends BaseIntegrationTest {
         // JWT gen unchanged — no second bump
         assertThat(queryJwtGen(tenantId)).isEqualTo(genAfterFirst);
 
-        // And no audit trail for the failed attempt (F-2 scope). This pins the
-        // current "silent failure" contract explicitly. The forensic gap — an
-        // attacker hammering suspend leaves no trail — is tracked for F-3 in
-        // project_tenant_lifecycle_attempt_audit_gap.md; that slice will add a
-        // TENANT_SUSPEND_ATTEMPT_REJECTED row via REQUIRES_NEW, at which point
-        // THIS assertion flips to expect one row and the test doc-comment updates.
+        // No success-path audit for the failed attempt — no state flip, no JWT
+        // bump, no API-key churn.
         List<String> attemptAudit = queryAuditActionsForTenant(tenantId, secondActor,
             List.of("TENANT_SUSPENDED", "JWT_KEY_GENERATION_BUMPED"));
         assertThat(attemptAudit).isEmpty();
+
+        // F-3.6 attempt-audit: the rejected suspend attempt DOES emit
+        // TENANT_SUSPEND_REJECTED via DetachedAuditPersister (REQUIRES_NEW) so
+        // the forensic trail survives the caller-tx rollback. This closes the
+        // Marcus F-2 HIGH gap.
+        List<String> rejectionAudit = queryAuditActionsForTenant(tenantId, secondActor,
+            List.of("TENANT_SUSPEND_REJECTED"));
+        assertThat(rejectionAudit).containsExactly("TENANT_SUSPEND_REJECTED");
     }
 
     @Test

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceIntegrationTest.java
@@ -1,0 +1,222 @@
+package org.fabt.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.auth.domain.ApiKey;
+import org.fabt.auth.repository.ApiKeyRepository;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.config.JsonString;
+import org.fabt.shared.security.KidRegistryService;
+import org.fabt.tenant.domain.IllegalStateTransitionException;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.repository.TenantRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * End-to-end integration test for Phase F slice F-2: suspend/unsuspend with JWT bump,
+ * API-key deactivation, and audit emission. Runs against the full Spring context
+ * (flag-on) so the real {@link TenantLifecycleService}, {@code TenantKeyRotationService},
+ * {@code ApiKeyService}, and {@code AuditEventService} all participate.
+ *
+ * <p>Covers the assertions the unit test cannot: that {@code JWT_KEY_GENERATION_BUMPED}
+ * and {@code TENANT_SUSPENDED} audit rows both land in the same transaction, that
+ * {@code tenant.jwt_key_generation} actually increments, that {@code api_key.active}
+ * rows flip to false in the database, and that the idempotency contract
+ * (second-POST-suspend → 409 via IllegalStateTransitionException) holds against a
+ * real Postgres instance.</p>
+ */
+@TestPropertySource(properties = "fabt.tenant.lifecycle.enabled=true")
+class TenantLifecycleServiceIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private TenantLifecycleService lifecycleService;
+    @Autowired private TenantRepository tenantRepository;
+    @Autowired private ApiKeyRepository apiKeyRepository;
+    @Autowired private KidRegistryService kidRegistryService;
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private org.springframework.transaction.PlatformTransactionManager transactionManager;
+
+    @Test
+    void suspend_incrementsJwtGeneration_flipsState_deactivatesKeys_writesBothAuditRows() {
+        Tenant tenant = saveActiveTenantWithKeyMaterial();
+        UUID tenantId = tenant.getId();
+        int genBefore = queryJwtGen(tenantId);
+        UUID key1 = seedActiveApiKey(tenantId);
+        UUID key2 = seedActiveApiKey(tenantId);
+        UUID actor = UUID.randomUUID();
+
+        Tenant result = lifecycleService.suspend(tenantId, actor, "live-fire-drill");
+
+        // State flipped
+        assertThat(result.getState()).isEqualTo(TenantState.SUSPENDED);
+        assertThat(tenantRepository.findById(tenantId).orElseThrow().getState())
+            .isEqualTo(TenantState.SUSPENDED);
+
+        // JWT generation bumped by exactly 1
+        assertThat(queryJwtGen(tenantId)).isEqualTo(genBefore + 1);
+
+        // Both API keys deactivated
+        assertThat(apiKeyRepository.findById(key1).orElseThrow().isActive()).isFalse();
+        assertThat(apiKeyRepository.findById(key2).orElseThrow().isActive()).isFalse();
+
+        // Both audit rows present in the same tx (JWT_KEY_GENERATION_BUMPED + TENANT_SUSPENDED).
+        // audit_events is FORCE-RLS'd (V69); this SELECT as fabt_app with no tenant
+        // context would see zero rows regardless of what got written. Bind
+        // app.tenant_id to the target tenant so RLS admits its own rows.
+        List<String> actions = queryAuditActionsForTenant(tenantId, actor,
+            List.of("JWT_KEY_GENERATION_BUMPED", "TENANT_SUSPENDED"));
+        assertThat(actions).containsExactly("JWT_KEY_GENERATION_BUMPED", "TENANT_SUSPENDED");
+    }
+
+    @Test
+    void suspend_alreadySuspendedTenant_throwsIllegalStateTransition_noSideEffects() {
+        // Idempotency-as-409 contract: second suspend on SUSPENDED tenant must
+        // throw without further JWT bumps or API-key churn.
+        Tenant tenant = saveActiveTenantWithKeyMaterial();
+        UUID tenantId = tenant.getId();
+        lifecycleService.suspend(tenantId, UUID.randomUUID(), "first");
+        int genAfterFirst = queryJwtGen(tenantId);
+
+        UUID secondActor = UUID.randomUUID();
+        assertThatThrownBy(() ->
+                lifecycleService.suspend(tenantId, secondActor, "second"))
+            .isInstanceOf(IllegalStateTransitionException.class);
+
+        // JWT gen unchanged — no second bump
+        assertThat(queryJwtGen(tenantId)).isEqualTo(genAfterFirst);
+
+        // And no audit trail for the failed attempt (F-2 scope). This pins the
+        // current "silent failure" contract explicitly. The forensic gap — an
+        // attacker hammering suspend leaves no trail — is tracked for F-3 in
+        // project_tenant_lifecycle_attempt_audit_gap.md; that slice will add a
+        // TENANT_SUSPEND_ATTEMPT_REJECTED row via REQUIRES_NEW, at which point
+        // THIS assertion flips to expect one row and the test doc-comment updates.
+        List<String> attemptAudit = queryAuditActionsForTenant(tenantId, secondActor,
+            List.of("TENANT_SUSPENDED", "JWT_KEY_GENERATION_BUMPED"));
+        assertThat(attemptAudit).isEmpty();
+    }
+
+    @Test
+    void unsuspend_restoresState_emitsAudit_doesNotReactivateKeys() {
+        // Asymmetric with suspend: unsuspend must NOT auto-reactivate API keys.
+        // Prove at the DB level, not just the mock level.
+        Tenant tenant = saveActiveTenantWithKeyMaterial();
+        UUID tenantId = tenant.getId();
+        UUID key = seedActiveApiKey(tenantId);
+
+        lifecycleService.suspend(tenantId, UUID.randomUUID(), "drill");
+        assertThat(apiKeyRepository.findById(key).orElseThrow().isActive()).isFalse();
+        int genAfterSuspend = queryJwtGen(tenantId);
+
+        UUID actor = UUID.randomUUID();
+        Tenant result = lifecycleService.unsuspend(tenantId, actor, "cleared");
+
+        assertThat(result.getState()).isEqualTo(TenantState.ACTIVE);
+
+        // API key stays deactivated — operator re-issues post-incident
+        assertThat(apiKeyRepository.findById(key).orElseThrow().isActive())
+            .as("unsuspend must NOT reactivate API keys (§D11 post-compromise hygiene)")
+            .isFalse();
+
+        // JWT gen stays at its post-suspend value — no rotation on unsuspend
+        assertThat(queryJwtGen(tenantId))
+            .as("unsuspend must NOT re-rotate JWT keys")
+            .isEqualTo(genAfterSuspend);
+
+        // TENANT_UNSUSPENDED audit row present (bind context to pass RLS).
+        List<String> actions = queryAuditActionsForTenant(tenantId, actor,
+            List.of("TENANT_UNSUSPENDED"));
+        assertThat(actions).containsExactly("TENANT_UNSUSPENDED");
+    }
+
+    // NOTE: a negative-path integration test for mid-transaction rollback (e.g.
+    // force bumpJwt to succeed but deactivateAllForTenant to throw, assert no
+    // partial side effects) requires a DB-layer poison we can't easily inject
+    // without test-only seams in the services. Left to the unit test (which
+    // verifies never-save/never-publish when the FSM assertion fails BEFORE any
+    // side effects); the @Transactional boundary is exercised by the assertion
+    // above that both audit rows land atomically — if a rollback happens after
+    // JWT bump but before TENANT_SUSPENDED, the joined tx would drop both rows.
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private Tenant newTenant(TenantState state) {
+        Tenant t = new Tenant();
+        t.setName("Integration Tenant " + state);
+        t.setSlug("int-f2-" + state.name().toLowerCase() + "-" + UUID.randomUUID());
+        t.setConfig(JsonString.empty());
+        t.setState(state);
+        Instant now = Instant.now();
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        return t;
+    }
+
+    /**
+     * Creates an ACTIVE tenant and bootstraps its JWT key material, simulating the
+     * lazy-bootstrap path that fires on first user login
+     * ({@code JwtService:511 → KidRegistryService.findOrCreateActiveKid}). F-4 will
+     * move this to an eager bootstrap inside {@code TenantLifecycleService.create};
+     * until then, the test path mirrors production's on-first-login bootstrap.
+     */
+    private Tenant saveActiveTenantWithKeyMaterial() {
+        Tenant tenant = tenantRepository.save(newTenant(TenantState.ACTIVE));
+        kidRegistryService.findOrCreateActiveKid(tenant.getId());
+        return tenant;
+    }
+
+    private UUID seedActiveApiKey(UUID tenantId) {
+        ApiKey k = new ApiKey();
+        k.setTenantId(tenantId);
+        k.setKeyHash("test-hash-" + UUID.randomUUID());
+        k.setKeySuffix(UUID.randomUUID().toString().substring(0, 4));
+        k.setLabel("test");
+        k.setRole("COC_ADMIN");
+        k.setActive(true);
+        k.setCreatedAt(Instant.now());
+        return apiKeyRepository.save(k).getId();
+    }
+
+    private int queryJwtGen(UUID tenantId) {
+        return jdbc.queryForObject(
+            "SELECT jwt_key_generation FROM tenant WHERE id = ?",
+            Integer.class, tenantId);
+    }
+
+    /**
+     * Queries {@code audit_events} for a given tenant's actions, binding
+     * {@code app.tenant_id} to the RLS-gated session first so FORCE RLS
+     * admits the tenant's own rows. Matches how the service writes them
+     * (via {@code set_config} inside its own transaction).
+     *
+     * <p>Uses {@code TransactionTemplate} so the {@code set_config(..., true)}
+     * (tx-local) binding and the subsequent query share one JDBC transaction.
+     * Without the tx, {@code is_local=true} scopes to a one-statement tx and
+     * the next statement sees an empty GUC again.</p>
+     */
+    private List<String> queryAuditActionsForTenant(UUID tenantId, UUID actor, List<String> actionFilter) {
+        org.springframework.transaction.support.TransactionTemplate tx =
+            new org.springframework.transaction.support.TransactionTemplate(transactionManager);
+        return tx.execute(status -> {
+            jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantId.toString());
+            // Placeholder-safe IN clause via ANY(array)
+            return jdbc.queryForList(
+                "SELECT action FROM audit_events "
+                + "WHERE actor_user_id = ? AND action = ANY(?) "
+                + "ORDER BY timestamp",
+                String.class, actor, actionFilter.toArray(new String[0]));
+        });
+    }
+
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
@@ -3,23 +3,35 @@ package org.fabt.tenant.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.time.Instant;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.UUID;
 
+import org.fabt.auth.service.ApiKeyService;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.security.TenantKeyRotationService;
 import org.fabt.tenant.domain.IllegalStateTransitionException;
 import org.fabt.tenant.domain.Tenant;
 import org.fabt.tenant.domain.TenantState;
 import org.fabt.tenant.repository.TenantRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 
 /**
  * Unit tests for {@link TenantLifecycleService}'s private {@code transitionTo} contract,
@@ -38,8 +50,42 @@ class TenantLifecycleServiceUnitTest {
     @Mock
     TenantRepository tenantRepository;
 
+    @Mock
+    TenantKeyRotationService tenantKeyRotationService;
+
+    @Mock
+    ApiKeyService apiKeyService;
+
+    @Mock
+    ApplicationEventPublisher eventPublisher;
+
+    @Mock
+    org.springframework.jdbc.core.JdbcTemplate jdbc;
+
     private TenantLifecycleService newService() {
-        return new TenantLifecycleService(tenantRepository);
+        return new TenantLifecycleService(tenantRepository, tenantKeyRotationService,
+                                          apiKeyService, eventPublisher, jdbc);
+    }
+
+    /**
+     * Simulates Spring's {@code @Transactional} tx-active flag so the service's runtime
+     * assertion in {@code bindTenantContextForAudit} passes. Without this, the assertion
+     * correctly fires (no real tx in a Mockito unit context). {@code @AfterEach} resets
+     * the flag so one test's state cannot leak to the next.
+     */
+    @BeforeEach
+    void activateMockTransaction() {
+        TransactionSynchronizationManager.setActualTransactionActive(true);
+    }
+
+    @AfterEach
+    void deactivateMockTransaction() {
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+    }
+
+    private static TenantKeyRotationService.RotationResult rotationResult(int kids) {
+        return new TenantKeyRotationService.RotationResult(
+            UUID.randomUUID(), 1, 2, kids, Instant.now());
     }
 
     // ─── Failure branch 1: tenant-not-found ──────────────────────────────────
@@ -82,8 +128,12 @@ class TenantLifecycleServiceUnitTest {
     }
 
     @Test
-    void suspend_archivedTenant_throwsIllegalStateTransition_noSave() {
-        // ARCHIVED -> SUSPENDED is not a permitted §D8 transition
+    void suspend_archivedTenant_throwsBeforeAnySideEffects() {
+        // ARCHIVED -> SUSPENDED is not a permitted §D8 transition. Critical
+        // safety property: the FSM assertion must fail BEFORE we invalidate
+        // JWT keys or deactivate API keys — otherwise a stray operator click
+        // on a SUSPEND button for an already-archived tenant would destroy
+        // evidence that belongs in the export bundle.
         Tenant archived = newTenant(TenantState.ARCHIVED);
         when(tenantRepository.findById(archived.getId())).thenReturn(Optional.of(archived));
 
@@ -91,6 +141,9 @@ class TenantLifecycleServiceUnitTest {
             .isInstanceOf(IllegalStateTransitionException.class);
 
         verify(tenantRepository, never()).save(any());
+        verify(tenantKeyRotationService, never()).bumpJwtKeyGeneration(any(), any());
+        verify(apiKeyService, never()).deactivateAllForTenant(any());
+        verify(eventPublisher, never()).publishEvent(any());
     }
 
     @Test
@@ -108,30 +161,99 @@ class TenantLifecycleServiceUnitTest {
     // ─── Happy path: load → assert → flip → save ────────────────────────────
 
     @Test
-    void suspend_activeTenant_flipsStateAndSavesExactlyOnce() {
+    void suspend_activeTenant_bumpsJwtDeactivatesKeysFlipsStateAndAudits() {
         Tenant active = newTenant(TenantState.ACTIVE);
+        UUID actor = UUID.randomUUID();
         when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+        when(tenantKeyRotationService.bumpJwtKeyGeneration(active.getId(), actor))
+            .thenReturn(rotationResult(3));
+        when(apiKeyService.deactivateAllForTenant(active.getId())).thenReturn(2);
         when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Tenant result = newService().suspend(active.getId(), UUID.randomUUID(), "quarantine");
+        Tenant result = newService().suspend(active.getId(), actor, "incident-2026-04-23");
 
         assertThat(result.getState()).isEqualTo(TenantState.SUSPENDED);
-        assertThat(active.getState())
-            .as("same instance mutated then saved")
-            .isEqualTo(TenantState.SUSPENDED);
+        verify(tenantKeyRotationService, times(1)).bumpJwtKeyGeneration(active.getId(), actor);
+        verify(apiKeyService, times(1)).deactivateAllForTenant(active.getId());
         verify(tenantRepository, times(1)).save(active);
+
+        AuditEventRecord audit = captureAuditEvent();
+        assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_SUSPENDED);
+        assertThat(audit.actorUserId()).isEqualTo(actor);
+        assertThat(audit.targetUserId()).isNull();
     }
 
     @Test
-    void unsuspend_suspendedTenant_flipsStateAndSaves() {
+    void suspend_auditDetailsContainActorJustificationPreviousStateAndCounts() {
+        // Phase G's platform_admin_access_log reads actor_user_id +
+        // justification directly — these field names are part of the F-1
+        // contract and regressing them breaks G3 silently. Pin the shape.
+        Tenant active = newTenant(TenantState.ACTIVE);
+        UUID actor = UUID.randomUUID();
+        when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+        when(tenantKeyRotationService.bumpJwtKeyGeneration(any(), any()))
+            .thenReturn(rotationResult(7));
+        when(apiKeyService.deactivateAllForTenant(any())).thenReturn(4);
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        newService().suspend(active.getId(), actor, "quarterly-review-fire");
+
+        AuditEventRecord audit = captureAuditEvent();
+        assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_SUSPENDED);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> details = (Map<String, Object>) audit.details();
+        assertThat(details)
+            .containsEntry("actor_user_id", actor.toString())
+            .containsEntry("justification", "quarterly-review-fire")
+            .containsEntry("previous_state", "ACTIVE")
+            .containsEntry("revokedKidCount", 7)
+            .containsEntry("deactivatedApiKeys", 4);
+    }
+
+    @Test
+    void suspend_nullActorUserId_permittedAndRenderedAsNullInDetails() {
+        // bumpJwtKeyGeneration Javadoc states actorUserId may be null for
+        // system-initiated operations (automated abuse response). Contract
+        // carries through the lifecycle service to the audit details.
+        Tenant active = newTenant(TenantState.ACTIVE);
+        when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+        when(tenantKeyRotationService.bumpJwtKeyGeneration(any(), eq((UUID) null)))
+            .thenReturn(rotationResult(0));
+        when(apiKeyService.deactivateAllForTenant(any())).thenReturn(0);
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        newService().suspend(active.getId(), null, "system-initiated");
+
+        AuditEventRecord audit = captureAuditEvent();
+        assertThat(audit.actorUserId()).isNull();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> details = (Map<String, Object>) audit.details();
+        assertThat(details).containsEntry("actor_user_id", null);
+    }
+
+    @Test
+    void unsuspend_suspendedTenant_doesNotBumpJwtOrDeactivateKeys_auditEmitted() {
+        // Asymmetry with suspend: unsuspend does NOT re-rotate JWT and does
+        // NOT reactivate API keys (§D11 post-compromise hygiene). Regressing
+        // either is a silent escalation of privilege on an already-SUSPENDED
+        // tenant — lock it down with explicit neverCalled assertions.
         Tenant suspended = newTenant(TenantState.SUSPENDED);
+        UUID actor = UUID.randomUUID();
         when(tenantRepository.findById(suspended.getId())).thenReturn(Optional.of(suspended));
         when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Tenant result = newService().unsuspend(suspended.getId(), UUID.randomUUID(), "cleared");
+        Tenant result = newService().unsuspend(suspended.getId(), actor, "incident-cleared");
 
         assertThat(result.getState()).isEqualTo(TenantState.ACTIVE);
+        verify(tenantKeyRotationService, never()).bumpJwtKeyGeneration(any(), any());
+        verify(apiKeyService, never()).deactivateAllForTenant(any());
         verify(tenantRepository, times(1)).save(suspended);
+
+        AuditEventRecord audit = captureAuditEvent();
+        assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_UNSUSPENDED);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> details = (Map<String, Object>) audit.details();
+        assertThat(details).containsEntry("previous_state", "SUSPENDED");
     }
 
     @Test
@@ -178,6 +300,29 @@ class TenantLifecycleServiceUnitTest {
             .hasMessageContaining("F-6");
     }
 
+    // ─── Runtime assertion guarding set_config scope ─────────────────────────
+
+    @Test
+    void suspend_withoutActiveTransaction_throwsBeforeSideEffects() {
+        // Defense against a future refactor that drops @Transactional from suspend:
+        // the set_config('app.tenant_id', ?, true) binding is tx-scoped, so without a
+        // tx the subsequent audit INSERT silently falls back to SYSTEM_TENANT_ID.
+        // The runtime assertion in bindTenantContextForAudit catches this at call
+        // time. Remove the tx-active simulation and prove the assertion fires.
+        TransactionSynchronizationManager.setActualTransactionActive(false);
+        Tenant active = newTenant(TenantState.ACTIVE);
+        when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+
+        assertThatThrownBy(() -> newService().suspend(active.getId(), UUID.randomUUID(), "op"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("requires an active transaction");
+
+        verify(tenantKeyRotationService, never()).bumpJwtKeyGeneration(any(), any());
+        verify(apiKeyService, never()).deactivateAllForTenant(any());
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(tenantRepository, never()).save(any());
+    }
+
     // ─── Fixture helper ──────────────────────────────────────────────────────
 
     private static Tenant newTenant(TenantState state) {
@@ -187,5 +332,18 @@ class TenantLifecycleServiceUnitTest {
         t.setSlug("test-tenant-" + UUID.randomUUID());
         t.setState(state);
         return t;
+    }
+
+    /**
+     * Captures the single {@link AuditEventRecord} published via the mocked
+     * {@link ApplicationEventPublisher}. Avoids the {@code argThat} type-inference
+     * collision between Spring's overloaded {@code publishEvent(ApplicationEvent)}
+     * and {@code publishEvent(Object)} — the captor binds the generic to
+     * {@link AuditEventRecord} directly.
+     */
+    private AuditEventRecord captureAuditEvent() {
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        return captor.getValue();
     }
 }

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
@@ -3,7 +3,9 @@ package org.fabt.tenant.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
@@ -70,8 +72,12 @@ class TenantLifecycleServiceUnitTest {
     @Mock
     DetachedAuditPersister detachedAuditPersister;
 
+    @Mock
+    org.fabt.shared.security.KidRegistryService kidRegistryService;
+
     private TenantLifecycleService newService() {
         return new TenantLifecycleService(tenantRepository, tenantKeyRotationService,
+                                          kidRegistryService,
                                           apiKeyService, eventPublisher, jdbc,
                                           tenantStateGuard, detachedAuditPersister);
     }
@@ -319,12 +325,114 @@ class TenantLifecycleServiceUnitTest {
 
     // ─── Stub methods (F-1 scope: create + hardDelete intentionally deferred) ─
 
+    // ─── F-4 create bootstrap ────────────────────────────────────────────────
+
     @Test
-    void create_throwsUnsupportedOperation_deferredToF4() {
+    void create_happyPath_savesTenantBootstrapsKeyMaterialSeedsChainHeadEmitsAudit() {
+        UUID generatedId = UUID.randomUUID();
+        UUID actor = UUID.randomUUID();
+        when(tenantRepository.existsBySlug("demo-slug")).thenReturn(false);
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> {
+            Tenant t = inv.getArgument(0);
+            t.setId(generatedId);
+            return t;
+        });
+
+        Tenant result = newService().create("Demo CoC", "demo-slug", actor);
+
+        assertThat(result.getId()).isEqualTo(generatedId);
+        assertThat(result.getState()).isEqualTo(TenantState.ACTIVE);
+        assertThat(result.getSlug()).isEqualTo("demo-slug");
+        assertThat(result.getName()).isEqualTo("Demo CoC");
+
+        // Step ordering assertions — save BEFORE key material bootstrap BEFORE
+        // audit_chain_head seed BEFORE audit emit. If any of these are swapped,
+        // the tx boundary and the D55 tenant-id binding break.
+        verify(tenantRepository, times(1)).existsBySlug("demo-slug");
+        verify(tenantRepository, times(1)).save(any(Tenant.class));
+        verify(kidRegistryService, times(1)).findOrCreateActiveKid(generatedId);
+        verify(jdbc, times(1)).update(contains("tenant_audit_chain_head"), eq(generatedId));
+
+        AuditEventRecord audit = captureAuditEvent();
+        assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_CREATED);
+        assertThat(audit.actorUserId()).isEqualTo(actor);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> details = (Map<String, Object>) audit.details();
+        assertThat(details)
+            .containsEntry("slug", "demo-slug")
+            .containsEntry("name", "Demo CoC")
+            .containsEntry("actor_user_id", actor.toString());
+    }
+
+    @Test
+    void create_duplicateSlug_throwsBeforeAnySideEffects() {
+        // Idempotency-as-409 contract: second create with a taken slug must throw
+        // without spending any key-derivation, audit, or chain-head work. Spring's
+        // @Transactional rolls back on the exception, so downstream state is
+        // untouched regardless — but the explicit existsBySlug fast-path avoids
+        // the expensive work entirely.
+        when(tenantRepository.existsBySlug("taken-slug")).thenReturn(true);
+
         assertThatThrownBy(() ->
-                newService().create("Demo", "demo-slug", UUID.randomUUID()))
-            .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("F-4");
+                newService().create("Second", "taken-slug", UUID.randomUUID()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("taken-slug");
+
+        verify(tenantRepository, never()).save(any());
+        verify(kidRegistryService, never()).findOrCreateActiveKid(any());
+        verify(jdbc, never()).update(contains("tenant_audit_chain_head"), any(Object.class));
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void create_nullActorUserId_acceptedForSystemInitiatedBootstraps() {
+        // create(name, slug, null) is valid — used by seed migrations and
+        // platform bootstrap scripts that have no human actor. The audit row's
+        // actor_user_id field is null; details map renders "actor_user_id" as
+        // JSON null for Phase G consumers.
+        UUID generatedId = UUID.randomUUID();
+        when(tenantRepository.existsBySlug(any())).thenReturn(false);
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> {
+            Tenant t = inv.getArgument(0);
+            t.setId(generatedId);
+            return t;
+        });
+
+        Tenant result = newService().create("Sys", "sys-seed", null);
+
+        assertThat(result.getId()).isEqualTo(generatedId);
+        AuditEventRecord audit = captureAuditEvent();
+        assertThat(audit.actorUserId()).isNull();
+        @SuppressWarnings("unchecked")
+        Map<String, Object> details = (Map<String, Object>) audit.details();
+        assertThat(details).containsEntry("actor_user_id", null);
+    }
+
+    @Test
+    void create_keyMaterialBootstrapFails_propagates_noAuditEmitted() {
+        // Failure-injection: if findOrCreateActiveKid throws (e.g. DB contention,
+        // RLS rejection, KEK unavailable), the tx rolls back and no audit row
+        // lands. The outer @Transactional handles rollback; this test pins the
+        // propagation shape.
+        UUID generatedId = UUID.randomUUID();
+        when(tenantRepository.existsBySlug(any())).thenReturn(false);
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> {
+            Tenant t = inv.getArgument(0);
+            t.setId(generatedId);
+            return t;
+        });
+        doThrow(new IllegalStateException("KEK unavailable"))
+            .when(kidRegistryService).findOrCreateActiveKid(generatedId);
+
+        assertThatThrownBy(() -> newService().create("Fail", "fail-slug", UUID.randomUUID()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("KEK unavailable");
+
+        // Audit must NOT fire — the tx will roll back, but we also want the
+        // explicit "not published" contract so a future refactor can't silently
+        // emit an audit row before the failing step.
+        verify(eventPublisher, never()).publishEvent(any());
+        verify(jdbc, never()).update(contains("tenant_audit_chain_head"), any(Object.class));
     }
 
     @Test

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
@@ -1,0 +1,191 @@
+package org.fabt.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.NoSuchElementException;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.fabt.tenant.domain.IllegalStateTransitionException;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.repository.TenantRepository;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Unit tests for {@link TenantLifecycleService}'s private {@code transitionTo} contract,
+ * exercised via the public suspend/unsuspend/offboard/archive methods. Covers the two
+ * failure branches (tenant-not-found, forbidden-transition) and the happy-path shape
+ * (load → assert → flip → save, no other side effects) before F-2 layers JWT bump +
+ * audit emission on top.
+ *
+ * <p>Scope deliberately narrow: the FSM matrix itself is covered by
+ * {@link org.fabt.tenant.domain.TenantStateTransitionTest}; the DB round-trip is
+ * covered by {@code TenantIntegrationTest}. This file is the service-level contract.</p>
+ */
+@ExtendWith(MockitoExtension.class)
+class TenantLifecycleServiceUnitTest {
+
+    @Mock
+    TenantRepository tenantRepository;
+
+    private TenantLifecycleService newService() {
+        return new TenantLifecycleService(tenantRepository);
+    }
+
+    // ─── Failure branch 1: tenant-not-found ──────────────────────────────────
+
+    @Test
+    void suspend_unknownTenant_throwsNoSuchElementExceptionReferencingId() {
+        UUID unknown = UUID.randomUUID();
+        when(tenantRepository.findById(unknown)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> newService().suspend(unknown, UUID.randomUUID(), "op"))
+            .isInstanceOf(NoSuchElementException.class)
+            .hasMessageContaining(unknown.toString());
+
+        verify(tenantRepository, never()).save(any());
+    }
+
+    @Test
+    void unsuspend_unknownTenant_throwsNoSuchElementException() {
+        UUID unknown = UUID.randomUUID();
+        when(tenantRepository.findById(unknown)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> newService().unsuspend(unknown, UUID.randomUUID(), "op"))
+            .isInstanceOf(NoSuchElementException.class);
+
+        verify(tenantRepository, never()).save(any());
+    }
+
+    // ─── Failure branch 2: forbidden transition ─────────────────────────────
+
+    @Test
+    void unsuspend_activeTenant_throwsIllegalStateTransition_noSave() {
+        // ACTIVE -> ACTIVE is a self-transition, disallowed by §D8
+        Tenant active = newTenant(TenantState.ACTIVE);
+        when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+
+        assertThatThrownBy(() -> newService().unsuspend(active.getId(), UUID.randomUUID(), "op"))
+            .isInstanceOf(IllegalStateTransitionException.class);
+
+        verify(tenantRepository, never()).save(any());
+    }
+
+    @Test
+    void suspend_archivedTenant_throwsIllegalStateTransition_noSave() {
+        // ARCHIVED -> SUSPENDED is not a permitted §D8 transition
+        Tenant archived = newTenant(TenantState.ARCHIVED);
+        when(tenantRepository.findById(archived.getId())).thenReturn(Optional.of(archived));
+
+        assertThatThrownBy(() -> newService().suspend(archived.getId(), UUID.randomUUID(), "op"))
+            .isInstanceOf(IllegalStateTransitionException.class);
+
+        verify(tenantRepository, never()).save(any());
+    }
+
+    @Test
+    void archive_activeTenant_throwsIllegalStateTransition_noSave() {
+        // ACTIVE -> ARCHIVED must go through OFFBOARDING first per §D8
+        Tenant active = newTenant(TenantState.ACTIVE);
+        when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+
+        assertThatThrownBy(() -> newService().archive(active.getId(), UUID.randomUUID(), "op"))
+            .isInstanceOf(IllegalStateTransitionException.class);
+
+        verify(tenantRepository, never()).save(any());
+    }
+
+    // ─── Happy path: load → assert → flip → save ────────────────────────────
+
+    @Test
+    void suspend_activeTenant_flipsStateAndSavesExactlyOnce() {
+        Tenant active = newTenant(TenantState.ACTIVE);
+        when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Tenant result = newService().suspend(active.getId(), UUID.randomUUID(), "quarantine");
+
+        assertThat(result.getState()).isEqualTo(TenantState.SUSPENDED);
+        assertThat(active.getState())
+            .as("same instance mutated then saved")
+            .isEqualTo(TenantState.SUSPENDED);
+        verify(tenantRepository, times(1)).save(active);
+    }
+
+    @Test
+    void unsuspend_suspendedTenant_flipsStateAndSaves() {
+        Tenant suspended = newTenant(TenantState.SUSPENDED);
+        when(tenantRepository.findById(suspended.getId())).thenReturn(Optional.of(suspended));
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Tenant result = newService().unsuspend(suspended.getId(), UUID.randomUUID(), "cleared");
+
+        assertThat(result.getState()).isEqualTo(TenantState.ACTIVE);
+        verify(tenantRepository, times(1)).save(suspended);
+    }
+
+    @Test
+    void offboard_fromActiveOrSuspended_flipsToOffboarding() {
+        for (TenantState start : new TenantState[]{TenantState.ACTIVE, TenantState.SUSPENDED}) {
+            Tenant t = newTenant(start);
+            when(tenantRepository.findById(t.getId())).thenReturn(Optional.of(t));
+            when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+            Tenant result = newService().offboard(t.getId(), UUID.randomUUID(), "tenant-request");
+
+            assertThat(result.getState())
+                .as("offboard from %s", start)
+                .isEqualTo(TenantState.OFFBOARDING);
+        }
+    }
+
+    @Test
+    void archive_fromOffboarding_flipsToArchived() {
+        Tenant t = newTenant(TenantState.OFFBOARDING);
+        when(tenantRepository.findById(t.getId())).thenReturn(Optional.of(t));
+        when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+
+        Tenant result = newService().archive(t.getId(), UUID.randomUUID(), "export-complete");
+
+        assertThat(result.getState()).isEqualTo(TenantState.ARCHIVED);
+    }
+
+    // ─── Stub methods (F-1 scope: create + hardDelete intentionally deferred) ─
+
+    @Test
+    void create_throwsUnsupportedOperation_deferredToF4() {
+        assertThatThrownBy(() ->
+                newService().create("Demo", "demo-slug", UUID.randomUUID()))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("F-4");
+    }
+
+    @Test
+    void hardDelete_throwsUnsupportedOperation_deferredToF6() {
+        assertThatThrownBy(() ->
+                newService().hardDelete(UUID.randomUUID(), UUID.randomUUID(), "retention-complete"))
+            .isInstanceOf(UnsupportedOperationException.class)
+            .hasMessageContaining("F-6");
+    }
+
+    // ─── Fixture helper ──────────────────────────────────────────────────────
+
+    private static Tenant newTenant(TenantState state) {
+        Tenant t = new Tenant();
+        t.setId(UUID.randomUUID());
+        t.setName("Test Tenant");
+        t.setSlug("test-tenant-" + UUID.randomUUID());
+        t.setState(state);
+        return t;
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
@@ -18,6 +18,7 @@ import java.util.UUID;
 import org.fabt.auth.service.ApiKeyService;
 import org.fabt.shared.audit.AuditEventRecord;
 import org.fabt.shared.audit.AuditEventTypes;
+import org.fabt.shared.audit.DetachedAuditPersister;
 import org.fabt.shared.security.TenantKeyRotationService;
 import org.fabt.tenant.service.TenantStateGuard;
 import org.fabt.tenant.domain.IllegalStateTransitionException;
@@ -66,10 +67,13 @@ class TenantLifecycleServiceUnitTest {
     @Mock
     TenantStateGuard tenantStateGuard;
 
+    @Mock
+    DetachedAuditPersister detachedAuditPersister;
+
     private TenantLifecycleService newService() {
         return new TenantLifecycleService(tenantRepository, tenantKeyRotationService,
                                           apiKeyService, eventPublisher, jdbc,
-                                          tenantStateGuard);
+                                          tenantStateGuard, detachedAuditPersister);
     }
 
     /**
@@ -121,46 +125,72 @@ class TenantLifecycleServiceUnitTest {
     // ─── Failure branch 2: forbidden transition ─────────────────────────────
 
     @Test
-    void unsuspend_activeTenant_throwsIllegalStateTransition_noSave() {
-        // ACTIVE -> ACTIVE is a self-transition, disallowed by §D8
+    void unsuspend_activeTenant_throwsIllegalStateTransition_persistsRejectedAuditBeforeRethrow() {
+        // ACTIVE -> ACTIVE is a self-transition, disallowed by §D8.
+        // F-3.6: the rejected attempt persists TENANT_UNSUSPEND_REJECTED via
+        // DetachedAuditPersister (REQUIRES_NEW) BEFORE the exception propagates.
         Tenant active = newTenant(TenantState.ACTIVE);
         when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+        UUID actor = UUID.randomUUID();
 
-        assertThatThrownBy(() -> newService().unsuspend(active.getId(), UUID.randomUUID(), "op"))
+        assertThatThrownBy(() -> newService().unsuspend(active.getId(), actor, "op"))
             .isInstanceOf(IllegalStateTransitionException.class);
 
         verify(tenantRepository, never()).save(any());
+
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(detachedAuditPersister, times(1)).persistDetached(eq(active.getId()), captor.capture());
+        AuditEventRecord rejection = captor.getValue();
+        assertThat(rejection.action()).isEqualTo(AuditEventTypes.TENANT_UNSUSPEND_REJECTED);
+        assertThat(rejection.actorUserId()).isEqualTo(actor);
     }
 
     @Test
-    void suspend_archivedTenant_throwsBeforeAnySideEffects() {
+    void suspend_archivedTenant_throwsBeforeAnySideEffects_persistsRejectedAudit() {
         // ARCHIVED -> SUSPENDED is not a permitted §D8 transition. Critical
         // safety property: the FSM assertion must fail BEFORE we invalidate
         // JWT keys or deactivate API keys — otherwise a stray operator click
         // on a SUSPEND button for an already-archived tenant would destroy
         // evidence that belongs in the export bundle.
+        //
+        // F-3.6: the rejected attempt still persists TENANT_SUSPEND_REJECTED
+        // via DetachedAuditPersister so forensic trail survives.
         Tenant archived = newTenant(TenantState.ARCHIVED);
         when(tenantRepository.findById(archived.getId())).thenReturn(Optional.of(archived));
+        UUID actor = UUID.randomUUID();
 
-        assertThatThrownBy(() -> newService().suspend(archived.getId(), UUID.randomUUID(), "op"))
+        assertThatThrownBy(() -> newService().suspend(archived.getId(), actor, "op"))
             .isInstanceOf(IllegalStateTransitionException.class);
 
         verify(tenantRepository, never()).save(any());
         verify(tenantKeyRotationService, never()).bumpJwtKeyGeneration(any(), any());
         verify(apiKeyService, never()).deactivateAllForTenant(any());
         verify(eventPublisher, never()).publishEvent(any());
+
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(detachedAuditPersister, times(1)).persistDetached(eq(archived.getId()), captor.capture());
+        AuditEventRecord rejection = captor.getValue();
+        assertThat(rejection.action()).isEqualTo(AuditEventTypes.TENANT_SUSPEND_REJECTED);
+        assertThat(rejection.actorUserId()).isEqualTo(actor);
     }
 
     @Test
-    void archive_activeTenant_throwsIllegalStateTransition_noSave() {
-        // ACTIVE -> ARCHIVED must go through OFFBOARDING first per §D8
+    void archive_activeTenant_throwsIllegalStateTransition_persistsRejectedAudit() {
+        // ACTIVE -> ARCHIVED must go through OFFBOARDING first per §D8.
+        // F-3.6: rejected archive attempts persist TENANT_ARCHIVE_REJECTED.
         Tenant active = newTenant(TenantState.ACTIVE);
         when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+        UUID actor = UUID.randomUUID();
 
-        assertThatThrownBy(() -> newService().archive(active.getId(), UUID.randomUUID(), "op"))
+        assertThatThrownBy(() -> newService().archive(active.getId(), actor, "op"))
             .isInstanceOf(IllegalStateTransitionException.class);
 
         verify(tenantRepository, never()).save(any());
+
+        ArgumentCaptor<AuditEventRecord> captor = ArgumentCaptor.forClass(AuditEventRecord.class);
+        verify(detachedAuditPersister, times(1)).persistDetached(eq(active.getId()), captor.capture());
+        assertThat(captor.getValue().action())
+            .isEqualTo(AuditEventTypes.TENANT_ARCHIVE_REJECTED);
     }
 
     // ─── Happy path: load → assert → flip → save ────────────────────────────

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
@@ -19,6 +19,7 @@ import org.fabt.auth.service.ApiKeyService;
 import org.fabt.shared.audit.AuditEventRecord;
 import org.fabt.shared.audit.AuditEventTypes;
 import org.fabt.shared.security.TenantKeyRotationService;
+import org.fabt.tenant.service.TenantStateGuard;
 import org.fabt.tenant.domain.IllegalStateTransitionException;
 import org.fabt.tenant.domain.Tenant;
 import org.fabt.tenant.domain.TenantState;
@@ -62,9 +63,13 @@ class TenantLifecycleServiceUnitTest {
     @Mock
     org.springframework.jdbc.core.JdbcTemplate jdbc;
 
+    @Mock
+    TenantStateGuard tenantStateGuard;
+
     private TenantLifecycleService newService() {
         return new TenantLifecycleService(tenantRepository, tenantKeyRotationService,
-                                          apiKeyService, eventPublisher, jdbc);
+                                          apiKeyService, eventPublisher, jdbc,
+                                          tenantStateGuard);
     }
 
     /**

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
@@ -75,11 +75,15 @@ class TenantLifecycleServiceUnitTest {
     @Mock
     org.fabt.shared.security.KidRegistryService kidRegistryService;
 
+    @Mock
+    TenantOffboardExportService offboardExportService;
+
     private TenantLifecycleService newService() {
         return new TenantLifecycleService(tenantRepository, tenantKeyRotationService,
                                           kidRegistryService,
                                           apiKeyService, eventPublisher, jdbc,
-                                          tenantStateGuard, detachedAuditPersister);
+                                          tenantStateGuard, detachedAuditPersister,
+                                          offboardExportService);
     }
 
     /**
@@ -298,29 +302,106 @@ class TenantLifecycleServiceUnitTest {
     }
 
     @Test
-    void offboard_fromActiveOrSuspended_flipsToOffboarding() {
+    void offboard_fromActiveOrSuspended_exportsThenFlipsThenAuditsWithReceiptUri() {
         for (TenantState start : new TenantState[]{TenantState.ACTIVE, TenantState.SUSPENDED}) {
+            // Fresh mocks per iteration — avoid stale argument captor state.
+            org.mockito.Mockito.reset(offboardExportService, eventPublisher, tenantRepository);
             Tenant t = newTenant(start);
+            String fakeReceiptUri = "/var/fabt/exports/" + t.getId() + "/20260424-010203.json";
             when(tenantRepository.findById(t.getId())).thenReturn(Optional.of(t));
             when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
+            when(offboardExportService.exportTenant(t.getId())).thenReturn(fakeReceiptUri);
 
             Tenant result = newService().offboard(t.getId(), UUID.randomUUID(), "tenant-request");
 
             assertThat(result.getState())
                 .as("offboard from %s", start)
                 .isEqualTo(TenantState.OFFBOARDING);
+            assertThat(result.getOffboardExportReceiptUri())
+                .as("receipt URI stored on tenant row")
+                .isEqualTo(fakeReceiptUri);
+            verify(offboardExportService, times(1)).exportTenant(t.getId());
+
+            AuditEventRecord audit = captureAuditEvent();
+            assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_OFFBOARDING_STARTED);
+            @SuppressWarnings("unchecked")
+            Map<String, Object> details = (Map<String, Object>) audit.details();
+            assertThat(details)
+                .containsEntry("previous_state", start.name())
+                .containsEntry("export_receipt_uri", fakeReceiptUri);
         }
     }
 
     @Test
-    void archive_fromOffboarding_flipsToArchived() {
+    void offboard_exportFails_propagatesWithoutStateFlip() {
+        // Export failure → outer @Transactional rolls back. We can't test the
+        // rollback mechanics in a unit context, but we CAN verify that the
+        // exception propagates unchanged AND that save() was never called
+        // (i.e. state flip never attempted).
+        Tenant t = newTenant(TenantState.ACTIVE);
+        when(tenantRepository.findById(t.getId())).thenReturn(Optional.of(t));
+        when(offboardExportService.exportTenant(t.getId()))
+            .thenThrow(new java.io.UncheckedIOException(
+                "Disk full",
+                new java.io.IOException("ENOSPC")));
+
+        assertThatThrownBy(() -> newService().offboard(t.getId(), UUID.randomUUID(), "drill"))
+            .isInstanceOf(java.io.UncheckedIOException.class)
+            .hasMessageContaining("Disk full");
+
+        verify(tenantRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void archive_withExportReceipt_flipsToArchivedAndStampsArchivedAt() {
         Tenant t = newTenant(TenantState.OFFBOARDING);
+        t.setOffboardExportReceiptUri("/var/fabt/exports/" + t.getId() + "/20260424-010203.json");
         when(tenantRepository.findById(t.getId())).thenReturn(Optional.of(t));
         when(tenantRepository.save(any(Tenant.class))).thenAnswer(inv -> inv.getArgument(0));
 
-        Tenant result = newService().archive(t.getId(), UUID.randomUUID(), "export-complete");
+        Tenant result = newService().archive(t.getId(), UUID.randomUUID(), "retention-start");
 
         assertThat(result.getState()).isEqualTo(TenantState.ARCHIVED);
+        assertThat(result.getArchivedAt())
+            .as("archived_at stamp starts the 30-day retention window")
+            .isNotNull();
+
+        AuditEventRecord audit = captureAuditEvent();
+        assertThat(audit.action()).isEqualTo(AuditEventTypes.TENANT_ARCHIVED);
+        @SuppressWarnings("unchecked")
+        Map<String, Object> details = (Map<String, Object>) audit.details();
+        assertThat(details)
+            .containsKey("archived_at")
+            .containsEntry("previous_state", "OFFBOARDING");
+    }
+
+    @Test
+    void archive_withoutExportReceipt_throwsBeforeStateFlip() {
+        // GDPR Art. 20 sequencing guard: archive() must refuse if offboard() never
+        // ran (receipt URI is null). The §D8 FSM allows OFFBOARDING -> ARCHIVED,
+        // but this is a stronger contract on top.
+        Tenant t = newTenant(TenantState.OFFBOARDING);
+        t.setOffboardExportReceiptUri(null);
+        when(tenantRepository.findById(t.getId())).thenReturn(Optional.of(t));
+
+        assertThatThrownBy(() -> newService().archive(t.getId(), UUID.randomUUID(), "drill"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("cannot be archived without an offboard export receipt");
+
+        verify(tenantRepository, never()).save(any());
+        verify(eventPublisher, never()).publishEvent(any());
+    }
+
+    @Test
+    void archive_withBlankExportReceipt_throwsLikeNull() {
+        Tenant t = newTenant(TenantState.OFFBOARDING);
+        t.setOffboardExportReceiptUri("   ");  // whitespace — isBlank() guard catches
+        when(tenantRepository.findById(t.getId())).thenReturn(Optional.of(t));
+
+        assertThatThrownBy(() -> newService().archive(t.getId(), UUID.randomUUID(), "drill"))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessageContaining("export receipt");
     }
 
     // ─── Stub methods (F-1 scope: create + hardDelete intentionally deferred) ─

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleServiceUnitTest.java
@@ -3,6 +3,7 @@ package org.fabt.tenant.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -78,12 +79,21 @@ class TenantLifecycleServiceUnitTest {
     @Mock
     TenantOffboardExportService offboardExportService;
 
+    @Mock
+    org.fabt.shared.security.TenantDekService tenantDekService;
+
     private TenantLifecycleService newService() {
+        // F-6.0 task 7.8f: two new constructor params — TenantDekService (for
+        // hardDelete cache invalidation) and the retention-days config value.
+        // Zero-day retention in unit tests so hardDelete is exercisable without
+        // time-travel; prod default is 30 days.
         return new TenantLifecycleService(tenantRepository, tenantKeyRotationService,
                                           kidRegistryService,
                                           apiKeyService, eventPublisher, jdbc,
                                           tenantStateGuard, detachedAuditPersister,
-                                          offboardExportService);
+                                          offboardExportService,
+                                          tenantDekService,
+                                          0L);
     }
 
     /**
@@ -517,11 +527,25 @@ class TenantLifecycleServiceUnitTest {
     }
 
     @Test
-    void hardDelete_throwsUnsupportedOperation_deferredToF6() {
+    void hardDelete_fromActiveState_rejectsFsmAndEmitsAttemptAudit() {
+        // F-6.0 task 7.8f: hardDelete is now implemented. Unit-test coverage
+        // here proves the FSM rejection path (ACTIVE → DELETED is not allowed)
+        // emits a TENANT_HARD_DELETE_REJECTED audit row via the detached
+        // persister before propagating the IllegalStateTransitionException.
+        // End-to-end happy-path + retention gate + CASCADE behavior is pinned
+        // by TenantLifecycleHardDeleteIntegrationTest against a real DB.
+        Tenant active = newTenant(TenantState.ACTIVE);
+        when(tenantRepository.findById(active.getId())).thenReturn(Optional.of(active));
+
+        UUID actor = UUID.randomUUID();
         assertThatThrownBy(() ->
-                newService().hardDelete(UUID.randomUUID(), UUID.randomUUID(), "retention-complete"))
-            .isInstanceOf(UnsupportedOperationException.class)
-            .hasMessageContaining("F-6");
+                newService().hardDelete(active.getId(), actor, "skip-archive"))
+            .isInstanceOf(org.fabt.tenant.domain.IllegalStateTransitionException.class);
+
+        verify(detachedAuditPersister).persistDetached(
+                eq(active.getId()),
+                argThat(event -> org.fabt.shared.audit.AuditEventTypes.TENANT_HARD_DELETE_REJECTED
+                        .equals(event.action())));
     }
 
     // ─── Runtime assertion guarding set_config scope ─────────────────────────

--- a/backend/src/test/java/org/fabt/tenant/service/TenantStateBreachSimIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantStateBreachSimIntegrationTest.java
@@ -1,0 +1,200 @@
+package org.fabt.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.Instant;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.auth.domain.ApiKey;
+import org.fabt.auth.repository.ApiKeyRepository;
+import org.fabt.shared.config.JsonString;
+import org.fabt.shared.security.KidRegistryService;
+import org.fabt.shared.web.TenantContext;
+import org.fabt.subscription.domain.Subscription;
+import org.fabt.subscription.repository.SubscriptionRepository;
+import org.fabt.tenant.domain.Tenant;
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.domain.TenantStateGuardException;
+import org.fabt.tenant.repository.TenantRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+/**
+ * J7-minimal breach simulation — Marcus's security bar for v0.51.0 per the F-2 warroom.
+ * Proves the F-3 read-path enforcement end-to-end: a tenant whose state is flipped to
+ * SUSPENDED via {@code TenantLifecycleService.suspend} becomes invisible to
+ * request-bound reads, both via the caller-tenant interceptor gate (F-3.3) and the
+ * target-tenant SQL JOIN gate (F-3.2). No 403, no 500, no data leak — just 404 (or an
+ * empty {@code Optional} at the service layer that maps to 404 at the controller).
+ *
+ * <p>Two attack vectors covered:
+ * <ol>
+ *   <li><b>Suspended caller</b> ({@link #suspendedCaller_cannotRead_viaInterceptor}) —
+ *       Tenant A's own token gets {@link TenantStateGuardException#kind()}
+ *       {@code NON_ACTIVE} from {@link TenantStateGuard#requireActive}. The interceptor
+ *       short-circuits every MVC request in this state.</li>
+ *   <li><b>Cross-tenant read of suspended resource</b>
+ *       ({@link #crossTenantRead_suspendedTarget_returnsEmpty}) — Tenant B's active
+ *       context attempts a direct-UUID read of Tenant A's ApiKey after A is suspended;
+ *       the F-3.2 SQL JOIN returns empty. At the controller layer this maps to 404;
+ *       at this level we assert the Optional directly.</li>
+ * </ol>
+ */
+@TestPropertySource(properties = "fabt.tenant.lifecycle.enabled=true")
+class TenantStateBreachSimIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private TenantLifecycleService lifecycleService;
+    @Autowired private TenantStateGuard tenantStateGuard;
+    @Autowired private TenantRepository tenantRepository;
+    @Autowired private ApiKeyRepository apiKeyRepository;
+    @Autowired private SubscriptionRepository subscriptionRepository;
+    @Autowired private KidRegistryService kidRegistryService;
+
+    private UUID tenantA;
+    private UUID tenantB;
+
+    @BeforeEach
+    void seedTenants() {
+        tenantA = saveActiveTenantWithKeyMaterial("breach-sim-A");
+        tenantB = saveActiveTenantWithKeyMaterial("breach-sim-B");
+        // Defense: reset the guard cache so a prior test's state doesn't bleed in.
+        tenantStateGuard.invalidate(tenantA);
+        tenantStateGuard.invalidate(tenantB);
+    }
+
+    @Test
+    void suspendedCaller_cannotRead_viaInterceptor() {
+        // Suspend Tenant A. Then simulate the JWT-authenticated request flow: the
+        // interceptor runs with TenantContext bound to A. requireActive should
+        // throw NON_ACTIVE with the correct observed state, which the
+        // TenantLifecycleExceptionAdvice maps to 404 at the HTTP layer.
+        lifecycleService.suspend(tenantA, UUID.randomUUID(), "breach-sim");
+
+        // Invalidate explicitly — the lifecycle service does this via after-commit
+        // hook, but the @TestPropertySource context may share the guard singleton
+        // across tests; belt-and-suspenders.
+        tenantStateGuard.invalidate(tenantA);
+
+        assertThatThrownBy(() -> TenantContext.callWithContext(tenantA, false,
+            () -> {
+                tenantStateGuard.requireActive(TenantContext.getTenantId());
+                return null;
+            }))
+            .isInstanceOf(TenantStateGuardException.class)
+            .satisfies(ex -> {
+                TenantStateGuardException typed = (TenantStateGuardException) ex;
+                assertThat(typed.kind()).isEqualTo(TenantStateGuardException.Kind.NON_ACTIVE);
+                assertThat(typed.tenantId()).isEqualTo(tenantA);
+                assertThat(typed.observedState()).isEqualTo(TenantState.SUSPENDED);
+            });
+    }
+
+    @Test
+    void crossTenantRead_suspendedTarget_returnsEmpty() {
+        // Tenant A has an ApiKey AND a Subscription. Tenant B — fully ACTIVE — tries
+        // to read A's resources by direct UUID via the Tier-1 SQL-JOIN methods.
+        // findByIdAndActiveTenantId on a SUSPENDED tenant returns empty (SQL JOIN
+        // filters out the row) AND findByIdAndActiveTenantId with Tenant B's
+        // tenantId would ALSO fail the tenant_id = :tenantId filter. Both paths =
+        // empty. The point: no row leaks regardless of which combination the
+        // attacker supplies.
+        UUID apiKeyId = seedApiKey(tenantA);
+        UUID subscriptionId = seedSubscription(tenantA);
+
+        // Sanity: before suspend, Tenant A's own context CAN see its own data.
+        Optional<ApiKey> preSuspend = apiKeyRepository.findByIdAndActiveTenantId(apiKeyId, tenantA);
+        assertThat(preSuspend)
+            .as("pre-suspend sanity: ACTIVE tenant sees its own key")
+            .isPresent();
+
+        lifecycleService.suspend(tenantA, UUID.randomUUID(), "breach-sim");
+
+        // Now: Tenant A's own query for its own key returns empty (A is SUSPENDED).
+        // D3 semantics: no existence leak — indistinguishable from "key never existed".
+        Optional<ApiKey> selfReadAfterSuspend =
+            apiKeyRepository.findByIdAndActiveTenantId(apiKeyId, tenantA);
+        assertThat(selfReadAfterSuspend)
+            .as("SUSPENDED tenant's own read returns empty")
+            .isEmpty();
+
+        // Cross-tenant: Tenant B tries to fetch Tenant A's key/sub via B's own
+        // tenantId. Returns empty on tenant_id filter (the row is A's, B is asking
+        // for B's). This is the pre-F-3 isolation behavior, still correct.
+        Optional<ApiKey> crossTenantAttemptKey =
+            apiKeyRepository.findByIdAndActiveTenantId(apiKeyId, tenantB);
+        assertThat(crossTenantAttemptKey)
+            .as("cross-tenant attempt (asking B's tenantId) returns empty")
+            .isEmpty();
+
+        // Cross-tenant: Tenant B tries to fetch A's subscription via A's tenantId
+        // (attacker guessed both). Returns empty — A is SUSPENDED, the JOIN filter
+        // blocks.
+        Optional<Subscription> crossTenantGuessedBoth =
+            subscriptionRepository.findByIdAndActiveTenantId(subscriptionId, tenantA);
+        assertThat(crossTenantGuessedBoth)
+            .as("attacker with both UUIDs guessed still gets empty — SUSPENDED A's SQL JOIN filter")
+            .isEmpty();
+    }
+
+    @Test
+    void unsuspendRestoresReads() {
+        // Round-trip: suspend → blocked, unsuspend → restored. Proves the cache
+        // invalidation after-commit hook lands in ms, not 10s (the TTL ceiling).
+        UUID apiKeyId = seedApiKey(tenantA);
+
+        lifecycleService.suspend(tenantA, UUID.randomUUID(), "drill");
+        assertThat(apiKeyRepository.findByIdAndActiveTenantId(apiKeyId, tenantA))
+            .as("suspended → empty")
+            .isEmpty();
+
+        lifecycleService.unsuspend(tenantA, UUID.randomUUID(), "cleared");
+        assertThat(apiKeyRepository.findByIdAndActiveTenantId(apiKeyId, tenantA))
+            .as("unsuspended → visible again, without waiting for 10s TTL")
+            .isPresent();
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private UUID saveActiveTenantWithKeyMaterial(String slugPrefix) {
+        Tenant t = new Tenant();
+        t.setName("Breach Sim " + slugPrefix);
+        t.setSlug(slugPrefix + "-" + UUID.randomUUID());
+        t.setConfig(JsonString.empty());
+        t.setState(TenantState.ACTIVE);
+        Instant now = Instant.now();
+        t.setCreatedAt(now);
+        t.setUpdatedAt(now);
+        Tenant saved = tenantRepository.save(t);
+        kidRegistryService.findOrCreateActiveKid(saved.getId());
+        return saved.getId();
+    }
+
+    private UUID seedApiKey(UUID tenantId) {
+        ApiKey k = new ApiKey();
+        k.setTenantId(tenantId);
+        k.setKeyHash("breach-sim-" + UUID.randomUUID());
+        k.setKeySuffix(UUID.randomUUID().toString().substring(0, 4));
+        k.setLabel("breach-sim");
+        k.setRole("COC_ADMIN");
+        k.setActive(true);
+        k.setCreatedAt(Instant.now());
+        return apiKeyRepository.save(k).getId();
+    }
+
+    private UUID seedSubscription(UUID tenantId) {
+        Subscription s = new Subscription();
+        s.setTenantId(tenantId);
+        s.setEventType("shelter.availability_changed");
+        s.setFilter(JsonString.empty());
+        s.setCallbackUrl("https://example.invalid/webhook");
+        s.setCallbackSecretHash("seed-hash-" + UUID.randomUUID());
+        s.setStatus("ACTIVE");
+        s.setCreatedAt(Instant.now());
+        return subscriptionRepository.save(s).getId();
+    }
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantStateGuardUnitTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantStateGuardUnitTest.java
@@ -1,0 +1,137 @@
+package org.fabt.tenant.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.UUID;
+
+import org.fabt.tenant.domain.TenantState;
+import org.fabt.tenant.domain.TenantStateGuardException;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Unit tests for {@link TenantStateGuard}. Pins the F-3 read-path contract:
+ * SUSPENDED/OFFBOARDING/ARCHIVED/DELETED tenants are rejected with
+ * {@link TenantStateGuardException} carrying the correct {@code Kind}; ACTIVE
+ * tenants pass through; NOT_FOUND uses the same-shape exception for
+ * existence-leak symmetry. Also pins cache behavior: repeated reads hit the
+ * cache (one DB call for many {@code requireActive}s on the same tenant) and
+ * {@link TenantStateGuard#invalidate} forces a re-load on the next call.
+ */
+@ExtendWith(MockitoExtension.class)
+class TenantStateGuardUnitTest {
+
+    @Mock
+    JdbcTemplate jdbc;
+
+    @Test
+    void requireActive_activeTenant_returnsNormally() {
+        TenantStateGuard guard = new TenantStateGuard(jdbc);
+        UUID tenantId = UUID.randomUUID();
+        stubLoad(tenantId, "ACTIVE");
+
+        guard.requireActive(tenantId);
+
+        verify(jdbc, times(1)).queryForObject(anyString(), eq(String.class), eq(tenantId));
+    }
+
+    @Test
+    void requireActive_suspendedTenant_throwsNonActiveWithObservedState() {
+        TenantStateGuard guard = new TenantStateGuard(jdbc);
+        UUID tenantId = UUID.randomUUID();
+        stubLoad(tenantId, "SUSPENDED");
+
+        assertThatThrownBy(() -> guard.requireActive(tenantId))
+            .isInstanceOf(TenantStateGuardException.class)
+            .satisfies(ex -> {
+                TenantStateGuardException typed = (TenantStateGuardException) ex;
+                assertThat(typed.kind()).isEqualTo(TenantStateGuardException.Kind.NON_ACTIVE);
+                assertThat(typed.tenantId()).isEqualTo(tenantId);
+                assertThat(typed.observedState()).isEqualTo(TenantState.SUSPENDED);
+            });
+    }
+
+    @Test
+    void requireActive_tenantNotFound_throwsNotFoundKind() {
+        TenantStateGuard guard = new TenantStateGuard(jdbc);
+        UUID tenantId = UUID.randomUUID();
+        when(jdbc.queryForObject(anyString(), eq(String.class), eq(tenantId)))
+            .thenThrow(new EmptyResultDataAccessException(1));
+
+        assertThatThrownBy(() -> guard.requireActive(tenantId))
+            .isInstanceOf(TenantStateGuardException.class)
+            .satisfies(ex -> {
+                TenantStateGuardException typed = (TenantStateGuardException) ex;
+                assertThat(typed.kind()).isEqualTo(TenantStateGuardException.Kind.NOT_FOUND);
+                assertThat(typed.tenantId()).isEqualTo(tenantId);
+                assertThat(typed.observedState()).isNull();
+            });
+    }
+
+    @Test
+    void requireActive_nullTenantId_throwsNotFound_withoutDbCall() {
+        TenantStateGuard guard = new TenantStateGuard(jdbc);
+
+        assertThatThrownBy(() -> guard.requireActive(null))
+            .isInstanceOf(TenantStateGuardException.class)
+            .satisfies(ex -> assertThat(((TenantStateGuardException) ex).kind())
+                .isEqualTo(TenantStateGuardException.Kind.NOT_FOUND));
+
+        verify(jdbc, never()).queryForObject(anyString(), any(Class.class), any(Object[].class));
+    }
+
+    @Test
+    void requireActive_cachedHit_doesNotHitDbOnRepeatCall() {
+        TenantStateGuard guard = new TenantStateGuard(jdbc);
+        UUID tenantId = UUID.randomUUID();
+        stubLoad(tenantId, "ACTIVE");
+
+        guard.requireActive(tenantId);
+        guard.requireActive(tenantId);
+        guard.requireActive(tenantId);
+
+        // One DB call for three requireActive invocations — cache absorbed two.
+        verify(jdbc, times(1)).queryForObject(anyString(), eq(String.class), eq(tenantId));
+    }
+
+    @Test
+    void invalidate_forcesReloadOnNextRequireActive() {
+        TenantStateGuard guard = new TenantStateGuard(jdbc);
+        UUID tenantId = UUID.randomUUID();
+        stubLoad(tenantId, "ACTIVE");
+
+        guard.requireActive(tenantId);   // first load
+        guard.invalidate(tenantId);      // cache cleared
+        guard.requireActive(tenantId);   // forced re-load
+
+        verify(jdbc, times(2)).queryForObject(anyString(), eq(String.class), eq(tenantId));
+    }
+
+    @Test
+    void invalidate_nullTenantId_noThrow() {
+        TenantStateGuard guard = new TenantStateGuard(jdbc);
+
+        // Defensive — lifecycle hooks may pass null during tests or edge cases;
+        // invalidate must be no-op safe so the after-commit path never throws.
+        guard.invalidate(null);
+
+        verify(jdbc, never()).queryForObject(anyString(), any(Class.class), any(Object[].class));
+    }
+
+    private void stubLoad(UUID tenantId, String state) {
+        when(jdbc.queryForObject(anyString(), eq(String.class), eq(tenantId)))
+            .thenReturn(state);
+    }
+}

--- a/docs/oracle-update-notes-v0.51.0.md
+++ b/docs/oracle-update-notes-v0.51.0.md
@@ -73,7 +73,7 @@ consulted:
 | Crypto-shred TDD anchor flipped green | `backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java` | Test-only |
 | New §11 tests (TenantDekRlsTest, TenantDekShredGuardTest, NTenantCanaryShredTest) | `backend/src/test/java/org/fabt/shared/security/` | Test-only |
 | Docs: `docs/security/crypto-shred-runbook.md` | NEW | No container action |
-| `pom.xml` version bump `0.49.0 → 0.51.0` | `backend/pom.xml` | Landed with backend rebuild |
+| `pom.xml` version bump `0.50.0 → 0.51.0` | `backend/pom.xml` | Landed with backend rebuild. (Prod `/api/v1/version` currently shows `0.49` because v0.50 didn't rebuild the JAR — the checked-in pom is already at 0.50.0. Post-deploy the reported version jumps 0.49 → 0.51, skipping 0.50.) |
 
 ### What does NOT change in this deploy
 
@@ -113,7 +113,7 @@ consulted:
 - [ ] **Rehearsal green** — `make rehearse-deploy` on operator laptop; confirm PASS. Includes fresh run of V79–V84 against the stub stack. **Expected new rehearsal findings** (this is v0.51's first pass through the harness): V82 trigger function, V83 Java migration encryption-key handling. Log filename: `logs/rehearsal-smoke-YYYYMMDD-HHMMSS.log`.
 - [ ] **CI green** — `gh run list --branch feature/phase-f-lifecycle-fsm --limit 5`; all runs green.
 - [ ] **Feature branch merged to main** — confirm `feature/phase-f-lifecycle-fsm` is merged before tagging v0.51.0.
-- [ ] **pom.xml version bump merged** — `backend/pom.xml` shows `<version>0.51.0</version>`. Without this, `/actuator/info` keeps reporting 0.49.0 and the post-deploy gate fails.
+- [ ] **pom.xml version bump merged** — `backend/pom.xml` shows `<version>0.51.0</version>`. Prod currently serves JAR `0.49.0.jar` (last built at v0.49 — v0.50 was ops-tier, pom bumped but not rebuilt). Without the v0.51.0 bump, a rebuild would produce `0.50.0.jar` and post-deploy `/api/v1/version` would show `0.50` — the deploy gate would fail.
 - [ ] **Env-var trailing-space lint** — `grep -nE "^FABT_[A-Z_]*= " ~/fabt-secrets/.env.prod` must return NO output (v0.49 lesson).
 - [ ] **`FABT_ENCRYPTION_KEY` present in `.env.prod`** — V83 Java migration will read it at Flyway boot time. Variable has been in `.env.prod` since v0.42; confirm presence without printing value (`grep -c '^FABT_ENCRYPTION_KEY=' ~/fabt-secrets/.env.prod` expect: 1). **If missing, V83 will WARN-and-skip (Flyway still marks it APPLIED); you then cannot re-run without `DELETE FROM flyway_schema_history WHERE version = '83'`.**
 - [ ] **pg_dump backup — MANDATORY** — V82/V83/V84 are irreversible without `pg_restore`. Take the dump BEFORE starting the backend recreate:
@@ -169,7 +169,8 @@ git pull origin main
 ```bash
 grep '<version>' backend/pom.xml | head -3
 # expect: <version>0.51.0</version>
-# If still 0.49.0, the version-bump commit is missing — STOP and investigate.
+# If 0.50.0, the v0.51 bump commit is missing — STOP and investigate.
+# If 0.49.0, this branch is behind main somehow — STOP and investigate.
 ```
 
 ### 4. Confirm `FABT_ENCRYPTION_KEY` is present (no cat)
@@ -187,7 +188,7 @@ grep -c '^FABT_ENCRYPTION_KEY=' ~/fabt-secrets/.env.prod
 cd backend
 mvn clean package -DskipTests
 ls target/*.jar
-# expect: finding-a-bed-tonight-0.51.0.jar present; no 0.49.0.jar or 0.50.0.jar
+# expect: finding-a-bed-tonight-0.51.0.jar present; no 0.50.0.jar or 0.49.0.jar
 
 cd ..
 
@@ -259,7 +260,7 @@ curl -s http://localhost:9091/actuator/info | grep version
 # expect: 0.51.0
 ```
 
-If these report 0.49.0, the `pom.xml` version bump was not in the built JAR — re-check step 3 + step 5.
+If these report anything other than `0.51.0` (most likely `0.50.0` if the pom-bump commit was missed, or `0.49.0` if the backend wasn't rebuilt at all), re-check step 3 + step 5.
 
 ### Flyway HWM
 
@@ -350,7 +351,7 @@ BASE_URL=https://findabed.org npx playwright test \
 | V84 fails mid-ALTER | Unlikely — ACCESS EXCLUSIVE is brief and table scans are pilot-scale. If it happens: transaction rolls back (all 18 ALTERs live in one `DO $$ ... $$` block); re-attempt by `--force-recreate backend`. |
 | Post-deploy: tests reach 500s on decrypt | Backward-compat shim broken. Downgrade: `docker tag fabt-backend:v0.50.0-lastgood fabt-backend:latest`; `--force-recreate backend`. New schema rows in `tenant_dek` become unused but don't break v0.50.0 code (it doesn't know the table exists). |
 | Full-release rollback (worst case) | (1) Stop backend: `docker compose ... stop backend`. (2) `pg_restore -U fabt -d fabt --clean --create ~/fabt-backups/fabt-pre-v0.51.0-*.dump` (will replace the live DB — expect ~30s outage). (3) Downgrade backend image: `docker tag fabt-backend:v0.50.0-lastgood fabt-backend:latest`. (4) `--force-recreate backend` with full 4-file chain. |
-| Backend boots but `/api/v1/version` shows 0.49 | pom.xml not bumped in the built JAR. Re-check step 3 + 5; rebuild with explicit `mvn clean`; re-run step 6. |
+| Backend boots but `/api/v1/version` shows `0.50` (or `0.49`) | pom.xml not bumped in the built JAR (0.50), or backend image wasn't rebuilt at all (0.49 — still running the v0.49-era JAR). Re-check step 3 + 5; rebuild with explicit `mvn clean`; re-run step 6. |
 
 ---
 

--- a/docs/oracle-update-notes-v0.51.0.md
+++ b/docs/oracle-update-notes-v0.51.0.md
@@ -1,0 +1,382 @@
+# Oracle Deploy Notes — v0.51.0
+
+**Status:** DRAFT — feature branch `feature/phase-f-lifecycle-fsm`; PR not yet opened. Update to READY before tagging.
+
+**Release summary:** Phase F slice F-6 — real crypto-shred.
+- Backend-code release (first since v0.49 — v0.50 was ops-tier)
+- 6 new Flyway migrations (V79–V84). HWM goes V78 → V84
+- Adds `TenantDekService`, `TenantLifecycleService.hardDelete`, per-tenant wrapped DEKs in `tenant_dek`
+- Converts the §D11 "crypto-shred" claim from a design statement into a verifiable cryptographic property (anchor test green)
+- `hardDelete` capability ships but is NOT exercised in prod this release — no shred scheduled
+
+**From:** v0.50.0 live at `findabed.org`
+**To:** v0.51.0
+
+---
+
+## 1. Consulted Memories
+
+```yaml
+consulted:
+  - file: feedback_runbook_compose_chain.md
+    # why-cited: postgres will be recreated this release (force-recreate for backend triggers migration-path health dependency); 4-file compose chain is non-negotiable. v0.50 90s postgres outage not to be repeated.
+  - file: feedback_deploy_old_jars.md
+    # why-cited: backend IS rebuilt this release; mvn clean mandatory before docker build.
+  - file: feedback_prod_docker_build_pattern.md
+    # why-cited: explicit docker build --no-cache + --force-recreate pattern. Three no-op traps caught during v0.48 live deploy still apply.
+  - file: feedback_bind_mount_inode_pitfall.md
+    # why-cited: no single-file bind mount changes this release, but --force-recreate pattern is universal.
+  - file: feedback_never_print_rendered_secrets.md
+    # why-cited: V83 re-encrypts under per-tenant DEKs wrapped by FABT_ENCRYPTION_KEY; never cat the env file at any step.
+  - file: feedback_smoke_config_on_prod.md
+    # why-cited: post-deploy Playwright smoke must use --config=deploy/playwright.config.ts + positional filter + BASE_URL override (v0.50 lesson #2).
+  - file: feedback_flyway_immutable_after_apply.md
+    # why-cited: V79-V84 are APPLIED on every dev + Testcontainer run; once this release hits staging, these files are immutable — no further edits.
+  - file: feedback_verify_doc_facts_against_source.md
+    # why-cited: every table name, constraint name, migration version, and SQL snippet in this runbook was grepped against source before inclusion.
+  - file: feedback_release_after_scans.md
+    # why-cited: tag only after CI scans green; gh release create after tag.
+  - file: project_live_deployment_status.md
+    # why-cited: current prod is v0.50.0, Flyway HWM V78, 3 tenants. v0.51 adds 6 migrations + backend rebuild.
+  - file: feedback_deploy_rehearsal_lessons.md
+    # why-cited: rehearsal harness caught 4 first-run bugs in v0.50; v0.51 adds new migrations + backend image, expect fresh rehearsal findings.
+  - file: project_phase_f_implementation_plan.md
+    not-applicable: internal slice-sequencing reference — implementation is complete for this release
+  - file: feedback_legal_claims_review.md
+    # why-cited: release notes language must say "designed to support" not "compliant" re NIST/GDPR. CHANGELOG + crypto-shred runbook legal-scanned.
+```
+
+---
+
+## 2. Scope & Non-Scope
+
+**Deploying:** v0.51.0 — Phase F crypto-shred foundation. Real crypto-shred via per-tenant wrapped DEKs.
+
+**From:** v0.50.0 live at `findabed.org`
+(confirm current version: `curl -s https://findabed.org/api/v1/version`)
+
+**To:** v0.51.0
+
+### What ships
+
+| Change | Files | Deploy action |
+|---|---|---|
+| V79 `tenant_state_to_varchar` | `backend/src/main/resources/db/migration/V79__*.sql` | Auto-applies on backend boot |
+| V80 `tenant_audit_chain_head_schema` | `V80__*.sql` | Auto-applies |
+| V81 `tenant_archive_retention_columns` | `V81__*.sql` | Auto-applies |
+| V82 `tenant_dek_schema` | `V82__*.sql` | Auto-applies; adds SECURITY DEFINER trigger function (see §11) |
+| V83 `reencrypt_v1_envelopes_under_tenant_dek` | `V83__*.java` (Java migration) | Auto-applies; needs `FABT_ENCRYPTION_KEY` in backend env (already present since v0.42) |
+| V84 `tenant_fk_cascade` | `V84__*.sql` | Auto-applies; ALTER TABLE × 18 (each sub-second at pilot scale) |
+| `TenantDekService` + `SecretEncryptionService` refactor | `backend/src/main/java/org/fabt/shared/security/` | Backend rebuild required |
+| `TenantLifecycleService.hardDelete` | `backend/src/main/java/org/fabt/tenant/service/` | Backend rebuild |
+| ArchUnit Family F rules 7.8h + 7.8j | `backend/src/test/java/org/fabt/architecture/CryptoShredArchitectureTest.java` | Test-only (runs in CI) |
+| Crypto-shred TDD anchor flipped green | `backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java` | Test-only |
+| New §11 tests (TenantDekRlsTest, TenantDekShredGuardTest, NTenantCanaryShredTest) | `backend/src/test/java/org/fabt/shared/security/` | Test-only |
+| Docs: `docs/security/crypto-shred-runbook.md` | NEW | No container action |
+| `pom.xml` version bump `0.49.0 → 0.51.0` | `backend/pom.xml` | Landed with backend rebuild |
+
+### What does NOT change in this deploy
+
+- **Frontend** — no change; no `docker build` for frontend, no force-recreate frontend
+- **nginx** — no change (Phase D header stripping from v0.50 stays)
+- **Alertmanager** — no change; config stays identical
+- **Prometheus** — no change; no new rules in this release
+- **Postgres image** — still `fabt-pgaudit:v0.45.0`; no postgres rebuild
+- **FORCE RLS posture** — unchanged; V82 adds RLS policies for the new `tenant_dek` table only
+- **SSH / VM / compose chain** — same 4-file chain as v0.50; `~/.fabt-secrets/*` unchanged
+- **Tenants** — 3 tenants (`dev-coc`, `dev-coc-west`, `dev-coc-east`) remain ACTIVE. No hardDelete scheduled. V83 will re-encrypt existing v1-HKDF envelopes for these 3 tenants under fresh random DEKs (12 new `tenant_dek` rows at pilot scale: 3 tenants × 4 purposes).
+
+### What v0.51.0 enables but does NOT use in prod yet
+
+- `hardDelete` service method is live on the backend, but there is no admin UI, CLI, or API endpoint that invokes it. First prod shred is a future release and will require warroom sign-off + `docs/security/crypto-shred-runbook.md` procedure.
+
+---
+
+## 3. Service-Recreate Matrix
+
+| Service | Changed? | Recreate required? | Reason |
+|---|---|---|---|
+| `backend` | ✅ Java code changed (TenantDekService, SecretEncryptionService refactor, hardDelete); JAR version bumped to 0.51.0 | ✅ Rebuild image + `--force-recreate`; Flyway runs V79–V84 on boot |
+| `postgres` | ❌ no image change, but schema mutates via Flyway at backend boot | ❌ no service recreate, but schema will change irreversibly (pg_dump REQUIRED before deploy) |
+| `frontend` | ❌ no change | ❌ |
+| `prometheus` | ❌ | ❌ |
+| `alertmanager` | ❌ | ❌ |
+| `grafana` / `otel-collector` / `jaeger` | ❌ | ❌ |
+| Host `nginx` | ❌ | ❌ |
+
+> **Backend recreate triggers Flyway.** The backend container runs Flyway on startup before Spring opens the webserver port. V79–V84 apply before `/actuator/health` returns UP. At pilot scale the full 6-migration chain runs in <5s (V83 per-row tx × ~65 rows + V84 × 18 ALTERs, both sub-second). Watch logs during the first ~30s for `V84 ... Successfully applied`.
+
+---
+
+## 4. Pre-Deploy Gates
+
+- [ ] **Rehearsal green** — `make rehearse-deploy` on operator laptop; confirm PASS. Includes fresh run of V79–V84 against the stub stack. **Expected new rehearsal findings** (this is v0.51's first pass through the harness): V82 trigger function, V83 Java migration encryption-key handling. Log filename: `logs/rehearsal-smoke-YYYYMMDD-HHMMSS.log`.
+- [ ] **CI green** — `gh run list --branch feature/phase-f-lifecycle-fsm --limit 5`; all runs green.
+- [ ] **Feature branch merged to main** — confirm `feature/phase-f-lifecycle-fsm` is merged before tagging v0.51.0.
+- [ ] **pom.xml version bump merged** — `backend/pom.xml` shows `<version>0.51.0</version>`. Without this, `/actuator/info` keeps reporting 0.49.0 and the post-deploy gate fails.
+- [ ] **Env-var trailing-space lint** — `grep -nE "^FABT_[A-Z_]*= " ~/fabt-secrets/.env.prod` must return NO output (v0.49 lesson).
+- [ ] **`FABT_ENCRYPTION_KEY` present in `.env.prod`** — V83 Java migration will read it at Flyway boot time. Variable has been in `.env.prod` since v0.42; confirm presence without printing value (`grep -c '^FABT_ENCRYPTION_KEY=' ~/fabt-secrets/.env.prod` expect: 1). **If missing, V83 will WARN-and-skip (Flyway still marks it APPLIED); you then cannot re-run without `DELETE FROM flyway_schema_history WHERE version = '83'`.**
+- [ ] **pg_dump backup — MANDATORY** — V82/V83/V84 are irreversible without `pg_restore`. Take the dump BEFORE starting the backend recreate:
+      ```bash
+      docker exec finding-a-bed-tonight-postgres-1 pg_dump -U fabt -d fabt -Fc \
+          > ~/fabt-backups/fabt-pre-v0.51.0-$(date -u +%Y%m%d-%H%M%S).dump
+      ```
+- [ ] **SSH access confirmed** — open SSH to the VM before starting; do not assume reachability mid-deploy.
+- [ ] **Compose dry-render** — with the full 4-file chain:
+      ```bash
+      docker compose \
+          -f docker-compose.yml \
+          -f ~/fabt-secrets/docker-compose.prod.yml \
+          -f ~/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml \
+          -f ~/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml \
+          --env-file ~/fabt-secrets/.env.prod \
+          --profile alerting \
+          config > /tmp/v0.51.0-config.rendered.yml
+      ```
+      Inspect: confirm backend image tag does NOT yet reference v0.51.0 (we build it in step 5 below).
+- [ ] **Flyway HWM pre-deploy check** — confirm prod is at V78:
+      ```bash
+      docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc \
+          "SELECT MAX(version::int) FROM flyway_schema_history WHERE success = true;"
+      # expect: 78
+      ```
+
+---
+
+## 5. Deploy Steps
+
+### 1. Preserve last-good image tag
+
+```bash
+# Only backend changes this release — preserve just the backend lastgood.
+docker tag fabt-backend:latest fabt-backend:v0.50.0-lastgood
+docker images | grep fabt-backend
+# Confirm: latest + v0.50.0-lastgood both present with same IMAGE ID
+```
+
+### 2. Pull latest main
+
+```bash
+cd ~/finding-a-bed-tonight
+git fetch origin
+git checkout main
+git pull origin main
+# Confirm: git log --oneline -5 shows the v0.51.0 tag or feature commits at top
+```
+
+### 3. Verify pom.xml version bump
+
+```bash
+grep '<version>' backend/pom.xml | head -3
+# expect: <version>0.51.0</version>
+# If still 0.49.0, the version-bump commit is missing — STOP and investigate.
+```
+
+### 4. Confirm `FABT_ENCRYPTION_KEY` is present (no cat)
+
+```bash
+grep -c '^FABT_ENCRYPTION_KEY=' ~/fabt-secrets/.env.prod
+# expect: 1
+# DO NOT cat or grep the value — feedback_never_print_rendered_secrets.md
+```
+
+### 5. mvn clean + build backend JAR + build backend image
+
+```bash
+# mvn clean FIRST — feedback_deploy_old_jars.md (stale JAR in image is the v0.47 foot-gun)
+cd backend
+mvn clean package -DskipTests
+ls target/*.jar
+# expect: finding-a-bed-tonight-0.51.0.jar present; no 0.49.0.jar or 0.50.0.jar
+
+cd ..
+
+# Build backend image --no-cache — feedback_prod_docker_build_pattern.md
+docker build --no-cache \
+    -f infra/docker/Dockerfile.backend \
+    -t fabt-backend:v0.51.0 \
+    -t fabt-backend:latest \
+    .
+docker images fabt-backend --format "table {{.Tag}}\t{{.CreatedAt}}" | head -4
+# Confirm: v0.51.0 tag present, new CreatedAt timestamp
+```
+
+### 6. Force-recreate backend (triggers Flyway V79–V84)
+
+Use the FULL 4-file compose chain. The v0.50 90s postgres crash loop was caused by a 2-file shorthand — do not repeat.
+
+```bash
+docker compose \
+    -f docker-compose.yml \
+    -f ~/fabt-secrets/docker-compose.prod.yml \
+    -f ~/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml \
+    -f ~/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml \
+    --env-file ~/fabt-secrets/.env.prod \
+    --profile alerting \
+    up -d --force-recreate backend
+
+# Watch Flyway output for ~30s — expect to see V79 through V84 applied in order
+docker compose \
+    -f docker-compose.yml \
+    -f ~/fabt-secrets/docker-compose.prod.yml \
+    -f ~/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml \
+    -f ~/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml \
+    --env-file ~/fabt-secrets/.env.prod \
+    --profile alerting \
+    logs --tail=100 -f backend | grep -E "Migrating schema|Successfully applied|V83 COMMITTED|V84"
+```
+
+> **Expected Flyway log signatures:**
+> - `Migrating schema "public" to version "79 - tenant state to varchar"`
+> - `Migrating schema "public" to version "80 - tenant audit chain head schema"`
+> - `Migrating schema "public" to version "81 - tenant archive retention columns"`
+> - `Migrating schema "public" to version "82 - tenant dek schema"`
+> - `V83 COMMITTED — re-encrypted N TOTP / N webhook / N OAuth2 / N HMIS rows under tenant_dek in Xms; rotation probe: passed`
+> - `Migrating schema "public" to version "84 - tenant fk cascade"`
+> - `Successfully applied 6 migrations to schema "public", now at version v84`
+
+### 7. Wait for backend health
+
+```bash
+# Backend opens the HTTP port AFTER Flyway completes — so a UP response means V79-V84 all committed
+until curl -fsS http://localhost:9091/actuator/health 2>/dev/null | grep -q '"status":"UP"'; do
+    echo "waiting for backend Flyway + boot..."; sleep 3
+done
+echo "backend UP"
+```
+
+---
+
+## 6. Post-Deploy Gates
+
+### Version check (backend JAR bumped — this is a code-change release)
+
+```bash
+curl -s https://findabed.org/api/v1/version
+# expect: "0.51" (or "0.51.0" depending on format; check both)
+
+curl -s http://localhost:9091/actuator/info | grep version
+# expect: 0.51.0
+```
+
+If these report 0.49.0, the `pom.xml` version bump was not in the built JAR — re-check step 3 + step 5.
+
+### Flyway HWM
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc \
+    "SELECT version, description, success FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 8;"
+# expect top entry: 84 | tenant fk cascade | t
+# expect entries 84, 83, 82, 81, 80, 79 all success = t
+```
+
+### V83 audit row — confirms re-encrypt ran
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -c \
+    "SET app.tenant_id = '00000000-0000-0000-0000-000000000001';
+     SELECT action, details ->> 'totp_reencrypted' AS totp_n,
+                    details ->> 'webhook_reencrypted' AS webhook_n,
+                    details ->> 'oauth2_reencrypted' AS oauth2_n,
+                    details ->> 'hmis_reencrypted' AS hmis_n,
+                    details ->> 'rotation_probe_result' AS probe
+       FROM audit_events
+      WHERE action = 'SYSTEM_MIGRATION_V83_TENANT_DEK'
+      ORDER BY timestamp DESC LIMIT 1;"
+# expect one row, probe = 'passed' (or 'skipped_no_rows' if fresh DB)
+# pilot scale: totp_n + webhook_n + oauth2_n + hmis_n combined ~10-12 rows
+```
+
+### V84 CASCADE drift guard — confirm 22 FKs to `tenant` are all CASCADE
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -c \
+    "SELECT conrelid::regclass::text AS owning_table, confdeltype
+       FROM pg_catalog.pg_constraint
+      WHERE confrelid = 'public.tenant'::regclass AND contype = 'f'
+      ORDER BY owning_table;"
+# expect: 22 rows, every confdeltype = 'c' (CASCADE)
+# audit_events is NOT in this list (intentionally FK-less per V57 / Q-F6-5)
+```
+
+### tenant_dek populated for existing tenants
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -c \
+    "SELECT tenant_id, purpose, generation, active,
+            length(wrapped_dek) AS wrapped_bytes
+       FROM tenant_dek
+      ORDER BY tenant_id, purpose;"
+# expect: N rows where N = tenants that had at least one v1-HKDF envelope pre-V83.
+# At pilot scale with 3 tenants × 4 purposes, typical N = 4 to 12 depending on
+# how many V74-era ciphertext columns were populated. Every wrapped_bytes = 40.
+```
+
+### V82 trigger guard installed
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc \
+    "SELECT tgname FROM pg_trigger WHERE tgrelid = 'public.tenant_dek'::regclass;"
+# expect: tenant_dek_shred_guard_trigger
+```
+
+### Playwright smoke (v0.50 lesson #2 — correct invocation)
+
+```bash
+# Use --config=deploy/playwright.config.ts + positional filter + BASE_URL override
+# (v0.50 lesson: bare `npx playwright test deploy/post-deploy-smoke.spec.ts` fails "No tests found")
+cd e2e/playwright
+BASE_URL=https://findabed.org npx playwright test \
+    --config=deploy/playwright.config.ts \
+    post-deploy-smoke \
+    --project chromium \
+    --reporter=list \
+    --trace on \
+    2>&1 | tee ../../logs/post-deploy-smoke-v0.51.0.log
+# expect: all tests pass; test 13/14 may rate-limit-flake per v0.50 lesson #4 —
+# re-run single spec if so, not a regression
+```
+
+---
+
+## 7. Rollback Matrix
+
+> **V82/V83/V84 are irreversible without `pg_restore`.** The `~/fabt-backups/fabt-pre-v0.51.0-*.dump` from pre-deploy gate is the canonical rollback artifact. Rollback requires a postgres outage for the restore duration.
+
+| Symptom | Action |
+|---|---|
+| Flyway fails on V82 trigger/RLS | Check `SET search_path`; V82 tests green in CI so failure in prod is unexpected — capture logs, tag `v0.51.0-failed`, restore from pg_dump, downgrade backend image to `v0.50.0-lastgood`, investigate offline. |
+| V83 logs `FABT_ENCRYPTION_KEY not set — skipping re-encryption` | Pre-deploy gate missed; V83 is marked APPLIED with no work done. Re-attempt: `DELETE FROM flyway_schema_history WHERE version = '83';` then `--force-recreate backend`. Does NOT break anything — legacy-HKDF shim in `SecretEncryptionService.decryptV1LegacyHkdf` keeps existing ciphertexts readable. |
+| V84 fails mid-ALTER | Unlikely — ACCESS EXCLUSIVE is brief and table scans are pilot-scale. If it happens: transaction rolls back (all 18 ALTERs live in one `DO $$ ... $$` block); re-attempt by `--force-recreate backend`. |
+| Post-deploy: tests reach 500s on decrypt | Backward-compat shim broken. Downgrade: `docker tag fabt-backend:v0.50.0-lastgood fabt-backend:latest`; `--force-recreate backend`. New schema rows in `tenant_dek` become unused but don't break v0.50.0 code (it doesn't know the table exists). |
+| Full-release rollback (worst case) | (1) Stop backend: `docker compose ... stop backend`. (2) `pg_restore -U fabt -d fabt --clean --create ~/fabt-backups/fabt-pre-v0.51.0-*.dump` (will replace the live DB — expect ~30s outage). (3) Downgrade backend image: `docker tag fabt-backend:v0.50.0-lastgood fabt-backend:latest`. (4) `--force-recreate backend` with full 4-file chain. |
+| Backend boots but `/api/v1/version` shows 0.49 | pom.xml not bumped in the built JAR. Re-check step 3 + 5; rebuild with explicit `mvn clean`; re-run step 6. |
+
+---
+
+## 8. Post-Deploy Housekeeping
+
+- [ ] **Update `project_live_deployment_status.md` memory** — version v0.51.0, Flyway HWM V84, backend image `fabt-backend:v0.51.0`, list V83 audit row counts, confirm `tenant_dek` row count, note "hardDelete capability live but not exercised."
+- [ ] **Commit rehearsal attestation** — `deploy/rehearsal-attest-v0.51.0.txt` with the rehearsal log filename.
+- [ ] **Update `CHANGELOG.md`** — move `[Unreleased]` items under `[v0.51.0]`.
+- [ ] **Prune old images** — `docker image prune -f` after confirming v0.50.0-lastgood tag retained.
+- [ ] **Archive spent OpenSpec change** — `multi-tenant-production-readiness` is still active (Phases G+ remain); do NOT archive yet.
+- [ ] **File operator verification query** — confirm `docs/security/crypto-shred-runbook.md` is in place; send Riley a pointer so ops knows the verification query exists before the first prod shred.
+- [ ] **Update `project_resume_point.md`** (per `feedback_periodic_resume_save.md`).
+- [ ] **Delete pre-deploy `.pid-backend` or test .pid files** if left from dev iteration.
+
+---
+
+## What's New in v0.51.0 (release notes summary)
+
+**Real crypto-shred.** Phase F slice F-6 adds per-tenant random DEKs wrapped via AES-KWP (RFC 5649) under a master-KEK-derived wrapping key, stored in a new `tenant_dek` table that `ON DELETE CASCADE` removes on tenant row deletion. The `TenantLifecycleService.hardDelete` method transitions an ARCHIVED tenant to DELETED and fires a single `DELETE FROM tenant` that unwinds 22 CASCADE FKs including `tenant_dek`. Post-commit, the wrapped DEK for that tenant exists nowhere in the live database or in any application cache. A TDD anchor test (`CryptoShredGapIntegrationTest`) asserts an adversary with the master KEK and a pre-shred ciphertext cannot recover plaintext after the shred completes. Designed to support NIST SP 800-88 Rev 2 §2.5 "Cryptographic Erase."
+
+**`hardDelete` ships but is not yet exercised.** v0.51.0 makes the capability available at the service layer. No admin UI or CLI endpoint invokes it; first prod shred is a future release. Operator procedures live in `docs/security/crypto-shred-runbook.md` — including a mandatory 5-query post-shred verification checklist.
+
+**Six new Flyway migrations (V79–V84).** V79 converts `tenant.state` to a VARCHAR-plus-CHECK enum. V80 adds the audit chain head table. V81 adds `offboard_export_receipt_uri` + `archived_at` columns. V82 creates `tenant_dek` with FORCE RLS + a SECURITY DEFINER trigger guard. V83 is a Java migration that re-encrypts the 4 existing v1-HKDF ciphertext columns under fresh random DEKs and writes a diagnostic audit row. V84 flips 18 child-table FKs to `ON DELETE CASCADE`.
+
+**Backend-only release.** Frontend, nginx, alertmanager, and prometheus images are unchanged. The compose chain is the same 4-file prod chain established in v0.44. First backend rebuild since v0.49.
+
+---
+
+*Template: `docs/runbook-template.md` v1 — mandatory for all `oracle-update-notes-vX.Y.Z.md` from v0.50.0 onward*

--- a/docs/oracle-update-notes-v0.51.0.md
+++ b/docs/oracle-update-notes-v0.51.0.md
@@ -43,7 +43,7 @@ consulted:
   - file: project_phase_f_implementation_plan.md
     not-applicable: internal slice-sequencing reference — implementation is complete for this release
   - file: feedback_legal_claims_review.md
-    # why-cited: release notes language must say "designed to support" not "compliant" re NIST/GDPR. CHANGELOG + crypto-shred runbook legal-scanned.
+    # why-cited: release notes language must use "designed to support" phrasing for NIST/GDPR references; CHANGELOG + crypto-shred runbook legal-scanned.
 ```
 
 ---

--- a/docs/security/crypto-shred-runbook.md
+++ b/docs/security/crypto-shred-runbook.md
@@ -1,0 +1,249 @@
+# Crypto-shred operational runbook
+
+**Status:** active — introduced v0.51.0
+**Feature doc:** `openspec/changes/multi-tenant-production-readiness/design-f6-real-cryptoshred.md`
+**First version that enables hardDelete in prod:** not yet; capability ships in v0.51.0 but no prod shred scheduled
+
+---
+
+## What crypto-shred means on FABT
+
+From v0.51.0 onward, `TenantLifecycleService.hardDelete(tenantId, actor, reason)` removes a tenant's per-tenant wrapped DEK rows (`tenant_dek`) via an `ON DELETE CASCADE` chain fired by a single `DELETE FROM tenant`. Post-commit, the wrapped data-encryption keys for that tenant no longer exist in the live database or in any application cache.
+
+This is **designed to support** NIST SP 800-88 Rev 2 §2.5 "Cryptographic Erase" as the destruction mechanism for the operational copy of the data. It is **not** a compliance certification. Pre-shred backup copies, PITR retention windows, and the master KEK continue to exist per their own retention policies — see §"Backup-hygiene scope" below.
+
+**Verifiable property:** the `CryptoShredGapIntegrationTest` anchor test (shipped in v0.51.0) asserts that an adversary with the master KEK and a pre-shred ciphertext cannot recover plaintext after the shred completes. Under the v0.51 `tenant_dek` design the data-encryption DEK is random (not HKDF-derivable), so raw-HKDF recomputation by an attacker yields a key that does not decrypt the ciphertext.
+
+---
+
+## Preconditions for `hardDelete`
+
+`hardDelete` will raise `IllegalStateException` or `IllegalStateTransitionException` unless all four preconditions hold:
+
+1. **Tenant exists.** `findById` returns the row.
+2. **State is ARCHIVED.** §D8 FSM allows only `ARCHIVED → DELETED`. Other states (`ACTIVE`, `SUSPENDED`, `OFFBOARDING`) reject with `IllegalStateTransitionException` and emit a `TENANT_HARD_DELETE_REJECTED` attempt-audit.
+3. **`archived_at` is non-null.** V81 schema contract — if someone manually flipped `state='ARCHIVED'` via SQL without stamping `archived_at`, the service refuses to proceed (data-integrity guard).
+4. **Retention window has elapsed.** `archived_at + fabt.tenant.hard-delete.retention-days <= NOW()`. Prod default is 30 days (GDPR Art. 17 industry practice). Test harnesses override to 0 via `@TestPropertySource`.
+
+---
+
+## How to shred a tenant (break-glass procedure)
+
+**Important:** v0.51.0 does NOT expose a public admin API or CLI for `hardDelete`. The method exists as a service-layer entry point; a CLI wrapper lands in a later release. For the first prod shred (if required before the CLI lands), use the Spring Boot actuator or a purpose-built one-shot migration. This section documents the operator-side procedure; run it through the warroom before executing.
+
+### Pre-shred operator checklist
+
+```text
+☐ Tenant in state ARCHIVED?
+☐ archived_at stamped > 30 days ago?
+☐ pg_dump backup taken and filed in ~/fabt-backups/ with retention tag
+☐ Asheville / legal-team sign-off recorded in audit_events as
+  TENANT_HARD_DELETE_APPROVED (manual INSERT; platform_admin actor)
+☐ Customer (if applicable) notified per data-processing agreement
+☐ Prometheus alert rules for this tenant reviewed and silenced for 24h
+  (avoid a flurry of "tenant disappeared" false positives)
+```
+
+### Shred execution (once the preconditions hold)
+
+The `TenantLifecycleService.hardDelete` path is `@Transactional`:
+
+1. FSM + retention gates verified.
+2. `tenant_audit_chain_head.last_hash` captured in-memory BEFORE the CASCADE destroys it.
+3. `fabt.shred_in_progress` GUC bound to the tenant UUID (V82 trigger-guard precondition).
+4. `DELETE FROM tenant WHERE id = ?` — 22-FK CASCADE chain fires.
+5. After-commit listener evicts `TenantDekService` + `TenantStateGuard` caches and writes a platform-owned `TENANT_HARD_DELETED` tombstone row to `audit_events`.
+
+On rollback (trigger guard raises, FK violates, tx poisoned), the tenant row still exists and no claim-of-deletion is persisted.
+
+---
+
+## Post-shred verification — the operator query
+
+Run ALL of these. Any non-zero row where zero is expected, or missing row where a row is expected, means the shred is incomplete and requires investigation. Warroom pass-3 Riley requirement — mandatory before declaring a shred complete.
+
+> `psql` runs on the Oracle VM against the prod DB: `docker exec -it finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt`.
+
+### 1. Tenant row is gone
+
+```sql
+SELECT COUNT(*) FROM tenant WHERE id = '<deleted-tenant-uuid>';
+-- expect: 0
+```
+
+### 2. All per-tenant child tables are empty for this tenant
+
+The `TenantChildCascadeAuditTest` allowlist enumerates the 22 CASCADE-bound tables. Repeat for each (or run the scripted version below):
+
+```sql
+WITH expected(table_name) AS (VALUES
+    ('app_user'), ('api_key'), ('shelter'), ('import_log'),
+    ('tenant_oauth2_provider'), ('subscription'), ('bed_availability'),
+    ('reservation'), ('surge_event'), ('referral_token'),
+    ('hmis_outbox'), ('hmis_audit_log'), ('bed_search_log'),
+    ('daily_utilization_summary'), ('one_time_access_code'),
+    ('notification'), ('password_reset_token'), ('escalation_policy'),
+    ('tenant_key_material'), ('kid_to_tenant_key'),
+    ('tenant_audit_chain_head'), ('tenant_dek')
+)
+SELECT e.table_name,
+       (SELECT COUNT(*) FROM app_user WHERE tenant_id = '<uuid>') AS cnt
+  FROM expected e WHERE e.table_name = 'app_user'
+UNION ALL
+-- Repeat per table — or automate with a DO block.
+SELECT 'tenant_dek' AS table_name,
+       (SELECT COUNT(*) FROM tenant_dek WHERE tenant_id = '<uuid>');
+-- expect: every `cnt` column = 0
+```
+
+**Fast version (single query):**
+
+```sql
+SELECT 'tenant_dek'              t, COUNT(*) n FROM tenant_dek              WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'tenant_key_material'     t, COUNT(*) n FROM tenant_key_material     WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'kid_to_tenant_key'       t, COUNT(*) n FROM kid_to_tenant_key       WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'tenant_audit_chain_head' t, COUNT(*) n FROM tenant_audit_chain_head WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'app_user'                t, COUNT(*) n FROM app_user                WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'shelter'                 t, COUNT(*) n FROM shelter                 WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'subscription'            t, COUNT(*) n FROM subscription            WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'tenant_oauth2_provider'  t, COUNT(*) n FROM tenant_oauth2_provider  WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'reservation'             t, COUNT(*) n FROM reservation             WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'referral_token'          t, COUNT(*) n FROM referral_token          WHERE tenant_id = '<uuid>' UNION ALL
+SELECT 'notification'            t, COUNT(*) n FROM notification            WHERE tenant_id = '<uuid>';
+-- expect: every n = 0
+```
+
+### 3. The platform-owned tombstone row is present
+
+```sql
+SELECT id, action, tenant_id,
+       details ->> 'deleted_tenant_id'        AS deleted_tenant_id,
+       details ->> 'actor_user_id'            AS actor,
+       details ->> 'deleted_at'               AS deleted_at,
+       details ->> 'previous_state'           AS previous_state,
+       details ->> 'last_audit_chain_hash'    AS chain_hash
+  FROM audit_events
+ WHERE action = 'TENANT_HARD_DELETED'
+   AND details ->> 'deleted_tenant_id' = '<uuid>'
+ ORDER BY timestamp DESC
+ LIMIT 1;
+-- expect: exactly one row, tenant_id = platform SYSTEM_TENANT_ID
+--         (00000000-0000-0000-0000-000000000001), chain_hash non-null
+```
+
+> The tombstone is written via `DetachedAuditPersister` (REQUIRES_NEW) from the after-commit hook. If the main tx commits but the pod crashes before the hook fires, the tenant is shredded but the tombstone is missing — see §"Known edge cases" below.
+
+### 4. `audit_events` rows for the deleted tenant are preserved (FK-less per V57)
+
+```sql
+SELECT COUNT(*)
+  FROM audit_events
+ WHERE tenant_id = '<uuid>';
+-- expect: > 0 (forensic trail survives shred per Q-F6-5)
+--         These rows are now "orphaned" — their tenant_id points to a
+--         no-longer-existing tenant UUID. This is intentional.
+```
+
+### 5. No orphan envelope bytes in the 4 encrypted columns
+
+If any row in the 4 V83-covered columns still carries a kid that pointed at this tenant's `tenant_dek` row, that row is now undecryptable. Shouldn't happen (CASCADE destroys the owning row too), but worth confirming.
+
+```sql
+-- For each encrypted column — app_user, subscription,
+-- tenant_oauth2_provider, tenant.config hmis_vendors — count rows
+-- referring to the deleted tenant.
+SELECT 'app_user.totp'                   t, COUNT(*) FROM app_user                WHERE tenant_id = '<uuid>' AND totp_secret_encrypted IS NOT NULL UNION ALL
+SELECT 'subscription.callback'           t, COUNT(*) FROM subscription            WHERE tenant_id = '<uuid>' AND callback_secret_hash IS NOT NULL UNION ALL
+SELECT 'tenant_oauth2_provider.client'   t, COUNT(*) FROM tenant_oauth2_provider  WHERE tenant_id = '<uuid>' AND client_secret_encrypted IS NOT NULL;
+-- expect: every COUNT = 0 (CASCADE destroyed these rows)
+```
+
+---
+
+## Backup-hygiene scope
+
+**What crypto-shred destroys:** operational data in the live Postgres database. After the shred commits, the tenant's wrapped DEKs do not exist in `tenant_dek` or in the app's in-JVM caches.
+
+**What crypto-shred does NOT destroy:**
+
+- Pre-shred `pg_dump` backups in `~/fabt-backups/`. These retain the `tenant_dek` row as it existed at dump time. An adversary with the backup + master KEK could unwrap the DEK and decrypt ciphertext.
+- Postgres PITR WAL segments (if enabled). A PITR restore into a pre-shred timestamp resurrects the deleted tenant's rows. **Document this as a retention-policy decision, not a crypto property.**
+- The master KEK (`FABT_ENCRYPTION_KEY` in `.env.prod` on the VM). It is required to unwrap any DEK — including the deleted one, if the backup contains it. Master KEK rotation is a separate operational topic (Phase L).
+- Grafana dashboards, Prometheus metrics retention (`prometheus_tsdb_retention_time`), log aggregator retention — these may reference the tenant ID by string.
+
+**What the operator must do alongside a prod shred:**
+
+1. **Record the retention window** for any pre-shred backups in a registered backup-log row. Industry practice for NIST SP 800-88 Cryptographic Erase cites the operational data as the erasure target; backup disposition is a separate policy.
+2. **Rotate the master KEK** if the ARCHIVED→DELETED boundary is tied to a compliance event that demands this. v0.51.0 does NOT rotate the master KEK on hardDelete — that rotation is manual and Phase L scope.
+3. **Review backup sharing contracts** (if any) to ensure the backup retention policy is documented and agreed with the subject.
+4. **Confirm pgdata encryption-at-rest posture.** The Oracle VM's pgdata is on a bind-mounted volume. Whether that volume is encrypted-at-rest is an infra-level policy; `FABT_ENCRYPTION_KEY` does NOT encrypt pgdata bytes on disk. The wrapping-key + wrapped-DEK + shred model relies on the operator not leaking both the env var and a backup to the same adversary.
+
+---
+
+## Known edge cases
+
+### Pod crash between main-commit and tombstone-write
+
+`hardDelete` commits the DELETE + CASCADE in the main tx. The `TENANT_HARD_DELETED` tombstone lands via `DetachedAuditPersister` (REQUIRES_NEW) inside the after-commit hook. If the pod crashes between the main commit and the hook firing, the shred is complete but the tombstone is missing.
+
+- **Detection:** monthly reconciliation query — join `tenant` against the last-90d `TENANT_HARD_DELETED` audit view, flag any shredded tenant without a tombstone:
+
+  ```sql
+  -- Tenants known to be shredded (in deploy-log-tracked list) but missing tombstone:
+  SELECT '<uuid>' AS maybe_missing
+  WHERE NOT EXISTS (
+      SELECT 1 FROM audit_events
+       WHERE action = 'TENANT_HARD_DELETED'
+         AND details ->> 'deleted_tenant_id' = '<uuid>'
+  );
+  ```
+
+- **Recovery:** the operator manually INSERTs a `TENANT_HARD_DELETED` row into `audit_events` citing the incident in the details JSONB (actor = `PLATFORM_ADMIN_MANUAL`, reason = `post-crash tombstone recovery`, event_timestamp = approximate DELETE time).
+
+### V84 rollback
+
+V84 flips 18 child-FKs to `ON DELETE CASCADE`. If a future change wants to revert (e.g., the CASCADE causes an unexpected production issue), the rollback is a forward-migration that runs the inverse `DROP/ADD CONSTRAINT` without the `ON DELETE CASCADE` clause. Template:
+
+```sql
+-- V85__tenant_fk_cascade_rollback.sql (DO NOT COMMIT UNLESS EXECUTING ROLLBACK)
+DO $$
+DECLARE
+    target_tables text[] := ARRAY['app_user', 'api_key', /* ... full list from V84 ... */ ];
+    tbl text; cname text;
+BEGIN
+    FOREACH tbl IN ARRAY target_tables LOOP
+        SELECT conname INTO cname FROM pg_catalog.pg_constraint
+         WHERE contype = 'f'
+           AND conrelid = format('public.%I', tbl)::regclass
+           AND confrelid = 'public.tenant'::regclass;
+        IF cname IS NULL THEN RAISE EXCEPTION 'V85: no FK found on %', tbl; END IF;
+        EXECUTE format('ALTER TABLE public.%I DROP CONSTRAINT %I', tbl, cname);
+        EXECUTE format(
+            'ALTER TABLE public.%I '
+            'ADD CONSTRAINT %I FOREIGN KEY (tenant_id) '
+            'REFERENCES public.tenant(id) NOT VALID',  -- no ON DELETE CASCADE
+            tbl, cname);
+        EXECUTE format('ALTER TABLE public.%I VALIDATE CONSTRAINT %I', tbl, cname);
+    END LOOP;
+END;
+$$;
+```
+
+Warroom must sign off on a CASCADE rollback; after V85 lands, `hardDelete` will fail on the first non-cascaded FK and no further shred is possible until V86 reinstates CASCADE.
+
+### V82/V83 are also irreversible
+
+There is no automated rollback for V82 (schema) or V83 (re-encrypt). Rollback requires `pg_restore` from the pre-deploy `pg_dump`. See the per-release deploy runbook for the `pg_dump` filename.
+
+---
+
+## References
+
+- Design doc: `openspec/changes/multi-tenant-production-readiness/design-f6-real-cryptoshred.md`
+- TDD anchor: `backend/src/test/java/org/fabt/shared/security/CryptoShredGapIntegrationTest.java`
+- Service entry: `backend/src/main/java/org/fabt/tenant/service/TenantLifecycleService.java` (`hardDelete` method)
+- Drift guard: `backend/src/test/java/org/fabt/architecture/TenantChildCascadeAuditTest.java`
+- ArchUnit rules: `backend/src/test/java/org/fabt/architecture/CryptoShredArchitectureTest.java` (Family F 7.8h + 7.8j)
+- NIST SP 800-88 Rev 2 §2.5 Cryptographic Erase (Sept 2025)
+- RFC 5649 AES Key Wrap with Padding
+- EDPB Guidelines 02/2025 on Art. 17 GDPR erasure


### PR DESCRIPTION
## Summary

- **Phase F complete** — F-1 (FSM skeleton) through F-6 (real crypto-shred). 17 commits on `feature/phase-f-lifecycle-fsm`, 6 new Flyway migrations (V79–V84), Flyway HWM goes V78 → V84.
- **Crypto-shred is now a verifiable cryptographic property** — not just a design claim. The `CryptoShredGapIntegrationTest` anchor that pinned the pre-F-6 gap (adversary recovers plaintext post-shred via public HKDF) now flips green under Option A (per-tenant random DEKs wrapped via AES-KWP, stored in `tenant_dek`, CASCADE-deleted on hardDelete). Designed to support NIST SP 800-88 Rev 2 §2.5 Cryptographic Erase as the operational-data destruction mechanism.
- **`hardDelete` ships but is not exercised in prod this release** — capability is live at the service layer, no admin UI/CLI invokes it. First prod shred is a future release; operator procedure documented in `docs/security/crypto-shred-runbook.md`.

## What ships

**Code:** `TenantDekService`, `SecretEncryptionService` refactor (with bounded backward-compat shim for pre-V83 envelopes), `TenantLifecycleService.hardDelete` with retention-days gate, `PurposeMismatchException`, ArchUnit Family F rules 7.8h + 7.8j, crypto-shred TDD anchor flipped green.

**Migrations (V79–V84):**
- V79 `tenant.state` → VARCHAR + CHECK (Spring Data JDBC simple-type)
- V80 `tenant_audit_chain_head` with CASCADE + zero-hash backfill
- V81 `offboard_export_receipt_uri` + `archived_at` columns on `tenant`
- V82 `tenant_dek` with FORCE RLS + PERMISSIVE+RESTRICTIVE policy pair + SECURITY DEFINER trigger guard
- V83 Java migration re-encrypts 4 existing v1-HKDF ciphertext columns under fresh random DEKs (per-row tx with round-trip verify + rotation-readiness probe)
- V84 flips 18 child-table FKs to `ON DELETE CASCADE` via DO-block with `NOT VALID` + `VALIDATE CONSTRAINT` pattern

**Tests (§11 minimum shipped in full):**
- `CryptoShredGapIntegrationTest` — adversary-vs-shred TDD anchor (1/1 green)
- `NTenantCanaryShredTest` — 10-seed property-style, 400 ciphertexts/seed (10/10 green)
- `TenantDekRlsTest` — 6-assertion RLS boundary (6/6 green)
- `TenantDekShredGuardTest` — trigger positive + no-GUC + cross-tenant-GUC-poisoning (3/3 green)
- `TenantChildCascadeAuditTest` — Flyway CI drift guard for the 22-FK CASCADE invariant (1/1 green)
- `V83MigrationIntegrationTest` — idempotency + completeness + rotation probe (5/5 green)
- `TenantLifecycleHardDeleteIntegrationTest` — lifecycle + tombstone + cache eviction (4/4 green)

**Docs:**
- `docs/oracle-update-notes-v0.51.0.md` — rehearsable deploy runbook (runbook-template v1 shape) grounded in v0.50 lessons (4-file compose chain, correct smoke invocation, pg_dump mandatory, FABT_ENCRYPTION_KEY presence, pom.xml version bump gate)
- `docs/security/crypto-shred-runbook.md` — operator reference with 5-query post-shred verification checklist, backup-hygiene scope, V84 rollback template, pod-crash edge case
- `CHANGELOG.md` — v0.51.0 Keep-a-Changelog entry, legal-scanned
- `openspec/changes/multi-tenant-production-readiness/design-f6-real-cryptoshred.md` — warroom-locked design (2 passes + code-review pass + post-implementation pass)

## Warroom passes

Four warroom passes (2026-04-24), all folded in:
1. Pass-1 design — 5 blockers + 5 open questions
2. Pass-2 design re-review after blocker fold-in — 5 new blockers + Q-F6-6 resolution (GUC vs role for trigger guard)
3. Pass-3 code review after initial implementation — 4 blockers (cache invalidation on OFFBOARDING/ARCHIVED, JWT_SIGN decrypt guard, §11 tests missing, anchor catch-all)
4. Pass-4 code review after blocker fixes — 1 docs-lie blocker (reflection-gap), all else GO

## Verification

- **Full backend regression:** 1067/1067 green, 0 skipped (the anchor that used to be `@Disabled` is now active and passing)
- **Ship-checklist (design §12):** every gate green except the release-tag step itself
- **Legal scan:** runbooks + CHANGELOG scanned for overclaim language per `feedback_legal_claims_review.md` — no "compliant" / "guarantees" / "equivalent to" in new content

## Test plan

- [ ] CI green on this PR — watch for scan results (CodeQL, dependency review, etc.)
- [ ] Manual rehearsal: `make rehearse-deploy` on operator laptop — expected new first-run findings since v0.51 is the first pass through the harness with V82/V83/V84 + a backend rebuild
- [ ] After rehearsal PASS + CI green: merge, bump `pom.xml` to 0.51.0 if not already, tag v0.51.0
- [ ] Deploy per `docs/oracle-update-notes-v0.51.0.md` — pg_dump first, full 4-file compose chain, watch V83 COMMITTED log line + V84 success
- [ ] Post-deploy gates: version bump visible at `/api/v1/version`, Flyway HWM at 84, V83 audit row present, `tenant_dek` populated for 3 tenants, 22-FK CASCADE drift guard passes, Playwright smoke green

🤖 Generated with [Claude Code](https://claude.com/claude-code)