### PR TITLE
fix(security): bump postcss to 8.5.10 — CVE-2026-41305

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -6653,9 +6653,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "dev": true,
       "funding": [
         {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -30,7 +30,8 @@
   },
   "overrides": {
     "serialize-javascript": ">=7.0.3",
-    "lodash": ">=4.18.1"
+    "lodash": ">=4.18.1",
+    "postcss": ">=8.5.10"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",


### PR DESCRIPTION
## Summary

- Bumps transitive `postcss` from 8.5.8 to 8.5.10 via `frontend/package.json` overrides to close Dependabot alert #16 (GHSA-qx2v-qp2m-jg93 / CVE-2026-41305, CVSS 6.1 Medium).
- **Practical impact on FABT: effectively zero.** postcss is a transitive dev dependency only — runs at `npm run build` time and produces a static `.css` file served via `<link rel="stylesheet">`. FABT does not accept user-submitted CSS anywhere, so the CVE's attack path (user CSS → stringify → `<style>` tag embedding) is structurally unreachable.
- Fix gives clean Dependabot + audit signal; no behavior change expected.

## Verification

- `npm install` regenerates `package-lock.json` with postcss@8.5.10.
- `npm audit` reports 0 vulnerabilities post-bump.
- `npm run build` verified clean: vite 7.3.2 produces identical `dist/` + `sw.js` + PWA manifest, built in 2.69s.

## Test plan

- [ ] CI green (CodeQL, dependency review, frontend build)
- [ ] Dependabot alert #16 auto-closes on merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)