### PR TITLE
Slice G-1: per-tenant audit hash chain writer

### DIFF
--- a/backend/src/main/java/org/fabt/shared/audit/AuditChainHasher.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditChainHasher.java
@@ -1,0 +1,295 @@
+package org.fabt.shared.audit;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.UUID;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.fabt.shared.web.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+/**
+ * Phase G slice G-1 — per-tenant audit hash chain writer.
+ *
+ * <p>Each {@code audit_events} INSERT becomes a link in a per-tenant SHA-256
+ * hash chain. The link is computed inside the INSERT transaction:
+ *
+ * <ol>
+ *   <li>{@link #computeHashes} reads the tenant's current head hash from
+ *       {@code tenant_audit_chain_head.last_hash} with {@code SELECT ... FOR
+ *       UPDATE} (serialises concurrent writers for the same tenant), then
+ *       returns the {@link HashedRow} containing the row's {@code prev_hash}
+ *       (the just-read head) and {@code row_hash = SHA-256(prev_hash ||
+ *       canonical_json(row))}.</li>
+ *   <li>Caller stamps the two hashes onto the {@link AuditEventEntity} and
+ *       calls {@code repository.save(entity)}. The DB assigns the row id.</li>
+ *   <li>Caller invokes {@link #advanceChainHead} with {@code entity.getId()}
+ *       to UPDATE the chain head (atomic with the INSERT — same tx).</li>
+ * </ol>
+ *
+ * <h2>Canonical JSON form (HASH INPUT IS PERMANENT)</h2>
+ *
+ * <p>{@link #canonicalJson} renders the row as a JSON object with
+ * fixed-order fields:
+ * {@code {"tenant_id":...,"timestamp":...,"actor_user_id":...,
+ * "target_user_id":...,"action":...,"details":<raw jsonb|null>,
+ * "ip_address":...}}.
+ *
+ * <p>Once the first chain row is written to a tenant, <b>this form is
+ * permanent</b>. A future change to field order, escaping rules, null
+ * representation, or any other visible-in-output detail breaks the
+ * hash-stability contract — the verifier (Slice G-2) would fail to reproduce
+ * historical hashes. Any change must ship with a migration that recomputes
+ * hashes for every affected row AND re-signs the external anchor (Slice G-3).
+ *
+ * <p>{@code id} is intentionally excluded from the canonical form because
+ * the DB assigns it on INSERT (after hashing). Row ordering in the chain is
+ * enforced by {@code tenant_audit_chain_head.last_row_id}, not by the id in
+ * the hash.
+ *
+ * <h2>SYSTEM_TENANT_ID orphan path</h2>
+ *
+ * <p>{@link TenantContext#SYSTEM_TENANT_ID} is a sentinel — no row in
+ * {@code tenant} and therefore no row in {@code tenant_audit_chain_head}.
+ * Audits that fall back to this tenant id are orphans already carrying a
+ * WARN signal per Phase B D55. This hasher detects the sentinel and skips
+ * hashing — the row's {@code prev_hash} and {@code row_hash} stay NULL.
+ * Orphan audits remain evidential but are not linked into any tenant chain.
+ *
+ * <h2>Missing chain head (defensive)</h2>
+ *
+ * <p>If {@code tenant_audit_chain_head} has no row for the tenant
+ * (theoretically impossible after V80's backfill + TenantLifecycleService.create
+ * seeding, but possible under a test that inserts tenant rows directly
+ * without going through the service), the hasher also skips hashing and
+ * increments {@code fabt.audit.chain_missing_head.count} so operators notice.
+ * Chain-verification (G-2) will flag the NULL-hash row anyway.
+ */
+@Service
+public class AuditChainHasher {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditChainHasher.class);
+
+    /** SHA-256 digest size — invariant pinned by the V85 CHECK constraint. */
+    public static final int HASH_LENGTH_BYTES = 32;
+
+    private final JdbcTemplate jdbc;
+    private final MeterRegistry meterRegistry;
+
+    public AuditChainHasher(JdbcTemplate jdbc,
+                            ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this.jdbc = jdbc;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
+    }
+
+    /**
+     * Read the tenant's current chain head (with row lock) and compute the
+     * new row's {@code prev_hash} + {@code row_hash}. Call BEFORE
+     * {@code repository.save(entity)} so the hashes can be stamped onto the
+     * entity and persisted in the same INSERT.
+     *
+     * <p>Returns {@link HashedRow#SKIPPED} for orphan paths
+     * (SYSTEM_TENANT_ID, or any tenant without a chain head row). The
+     * caller should leave {@code prev_hash} and {@code row_hash} unset
+     * (null) on the entity in those cases.
+     */
+    public HashedRow computeHashes(UUID tenantId, AuditEventEntity entity) {
+        if (TenantContext.SYSTEM_TENANT_ID.equals(tenantId)) {
+            // Orphan path. Phase B D55 already treats this as "publisher
+            // forgot to bind TenantContext" — don't chain these rows.
+            return HashedRow.SKIPPED;
+        }
+
+        byte[] prevHash;
+        try {
+            prevHash = jdbc.query(
+                    "SELECT last_hash FROM tenant_audit_chain_head "
+                    + "WHERE tenant_id = ? FOR UPDATE",
+                    rs -> rs.next() ? rs.getBytes(1) : null,
+                    tenantId);
+        } catch (Exception e) {
+            log.warn("Failed to read tenant_audit_chain_head for tenant={}: {}. "
+                    + "Row will be inserted with NULL hash — will surface in G-2 verifier.",
+                    tenantId, e.getMessage());
+            incrementMissingHeadCounter();
+            return HashedRow.SKIPPED;
+        }
+
+        if (prevHash == null) {
+            // No chain head row — unexpected. V80 backfill + TenantLifecycleService.create
+            // both seed one. Log + skip rather than block the audit INSERT.
+            log.warn("tenant_audit_chain_head has no row for tenant={} — audit row "
+                    + "will be inserted with NULL hash. Investigate the tenant's "
+                    + "creation path; every tenant should have a seeded chain head.",
+                    tenantId);
+            incrementMissingHeadCounter();
+            return HashedRow.SKIPPED;
+        }
+
+        if (prevHash.length != HASH_LENGTH_BYTES) {
+            // CHECK constraint in V80 should have prevented this, but defensive.
+            log.error("tenant_audit_chain_head.last_hash for tenant={} is {} bytes, "
+                    + "expected {}. Skipping hash for this row.",
+                    tenantId, prevHash.length, HASH_LENGTH_BYTES);
+            incrementMissingHeadCounter();
+            return HashedRow.SKIPPED;
+        }
+
+        byte[] canonical = canonicalJson(entity).getBytes(StandardCharsets.UTF_8);
+        byte[] rowHash = sha256(concat(prevHash, canonical));
+
+        return new HashedRow(prevHash, rowHash);
+    }
+
+    /**
+     * Update {@code tenant_audit_chain_head} to point at the just-inserted
+     * row. Call AFTER {@code repository.save(entity)} so {@code entity.getId()}
+     * is available.
+     *
+     * <p>No-op when {@code hashed} is {@link HashedRow#SKIPPED} — orphan
+     * paths do not advance any chain.
+     *
+     * <p>Atomicity: this UPDATE and the preceding audit_events INSERT run
+     * in the same tx (REQUIRED or REQUIRES_NEW depending on caller).
+     * Rollback rolls both back together; commit commits both — chain head
+     * and audit row never disagree.
+     */
+    public void advanceChainHead(UUID tenantId, UUID auditRowId, HashedRow hashed) {
+        if (hashed == null || hashed == HashedRow.SKIPPED) return;
+
+        int updated = jdbc.update(
+                "UPDATE tenant_audit_chain_head "
+                + "SET last_hash = ?, last_row_id = ?, updated_at = NOW() "
+                + "WHERE tenant_id = ?",
+                hashed.rowHash(), auditRowId, tenantId);
+
+        if (updated != 1) {
+            // Chain head disappeared between computeHashes() SELECT FOR UPDATE
+            // and this UPDATE — only possible if another tx committed a DELETE
+            // on the chain head (i.e. tenant hardDelete). That path captures
+            // last_hash first, so losing the race here is a correctness issue
+            // for the audit trail but doesn't silently corrupt the chain.
+            // Log + emit metric for operator attention.
+            log.error("advanceChainHead updated {} rows for tenant={} auditRowId={} — "
+                    + "chain head row may have been concurrently deleted. The audit "
+                    + "row INSERT is committed but the chain head was not advanced.",
+                    updated, tenantId, auditRowId);
+            incrementAdvanceFailedCounter();
+        }
+    }
+
+    /**
+     * Serialise the entity to canonical JSON used as the hash input.
+     *
+     * <p><b>Stability contract.</b> This output form is permanent. Any
+     * change after first ship requires recomputing hashes for every
+     * affected row and re-signing the external anchor (G-3).
+     *
+     * <p>Public so the verifier (G-2) can call the same code path — a
+     * single implementation of the canonical form prevents drift between
+     * writer + verifier.
+     */
+    public String canonicalJson(AuditEventEntity entity) {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append('{');
+        sb.append("\"tenant_id\":").append(jsonStringOrNull(
+                entity.getTenantId() == null ? null : entity.getTenantId().toString()));
+        sb.append(",\"timestamp\":").append(jsonStringOrNull(
+                entity.getTimestamp() == null ? null : entity.getTimestamp().toString()));
+        sb.append(",\"actor_user_id\":").append(jsonStringOrNull(
+                entity.getActorUserId() == null ? null : entity.getActorUserId().toString()));
+        sb.append(",\"target_user_id\":").append(jsonStringOrNull(
+                entity.getTargetUserId() == null ? null : entity.getTargetUserId().toString()));
+        sb.append(",\"action\":").append(jsonStringOrNull(entity.getAction()));
+        sb.append(",\"details\":");
+        if (entity.getDetails() == null || entity.getDetails().value() == null) {
+            sb.append("null");
+        } else {
+            // details.value() is already a canonical JSON string produced by
+            // ObjectMapper.writeValueAsString in the persister. Embed it
+            // verbatim (not escape-wrapped) — it's JSONB-valid by construction.
+            sb.append(entity.getDetails().value());
+        }
+        sb.append(",\"ip_address\":").append(jsonStringOrNull(entity.getIpAddress()));
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Returns {@code "value"} with JSON-escape rules applied, or {@code null}. */
+    private static String jsonStringOrNull(String value) {
+        if (value == null) return "null";
+        StringBuilder sb = new StringBuilder(value.length() + 2);
+        sb.append('"');
+        for (int i = 0; i < value.length(); i++) {
+            char c = value.charAt(i);
+            switch (c) {
+                case '"':  sb.append("\\\""); break;
+                case '\\': sb.append("\\\\"); break;
+                case '\b': sb.append("\\b");  break;
+                case '\f': sb.append("\\f");  break;
+                case '\n': sb.append("\\n");  break;
+                case '\r': sb.append("\\r");  break;
+                case '\t': sb.append("\\t");  break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        sb.append('"');
+        return sb.toString();
+    }
+
+    static byte[] sha256(byte[] input) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            return md.digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            // SHA-256 is a required JCA algorithm — unreachable on any
+            // standard JVM. Wrap as unchecked so callers aren't forced
+            // to declare it.
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+
+    private void incrementMissingHeadCounter() {
+        if (meterRegistry != null) {
+            Counter.builder("fabt.audit.chain_missing_head.count")
+                    .description("Audit rows written without a linked chain head (expected for pre-V85 rows + SYSTEM_TENANT_ID orphans; non-zero rate for real tenants is a data-integrity signal)")
+                    .register(meterRegistry)
+                    .increment();
+        }
+    }
+
+    private void incrementAdvanceFailedCounter() {
+        if (meterRegistry != null) {
+            Counter.builder("fabt.audit.chain_advance_failed.count")
+                    .description("UPDATE of tenant_audit_chain_head affected != 1 row — chain head concurrently deleted between compute + advance")
+                    .register(meterRegistry)
+                    .increment();
+        }
+    }
+
+    /**
+     * Immutable result of {@link #computeHashes}. {@link #SKIPPED} is the
+     * sentinel returned for orphan paths where no chain update should occur.
+     */
+    public record HashedRow(byte[] prevHash, byte[] rowHash) {
+        public static final HashedRow SKIPPED = new HashedRow(null, null);
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventEntity.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventEntity.java
@@ -1,6 +1,7 @@
 package org.fabt.shared.audit;
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.UUID;
 
 import org.fabt.shared.config.JsonString;
@@ -19,6 +20,11 @@ public class AuditEventEntity {
     private String action;
     private JsonString details;
     private String ipAddress;
+    // Phase G-1 hash chain — Slice G-1. NULL for pre-V85 rows and for
+    // orphan audits under SYSTEM_TENANT_ID; set by AuditChainHasher for
+    // all real-tenant rows written post-V85. See V85 migration comments.
+    private byte[] prevHash;
+    private byte[] rowHash;
 
     public AuditEventEntity() {}
 
@@ -30,7 +36,15 @@ public class AuditEventEntity {
         this.action = action;
         this.details = details;
         this.ipAddress = ipAddress;
-        this.timestamp = Instant.now();
+        // Truncate to microseconds so the timestamp round-trips through
+        // PostgreSQL TIMESTAMPTZ (microsecond precision) without losing
+        // sub-microsecond bits. Load-bearing for Phase G-1 chain hashing:
+        // the hash input at write time must match the value the G-2
+        // verifier reads back from the DB, or SHA-256 output diverges and
+        // verification fails. Without truncation, Instant.now() on the
+        // JVM has nanosecond precision; a save+read cycle drops the last
+        // 3 digits and produces a different canonical_json.
+        this.timestamp = Instant.now().truncatedTo(ChronoUnit.MICROS);
     }
 
     public UUID getId() { return id; }
@@ -49,4 +63,8 @@ public class AuditEventEntity {
     public void setDetails(JsonString details) { this.details = details; }
     public String getIpAddress() { return ipAddress; }
     public void setIpAddress(String ipAddress) { this.ipAddress = ipAddress; }
+    public byte[] getPrevHash() { return prevHash; }
+    public void setPrevHash(byte[] prevHash) { this.prevHash = prevHash; }
+    public byte[] getRowHash() { return rowHash; }
+    public void setRowHash(byte[] rowHash) { this.rowHash = rowHash; }
 }

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventPersister.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventPersister.java
@@ -58,21 +58,33 @@ class AuditEventPersister {
 
     private final AuditEventRepository repository;
     private final JdbcTemplate jdbc;
+    private final AuditChainHasher chainHasher;
 
-    AuditEventPersister(AuditEventRepository repository, JdbcTemplate jdbc) {
+    AuditEventPersister(AuditEventRepository repository, JdbcTemplate jdbc,
+                        AuditChainHasher chainHasher) {
         this.repository = repository;
         this.jdbc = jdbc;
+        this.chainHasher = chainHasher;
     }
 
     /**
      * Binds {@code app.tenant_id} to {@code tenantId} for this transaction,
-     * then persists the audit event.
+     * then persists the audit event with Phase G-1 chain hashes stamped in.
      *
      * <p>{@code PROPAGATION_REQUIRED} preserves the "audit joins publisher tx"
      * contract — a publisher rollback rolls the audit row back too. When
      * there is no publisher tx (orphan paths), REQUIRED creates a fresh one,
      * which is exactly what we need for the {@code set_config(is_local=true)}
      * to behave correctly.
+     *
+     * <p><b>Phase G-1 chain hashing:</b> {@link AuditChainHasher#computeHashes}
+     * runs BEFORE {@code repository.save}, reads
+     * {@code tenant_audit_chain_head.last_hash} under a row lock, and
+     * returns the row's {@code prev_hash} + {@code row_hash}.
+     * {@link AuditChainHasher#advanceChainHead} runs AFTER save (needs the
+     * DB-assigned row id) and bumps the chain head. Both operations run in
+     * this method's REQUIRED transaction — the audit row INSERT, the chain
+     * head UPDATE, and the publisher's work all commit or roll back together.
      *
      * <p>Called only from {@link AuditEventService#onAuditEvent}. Package-
      * private to enforce that.
@@ -88,6 +100,13 @@ class AuditEventPersister {
                 event.action() == null ? null : event.action().name(),
                 details,
                 event.ipAddress());
+
+        AuditChainHasher.HashedRow hashed = chainHasher.computeHashes(tenantId, entity);
+        entity.setPrevHash(hashed.prevHash());
+        entity.setRowHash(hashed.rowHash());
+
         repository.save(entity);
+
+        chainHasher.advanceChainHead(tenantId, entity.getId(), hashed);
     }
 }

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventRecord.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventRecord.java
@@ -1,11 +1,39 @@
 package org.fabt.shared.audit;
 
+import java.util.Objects;
 import java.util.UUID;
 
 /**
  * Audit event published via Spring ApplicationEventPublisher.
  * Lives in shared.audit so any module can publish without creating
  * a dependency on the auth module.
+ *
+ * <p><b>Non-null action contract (Slice G-1 §8.0.16).</b> {@code action}
+ * must be non-null. A null action would be hashed by the Phase G-1 chain
+ * writer as {@code "action":null} in canonical_json — a forensically
+ * meaningless audit row with no event type. Enforced via compact
+ * constructor. Casey Drummond warroom concern from G-0 review.</p>
+ *
+ * <p>Other fields remain nullable:
+ * <ul>
+ *   <li>{@code actorUserId} — null for system-driven writes (batch jobs,
+ *       scheduled tasks)</li>
+ *   <li>{@code targetUserId} — null when the audit subject is not a user
+ *       (e.g. SHELTER_DEACTIVATED has a shelter id in details)</li>
+ *   <li>{@code details} — null when the action type needs no payload
+ *       (e.g. TOTP_ENABLED)</li>
+ *   <li>{@code ipAddress} — null for non-request-bound contexts</li>
+ * </ul>
  */
 public record AuditEventRecord(UUID actorUserId, UUID targetUserId, AuditEventType action,
-                                Object details, String ipAddress) {}
+                                Object details, String ipAddress) {
+
+    public AuditEventRecord {
+        Objects.requireNonNull(action,
+                "AuditEventRecord.action must be non-null (Slice G-1 §8.0.16 contract). "
+                + "Every audit row must have a defined event type — null-action rows are "
+                + "hashed as \"action\":null by Phase G-1 chain writer, producing "
+                + "forensically meaningless evidence. Use AuditEventType.TEST_PROBE for "
+                + "tests that need a synthetic action.");
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/audit/DetachedAuditPersister.java
+++ b/backend/src/main/java/org/fabt/shared/audit/DetachedAuditPersister.java
@@ -61,15 +61,18 @@ public class DetachedAuditPersister {
     private final JdbcTemplate jdbc;
     private final ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
+    private final AuditChainHasher chainHasher;
 
     public DetachedAuditPersister(AuditEventRepository repository,
                                    JdbcTemplate jdbc,
                                    ObjectMapper objectMapper,
-                                   ObjectProvider<MeterRegistry> meterRegistryProvider) {
+                                   ObjectProvider<MeterRegistry> meterRegistryProvider,
+                                   AuditChainHasher chainHasher) {
         this.repository = repository;
         this.jdbc = jdbc;
         this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistryProvider.getIfAvailable();
+        this.chainHasher = chainHasher;
     }
 
     /**
@@ -96,7 +99,19 @@ public class DetachedAuditPersister {
                     event.action() == null ? null : event.action().name(),
                     details,
                     event.ipAddress());
+
+            // Phase G-1 chain hashing — compute BEFORE save so the hashes
+            // are stamped onto the row, advance AFTER save so we have the
+            // DB-assigned id. REQUIRES_NEW scope means the chain head
+            // UPDATE commits independently of the caller's rollback,
+            // matching the security-evidence contract of this persister.
+            AuditChainHasher.HashedRow hashed = chainHasher.computeHashes(tenantId, entity);
+            entity.setPrevHash(hashed.prevHash());
+            entity.setRowHash(hashed.rowHash());
+
             repository.save(entity);
+
+            chainHasher.advanceChainHead(tenantId, entity.getId(), hashed);
         } catch (Exception e) {
             // Swallow + log: the security-evidence contract is best-effort; the
             // caller's IllegalStateException (the reason we're here) has already

--- a/backend/src/main/resources/db/migration/V85__audit_events_hash_chain_columns.sql
+++ b/backend/src/main/resources/db/migration/V85__audit_events_hash_chain_columns.sql
@@ -1,0 +1,48 @@
+-- V85 — Phase G slice G-1: audit_events hash-chain columns.
+--
+-- Adds two BYTEA columns to audit_events:
+--   * prev_hash — the immediately-preceding row's row_hash in this tenant's
+--                 chain at the time this row was inserted. Reads from
+--                 tenant_audit_chain_head.last_hash (set by G-1's
+--                 AuditChainHasher during the INSERT tx). First row in a
+--                 tenant's chain picks up the 32-byte zero sentinel that
+--                 V80 / TenantLifecycleService.create seeded.
+--   * row_hash  — SHA-256(prev_hash || canonical_json(row)), 32 bytes. Stored
+--                 on the row itself so a verifier can re-compute on read.
+--
+-- Both columns are NULLABLE. Rationale:
+--   * Historical rows written before V85 have no hash. The verifier (G-2)
+--     treats NULL-hash rows as "chain starts after this point" and validates
+--     forward from the first non-null row_hash per tenant.
+--   * Orphan audits that land under TenantContext.SYSTEM_TENANT_ID have no
+--     corresponding tenant_audit_chain_head row (SYSTEM_TENANT_ID is a
+--     sentinel, not a real tenant). The hasher skips them cleanly — they
+--     keep NULL hashes. Orphans are already a WARN signal per Phase B D55;
+--     the chain simply doesn't cover them.
+--
+-- Length invariant: when non-null, both columns must be exactly 32 bytes
+-- (SHA-256 digest size). Enforced via CHECK constraint.
+--
+-- Crypto-shred compatibility: tenant hardDelete CASCADE on the parent tenant
+-- row destroys audit_events via the existing FK (or, if audit_events has no
+-- direct FK to tenant, the verifier simply stops finding rows for that
+-- tenant). tenant_audit_chain_head ON DELETE CASCADE from V80 takes care of
+-- the chain head itself. No change to the shred path.
+
+ALTER TABLE audit_events
+    ADD COLUMN prev_hash BYTEA,
+    ADD COLUMN row_hash  BYTEA;
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT audit_events_prev_hash_length
+        CHECK (prev_hash IS NULL OR octet_length(prev_hash) = 32);
+
+ALTER TABLE audit_events
+    ADD CONSTRAINT audit_events_row_hash_length
+        CHECK (row_hash IS NULL OR octet_length(row_hash) = 32);
+
+COMMENT ON COLUMN audit_events.prev_hash IS
+    'Phase G-1 hash chain: 32-byte SHA-256 of the immediately-preceding row in this tenant''s chain (pulled from tenant_audit_chain_head.last_hash at INSERT time). First row in a tenant''s chain picks up the 32-byte zero sentinel. NULL for pre-V85 historical rows and for orphan audits under SYSTEM_TENANT_ID.';
+
+COMMENT ON COLUMN audit_events.row_hash IS
+    'Phase G-1 hash chain: 32-byte SHA-256(prev_hash || canonical_json(row)) stored on the row itself. Verifier (G-2) re-computes on read and alerts on drift. NULL for pre-V85 historical rows and for orphan audits under SYSTEM_TENANT_ID.';

--- a/backend/src/test/java/org/fabt/architecture/FamilyG0ArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/architecture/FamilyG0ArchitectureTest.java
@@ -1,0 +1,101 @@
+package org.fabt.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.fabt.shared.audit.AuditEventType;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+/**
+ * ArchUnit Family G-0 — test-sentinel guardrail. Introduced by
+ * multi-tenant-production-readiness task 8.0.15, warroom-deferred from Slice
+ * G-0 (issue #98).
+ *
+ * <h2>Why this rule exists</h2>
+ *
+ * <p>{@link AuditEventType#TEST_PROBE} is a dedicated sentinel enum case
+ * reserved for audit-infrastructure tests that need to publish a synthetic
+ * {@link org.fabt.shared.audit.AuditEventRecord} without polluting a
+ * business case's counter tag or audit-trail meaning. See
+ * {@code AuditEventType.TEST_PROBE} Javadoc for the full rationale.</p>
+ *
+ * <p>Because the sentinel lives in the production enum (pragmatic — avoids
+ * a String-escape-hatch on {@code AuditEventRecord.action}), a developer
+ * could paste {@code AuditEventType.TEST_PROBE} into a production code path
+ * and ship it. This rule makes that compile-time-invisible path
+ * test-time-visible: any production reference fails ArchUnit and blocks
+ * the build.</p>
+ *
+ * <h2>Scope</h2>
+ *
+ * <p>All classes under {@code backend/src/main/java/} (ArchUnit's main
+ * classpath import). Test-side references ({@code backend/src/test/java/})
+ * are the intended use and are outside this rule's scope — we import main
+ * classes only.</p>
+ *
+ * <p>The {@code AuditEventType} enum itself is exempt (it declares the case).</p>
+ */
+@DisplayName("ArchUnit Family G-0 — TEST_PROBE sentinel guardrail")
+class FamilyG0ArchitectureTest {
+
+    @Test
+    @DisplayName("Production code must not reference AuditEventType.TEST_PROBE")
+    void productionCodeMustNotReferenceTestProbe() {
+        ArchRule rule = noClasses()
+                .should(referenceTestProbe())
+                .allowEmptyShould(false)
+                .as("Family G-0: no production reference to AuditEventType.TEST_PROBE")
+                .because("TEST_PROBE is a test-only sentinel. See AuditEventType.TEST_PROBE Javadoc. "
+                        + "A production reference would pollute audit-trail semantics + "
+                        + "Prometheus counter tags, and operators filter 'action != TEST_PROBE' "
+                        + "in dashboards on the assumption this case never appears in prod.");
+
+        // Import main classes only — excludes test sources where TEST_PROBE is
+        // intentionally referenced.
+        rule.check(new ClassFileImporter()
+                .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+                .importPackages("org.fabt"));
+    }
+
+    /**
+     * Fires a violation for every class (other than {@link AuditEventType}
+     * itself) that reads the {@link AuditEventType#TEST_PROBE} enum constant.
+     * Enum-constant access compiles to a GETSTATIC on the declaring class's
+     * synthetic field, which ArchUnit surfaces as a field access.
+     */
+    private static ArchCondition<JavaClass> referenceTestProbe() {
+        String enumClassName = AuditEventType.class.getName();
+        String sentinelFieldName = AuditEventType.TEST_PROBE.name();
+
+        return new ArchCondition<>("reference AuditEventType." + sentinelFieldName) {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                // Self-reference exemption: the enum declaration itself has
+                // a synthetic accessor for every case.
+                if (javaClass.getName().equals(enumClassName)) {
+                    return;
+                }
+
+                javaClass.getFieldAccessesFromSelf().forEach(access -> {
+                    if (access.getTarget().getOwner().getName().equals(enumClassName)
+                            && access.getTarget().getName().equals(sentinelFieldName)) {
+                        events.add(SimpleConditionEvent.violated(
+                                javaClass,
+                                String.format("%s references AuditEventType.%s at %s — "
+                                        + "TEST_PROBE is test-only; use a real business case",
+                                        javaClass.getName(),
+                                        sentinelFieldName,
+                                        access.getSourceCodeLocation())));
+                    }
+                });
+            }
+        };
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/audit/AuditChainHasherIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/audit/AuditChainHasherIntegrationTest.java
@@ -72,12 +72,18 @@ class AuditChainHasherIntegrationTest extends BaseIntegrationTest {
             }
         });
 
-        // Read the 3 rows back, ordered by timestamp.
+        // Read the 3 rows back, ordered by publish sequence. NOT timestamp
+        // alone — after AuditEventEntity's microsecond truncation, two events
+        // fired inside the same microsecond (possible on a fast JVM) share
+        // the same timestamp value and the DB's tie-break order is
+        // undefined, producing flaky chain assertions. The details->>'seq'
+        // marker is deterministic by publish order (Alex + Riley warroom
+        // lens on G-1 PR #154).
         List<byte[][]> hashes = WithTenantContext.readAs(tenantId, () ->
                 jdbc.query(
                         "SELECT prev_hash, row_hash FROM audit_events "
                         + "WHERE tenant_id = ? AND details ->> 'probe_token' = ? "
-                        + "ORDER BY timestamp",
+                        + "ORDER BY (details ->> 'seq')::int",
                         (rs, n) -> new byte[][]{ rs.getBytes(1), rs.getBytes(2) },
                         tenantId, probeToken));
 

--- a/backend/src/test/java/org/fabt/shared/audit/AuditChainHasherIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/audit/AuditChainHasherIntegrationTest.java
@@ -1,0 +1,256 @@
+package org.fabt.shared.audit;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.shared.web.TenantContext;
+import org.fabt.testsupport.WithTenantContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Slice G-1 — integration tests for the per-tenant audit hash chain.
+ *
+ * <h2>T1 — chain progression</h2>
+ * Three audit events for the same tenant; assert each row's
+ * {@code prev_hash} equals the previous row's {@code row_hash}, and
+ * {@code tenant_audit_chain_head.last_hash} matches the last row's
+ * {@code row_hash}.
+ *
+ * <h2>T2 — genesis hash is the zero sentinel</h2>
+ * First audit row for a freshly-seeded tenant picks up the 32-byte zero
+ * value from {@code tenant_audit_chain_head.last_hash} (seeded by V80 /
+ * {@code TenantLifecycleService.create}). Assert the row's
+ * {@code prev_hash} is exactly 32 zero bytes and {@code row_hash} matches
+ * {@code SHA-256(zeros || canonical_json(row))}.
+ *
+ * <h2>T3 — SYSTEM_TENANT_ID orphan path skipped</h2>
+ * Publish an event outside any TenantContext so it falls back to
+ * SYSTEM_TENANT_ID. Assert the persisted row has {@code prev_hash = NULL}
+ * and {@code row_hash = NULL}. Orphans are not chained.
+ *
+ * <h2>T4 — canonical_json byte-for-byte reproducibility</h2>
+ * Build two equal entities, assert their canonical JSON is byte-identical.
+ * Verifier (Slice G-2) relies on this invariant to re-compute historical
+ * hashes.
+ */
+class AuditChainHasherIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private AuditChainHasher chainHasher;
+
+    private static final byte[] ZERO_SENTINEL = new byte[32]; // all zeros
+
+    @Test
+    @DisplayName("T1 — chain progression: each row's prev_hash == previous row's row_hash")
+    void t1_chainProgression() {
+        UUID tenantId = seedTenantAndChainHead();
+        UUID actor = UUID.randomUUID();
+
+        String probeToken = "G1_CHAIN_" + UUID.randomUUID();
+
+        // Publish 3 audit events in order under the tenant's context.
+        TenantContext.runWithContext(tenantId, false, () -> {
+            for (int i = 1; i <= 3; i++) {
+                eventPublisher.publishEvent(new AuditEventRecord(
+                        actor, null, AuditEventType.TEST_PROBE,
+                        Map.of("probe_token", probeToken, "seq", i),
+                        null));
+            }
+        });
+
+        // Read the 3 rows back, ordered by timestamp.
+        List<byte[][]> hashes = WithTenantContext.readAs(tenantId, () ->
+                jdbc.query(
+                        "SELECT prev_hash, row_hash FROM audit_events "
+                        + "WHERE tenant_id = ? AND details ->> 'probe_token' = ? "
+                        + "ORDER BY timestamp",
+                        (rs, n) -> new byte[][]{ rs.getBytes(1), rs.getBytes(2) },
+                        tenantId, probeToken));
+
+        assertThat(hashes)
+                .as("Expected 3 chained audit rows for tenant")
+                .hasSize(3);
+
+        // Row 0: prev_hash = zeros (genesis), row_hash = non-null
+        assertThat(hashes.get(0)[0])
+                .as("Genesis row's prev_hash must be 32-byte zero sentinel")
+                .isEqualTo(ZERO_SENTINEL);
+        assertThat(hashes.get(0)[1]).as("row_hash must be 32 bytes").hasSize(32);
+
+        // Row 1: prev_hash = row 0's row_hash
+        assertThat(hashes.get(1)[0])
+                .as("Row 1's prev_hash must equal row 0's row_hash (chain link)")
+                .isEqualTo(hashes.get(0)[1]);
+
+        // Row 2: prev_hash = row 1's row_hash
+        assertThat(hashes.get(2)[0])
+                .as("Row 2's prev_hash must equal row 1's row_hash (chain link)")
+                .isEqualTo(hashes.get(1)[1]);
+
+        // Chain head must point at row 2's row_hash
+        byte[] chainHead = jdbc.queryForObject(
+                "SELECT last_hash FROM tenant_audit_chain_head WHERE tenant_id = ?",
+                byte[].class, tenantId);
+        assertThat(chainHead)
+                .as("tenant_audit_chain_head.last_hash must point at the most recent row_hash")
+                .isEqualTo(hashes.get(2)[1]);
+    }
+
+    @Test
+    @DisplayName("T2 — genesis row has zero-sentinel prev_hash and a 32-byte row_hash")
+    void t2_genesisHashStructuralProperties() throws Exception {
+        UUID tenantId = seedTenantAndChainHead();
+        UUID actor = UUID.randomUUID();
+        String probeToken = "G1_GENESIS_" + UUID.randomUUID();
+
+        TenantContext.runWithContext(tenantId, false, () -> {
+            eventPublisher.publishEvent(new AuditEventRecord(
+                    actor, null, AuditEventType.TEST_PROBE,
+                    Map.of("probe_token", probeToken),
+                    null));
+        });
+
+        Map<String, Object> row = WithTenantContext.readAs(tenantId, () ->
+                jdbc.queryForMap(
+                        "SELECT prev_hash, row_hash FROM audit_events "
+                        + "WHERE tenant_id = ? AND details ->> 'probe_token' = ?",
+                        tenantId, probeToken));
+
+        byte[] prevHash = (byte[]) row.get("prev_hash");
+        byte[] rowHash = (byte[]) row.get("row_hash");
+
+        assertThat(prevHash)
+                .as("Genesis prev_hash must be 32-byte zero sentinel (V80 seed value)")
+                .isEqualTo(ZERO_SENTINEL);
+        assertThat(rowHash)
+                .as("Genesis row_hash must be 32 bytes (SHA-256 digest)")
+                .isNotNull()
+                .hasSize(32);
+        assertThat(rowHash)
+                .as("Genesis row_hash must differ from the zero sentinel — hashing a "
+                    + "non-empty canonical_json with any input yields a non-zero digest "
+                    + "with overwhelming probability")
+                .isNotEqualTo(ZERO_SENTINEL);
+
+        // NOTE on full hash re-computation: asserting `row_hash == SHA-256(zeros || canonical_json(row))`
+        // requires a canonicalizer that matches the form stored in the DB. At write time the
+        // hasher consumes Jackson's JSON output for `details`; at verify time the DB returns
+        // PG's JSONB canonical form (`::text`) which has different whitespace + sorted keys.
+        // Bridging that gap is G-2's canonicalizer — tracked as §8.6 in
+        // multi-tenant-production-readiness/tasks.md. For G-1 we verify structural
+        // properties only; full round-trip verification lands with the verifier.
+    }
+
+    @Test
+    @DisplayName("T3 — SYSTEM_TENANT_ID orphan audit skips hashing (NULL prev_hash + row_hash)")
+    void t3_systemTenantOrphanSkipsHashing() {
+        String probeToken = "G1_ORPHAN_" + UUID.randomUUID();
+
+        // Publish outside any TenantContext — falls back to SYSTEM_TENANT_ID.
+        eventPublisher.publishEvent(new AuditEventRecord(
+                UUID.randomUUID(), null, AuditEventType.TEST_PROBE,
+                Map.of("probe_token", probeToken),
+                null));
+
+        // Read under SYSTEM context (FORCE RLS on audit_events).
+        Map<String, Object> row = WithTenantContext.readAsSystem(() ->
+                jdbc.queryForMap(
+                        "SELECT prev_hash, row_hash, tenant_id FROM audit_events "
+                        + "WHERE tenant_id = ?::uuid AND details ->> 'probe_token' = ?",
+                        TenantContext.SYSTEM_TENANT_ID, probeToken));
+
+        assertThat(row.get("prev_hash"))
+                .as("Orphan audit under SYSTEM_TENANT_ID must have NULL prev_hash "
+                    + "(no chain head exists for the sentinel — by design)")
+                .isNull();
+        assertThat(row.get("row_hash"))
+                .as("Orphan audit under SYSTEM_TENANT_ID must have NULL row_hash")
+                .isNull();
+    }
+
+    @Test
+    @DisplayName("T4 — canonicalJson is byte-identical for equal entities (verifier stability)")
+    void t4_canonicalJsonStableForEqualEntities() {
+        AuditEventEntity a = sampleEntity();
+        AuditEventEntity b = sampleEntity();
+
+        String canonicalA = chainHasher.canonicalJson(a);
+        String canonicalB = chainHasher.canonicalJson(b);
+
+        assertThat(canonicalA)
+                .as("canonical_json must be byte-identical for equal logical entities — "
+                    + "Phase G-2 verifier re-hashes rows read from the DB and compares to "
+                    + "stored row_hash. Any non-determinism breaks verification.")
+                .isEqualTo(canonicalB);
+
+        // Pin the structural shape so a future change to the serialiser
+        // (field order, escaping, null rendering) fails here instead of
+        // silently breaking the G-2 verifier on shipped rows.
+        assertThat(canonicalA)
+                .as("canonical_json structural shape is load-bearing — see AuditChainHasher "
+                    + "javadoc on STABILITY CONTRACT")
+                .startsWith("{\"tenant_id\":")
+                .contains("\"timestamp\":")
+                .contains("\"actor_user_id\":")
+                .contains("\"target_user_id\":")
+                .contains("\"action\":\"TEST_PROBE\"")
+                .contains("\"details\":")
+                .contains("\"ip_address\":")
+                .endsWith("}");
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────
+
+    /**
+     * Creates a tenant row directly via SQL (bypassing TenantLifecycleService
+     * so this test suite doesn't depend on the full lifecycle bootstrap) and
+     * inserts a tenant_audit_chain_head seed row with the 32-zero sentinel
+     * (matching what V80 backfill + TenantLifecycleService.create do).
+     */
+    private UUID seedTenantAndChainHead() {
+        UUID tenantId = UUID.randomUUID();
+        String slug = "g1-chain-" + tenantId.toString().substring(0, 8);
+        WithTenantContext.readAsSystem(() -> {
+            jdbc.update(
+                    "INSERT INTO tenant (id, slug, name, state, "
+                    + "jwt_key_generation, data_residency_region) "
+                    + "VALUES (?, ?, ?, 'ACTIVE', 1, 'us-any')",
+                    tenantId, slug, "G-1 chain test");
+            jdbc.update(
+                    "INSERT INTO tenant_audit_chain_head (tenant_id, last_hash, last_row_id) "
+                    + "VALUES (?, decode('"
+                    + "0000000000000000000000000000000000000000000000000000000000000000"
+                    + "', 'hex'), NULL)",
+                    tenantId);
+            return null;
+        });
+        return tenantId;
+    }
+
+    private static AuditEventEntity sampleEntity() {
+        AuditEventEntity e = new AuditEventEntity();
+        e.setTenantId(UUID.fromString("11111111-1111-1111-1111-111111111111"));
+        e.setTimestamp(java.time.Instant.parse("2026-04-24T20:00:00Z"));
+        e.setActorUserId(UUID.fromString("22222222-2222-2222-2222-222222222222"));
+        e.setTargetUserId(null);
+        e.setAction(AuditEventType.TEST_PROBE.name());
+        e.setDetails(new org.fabt.shared.config.JsonString("{\"k\":\"v\"}"));
+        e.setIpAddress("10.0.0.1");
+        return e;
+    }
+
+}

--- a/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleCreateIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/service/TenantLifecycleCreateIntegrationTest.java
@@ -73,10 +73,20 @@ class TenantLifecycleCreateIntegrationTest extends BaseIntegrationTest {
         byte[] hash = jdbc.queryForObject(
             "SELECT last_hash FROM tenant_audit_chain_head WHERE tenant_id = ?",
             byte[].class, tenantId);
+        // Post-Slice G-1: chain head is seeded with 32 zero bytes (step 8 of
+        // create()), then immediately advanced when the TENANT_CREATED audit
+        // row (step 9) is hashed by AuditChainHasher. So the observed hash
+        // after create() returns is the SHA-256 of the genesis row, NOT the
+        // original zero sentinel. The zero-sentinel seed behavior is
+        // verified separately in AuditChainHasherIntegrationTest.
         assertThat(hash)
-            .as("chain head seeded with 32 zero bytes (chain-start sentinel)")
-            .hasSize(32)
-            .containsOnly((byte) 0);
+            .as("chain head exists and is 32 bytes — advanced by the TENANT_CREATED "
+                + "audit event written in the same tx as create()")
+            .hasSize(32);
+        assertThat(hash)
+            .as("chain head must have been advanced from the zero sentinel — the "
+                + "TENANT_CREATED audit row hashed into it")
+            .isNotEqualTo(new byte[32]);
 
         // TENANT_CREATED audit row — query under tenant context so RLS admits it
         List<String> actions = queryAuditActionsForTenant(tenantId, actor);


### PR DESCRIPTION
## Summary

Phase G slice G-1 (`multi-tenant-production-readiness` §8.1 + §8.4). Each `audit_events` INSERT becomes a link in a per-tenant SHA-256 hash chain, computed in the same tx as the row INSERT. Unlocks Slice G-2 (verifier) and G-3 (OCI Object Storage external anchor).

## Scope

### Migration
- **V85** — `audit_events ADD prev_hash BYTEA, ADD row_hash BYTEA`. Both nullable (pre-V85 rows + SYSTEM_TENANT_ID orphans stay NULL). 32-byte length CHECK when non-null.
- **No V86 needed** — `tenant_audit_chain_head` already created + seeded by V80 (Phase F-4), with `TenantLifecycleService.create()` seeding per-tenant rows on tenant creation.

### New service — `AuditChainHasher`
- `computeHashes(tenantId, entity)` reads the tenant's current `last_hash` with `SELECT ... FOR UPDATE` (serialises concurrent writers per tenant), returns `HashedRow(prev_hash, row_hash)` where `row_hash = SHA-256(prev_hash || canonical_json(row))`.
- `advanceChainHead(tenantId, auditRowId, hashed)` UPDATEs `tenant_audit_chain_head` atomically with the INSERT — commit / rollback together.
- `canonicalJson(entity)` — fixed-order JSON form of the row, `public` so the G-2 verifier can reuse the identical serialiser (single source of truth for the canonical form).
- **SYSTEM_TENANT_ID short-circuit** — orphan audits under the sentinel have no chain head row (by design, sentinel is not a real tenant). Hasher skips, `prev_hash` + `row_hash` stay NULL. Phase B D55 already treats these as WARN-signal orphans.
- Defensive `fabt.audit.chain_missing_head.count` + `fabt.audit.chain_advance_failed.count` counters on failure paths — operators alert on non-zero rate.

### Wiring
Both `AuditEventPersister` (REQUIRED) and `DetachedAuditPersister` (REQUIRES_NEW) call `computeHashes` before `repository.save` and `advanceChainHead` after. Atomic within each tx.

### Warroom-deferred follow-ups from Slice G-0 (closed in this PR)
- **§8.0.15** — `FamilyG0ArchitectureTest` ArchUnit rule: production packages may not reference `AuditEventType.TEST_PROBE`. Sentinel leak into prod now blocks the build.
- **§8.0.16** — `AuditEventRecord` compact constructor: rejects `null` action via `Objects.requireNonNull`. Null-action rows would be forensically meaningless when hashed.

### Timestamp precision fix (load-bearing for G-2)
`AuditEventEntity` constructor now truncates `Instant.now()` to microseconds (`ChronoUnit.MICROS`) to match PostgreSQL TIMESTAMPTZ precision. Without truncation, a DB round-trip drops nanoseconds and the G-2 verifier would compute a different hash than the writer.

## G-2 follow-up surfaced during G-1 (tracked in tasks.md §8.6a)

PostgreSQL JSONB `::text` canonical form (sorted keys + `": "` whitespace) differs from Jackson's insertion-order output at write time. G-1's chain links prove **ordering + field integrity for all non-details columns**; full details-payload tamper detection requires the canonicalizer that ships with G-2. Captured explicitly as §8.6a so it doesn't get missed.

## New tests (5)

- **`AuditChainHasherIntegrationTest`** — 4 ITs
  - T1 chain progression: 3 events, each row's `prev_hash == previous row's row_hash`; chain head points at the most recent row
  - T2 genesis structural properties: zero-sentinel `prev_hash`, 32-byte non-zero `row_hash`
  - T3 `SYSTEM_TENANT_ID` orphan skips hashing (NULL on both columns)
  - T4 `canonicalJson` byte-identical for equal entities (writer/verifier stability)
- **`FamilyG0ArchitectureTest`** — 1 ArchUnit test (TEST_PROBE guardrail)
- **`TenantLifecycleCreateIntegrationTest`** updated: post-G-1, the chain head is advanced by the `TENANT_CREATED` audit row in the same tx as `create()`, so the assertion flipped from "zero sentinel" to "non-zero 32 bytes."

## Test plan

- [x] `mvn -o verify` — full regression, **1120/1120 green**
- [x] `AuditChainHasherIntegrationTest` — 4/4 green
- [x] `FamilyG0ArchitectureTest` — 1/1 green
- [x] Manual: confirmed no production code references `AuditEventType.TEST_PROBE` (ArchUnit rule enforces)
- [x] Legal-language-scan clean

## Unblocks

- Slice G-2 (daily scheduled verifier + Prometheus drift alert) — needs canonicalizer (§8.6a)
- Slice G-3 (OCI Object Storage weekly anchor) — independent of G-2

🤖 Generated with [Claude Code](https://claude.com/claude-code)