### PR TITLE
Slice G-2: audit chain canonicalizer + daily verifier (Spring Batch)

### DIFF
--- a/backend/src/main/java/org/fabt/observability/batch/AuditChainVerifierJobConfig.java
+++ b/backend/src/main/java/org/fabt/observability/batch/AuditChainVerifierJobConfig.java
@@ -36,6 +36,8 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.event.EventListener;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.support.TransactionTemplate;
 
 /**
  * Phase G slice G-2 — Spring Batch job that re-verifies every tenant's audit
@@ -127,17 +129,20 @@ public class AuditChainVerifierJobConfig {
     private final AuditChainHasher chainHasher;
     private final BatchJobScheduler batchJobScheduler;
     private final MeterRegistry meterRegistry;
+    private final TransactionTemplate perTenantTx;
 
     public AuditChainVerifierJobConfig(JobRepository jobRepository,
                                        JdbcTemplate jdbc,
                                        AuditChainHasher chainHasher,
                                        BatchJobScheduler batchJobScheduler,
-                                       ObjectProvider<MeterRegistry> meterRegistryProvider) {
+                                       ObjectProvider<MeterRegistry> meterRegistryProvider,
+                                       PlatformTransactionManager transactionManager) {
         this.jobRepository = jobRepository;
         this.jdbc = jdbc;
         this.chainHasher = chainHasher;
         this.batchJobScheduler = batchJobScheduler;
         this.meterRegistry = meterRegistryProvider.getIfAvailable();
+        this.perTenantTx = new TransactionTemplate(transactionManager);
     }
 
     @Bean
@@ -176,8 +181,16 @@ public class AuditChainVerifierJobConfig {
 
             for (UUID tenantId : tenantIds) {
                 try {
+                    // Run per-tenant verification inside a TransactionTemplate
+                    // so set_config(app.tenant_id, ?, is_local=true) persists
+                    // across every SELECT within the same connection/tx.
+                    // Without this wrapper, each JdbcTemplate call auto-commits
+                    // and loses the GUC binding, leaving Phase B FORCE RLS on
+                    // audit_events to return zero rows. TenantContext binds
+                    // OUTSIDE the tx boundary per the B11 ordering rule
+                    // (feedback_transactional_rls_scoped_value_ordering).
                     VerifyResult result = TenantContext.callWithContext(tenantId, false, () ->
-                            verifyTenantChain(tenantId));
+                            perTenantTx.execute(status -> verifyTenantChain(tenantId)));
                     tenantsVerified++;
                     totalRows += result.rowsVerified();
                     totalDrift += result.driftCount();
@@ -249,6 +262,16 @@ public class AuditChainVerifierJobConfig {
      * gives O(1) memory per batch regardless of total per-tenant row count.
      */
     private VerifyResult verifyTenantChain(UUID tenantId) {
+        // Explicit set_config('app.tenant_id', ...) matching the pattern
+        // AuditEventPersister uses: Phase B FORCE RLS on audit_events requires
+        // this GUC to be bound on the connection. TenantContext.callWithContext
+        // binds the ScopedValue, but RlsAwareDataSource's automatic GUC binding
+        // fires reliably only at new-connection-acquisition, not on pooled
+        // reuse inside a non-transactional JdbcTemplate chain. Explicit
+        // set_config is belt-and-braces + matches the writer path.
+        jdbc.queryForObject("SELECT set_config('app.tenant_id', ?, true)",
+                String.class, tenantId.toString());
+
         int drift = 0;
         int totalRows = 0;
         byte[] previousRowHash = null;

--- a/backend/src/main/java/org/fabt/observability/batch/AuditChainVerifierJobConfig.java
+++ b/backend/src/main/java/org/fabt/observability/batch/AuditChainVerifierJobConfig.java
@@ -1,0 +1,397 @@
+package org.fabt.observability.batch;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.fabt.analytics.config.BatchJobScheduler;
+import org.fabt.shared.audit.AuditChainHasher;
+import org.fabt.shared.audit.AuditEventEntity;
+import org.fabt.shared.config.JsonString;
+import org.fabt.shared.security.TenantUnscoped;
+import org.fabt.shared.web.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.batch.infrastructure.support.transaction.ResourcelessTransactionManager;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Phase G slice G-2 — Spring Batch job that re-verifies every tenant's audit
+ * hash chain daily ({@code multi-tenant-production-readiness} §8.6, §8.15).
+ *
+ * <p><b>Package home.</b> Lives in {@code org.fabt.observability.batch} rather
+ * than {@code shared.audit.batch} so the dependency on
+ * {@link BatchJobScheduler} (an {@code analytics.*} class) doesn't violate
+ * the shared-kernel-no-domain-deps ArchUnit rule. The verifier is
+ * conceptually an observability concern — it monitors audit-trail integrity
+ * rather than being part of the audit domain itself.
+ *
+ * <h2>What it does</h2>
+ *
+ * <p>For each tenant listed in {@code tenant_audit_chain_head}, the tasklet:
+ *
+ * <ol>
+ *   <li>Binds {@link TenantContext} to the tenant (needed for Phase B FORCE RLS on
+ *       {@code audit_events})</li>
+ *   <li>Walks every row with a non-null {@code row_hash} in publish order
+ *       via a cursor-style keyset pagination ({@code (timestamp, id) > (?, ?)})
+ *       with 1000-row batches — constant memory regardless of per-tenant row
+ *       count. Replaces a naive load-all-rows-in-memory approach that would
+ *       grow O(N) with the audit volume.</li>
+ *   <li>For each row, recomputes
+ *       {@code expected_hash = SHA-256(prev_hash_from_row || canonical_json(row))}
+ *       using the same {@link AuditChainHasher#canonicalJson} that the writer uses
+ *       — single source of truth for the canonical form (§8.6a)</li>
+ *   <li>Compares the computed hash to the stored {@code row_hash}. On mismatch,
+ *       increments {@code fabt.audit.chain_verify.drift.count{tenant_id}} and logs
+ *       the offending row id + timestamp.</li>
+ *   <li>Verifies chain continuity: row N+1's {@code prev_hash} must equal row N's
+ *       {@code row_hash}. Gap → same drift counter + log.</li>
+ *   <li>Verifies chain-head alignment: the last row's {@code row_hash} must equal
+ *       {@code tenant_audit_chain_head.last_hash}. Mismatch indicates an
+ *       {@code advanceChainHead} failure (G-1 path) or post-advance corruption.</li>
+ * </ol>
+ *
+ * <h2>What it doesn't do (yet)</h2>
+ *
+ * <ul>
+ *   <li>Does NOT page on drift — emits metric only. Prometheus rule
+ *       {@code AuditChainDrift} in {@code deploy/prometheus/phase-g-chain-verify.rules.yml}
+ *       handles alerting.</li>
+ *   <li>Does NOT verify hard-deleted tenants (no chain head row to iterate).
+ *       A future slice can cross-reference the {@code TENANT_HARD_DELETED}
+ *       tombstone's captured terminal hash against the orphaned rows.</li>
+ *   <li>Does NOT re-verify rows with NULL {@code row_hash} (pre-V85 historical
+ *       rows + {@code SYSTEM_TENANT_ID} orphans). By design — these were never
+ *       chained.</li>
+ * </ul>
+ *
+ * <h2>Scheduling</h2>
+ *
+ * <p>Registered with {@link BatchJobScheduler} on {@link ApplicationReadyEvent}
+ * with cron {@code 0 0 4 * * *} (04:00 UTC daily) and {@code dvAccess=false}
+ * (verifier operates on hash bytes + structural columns only; never reads the
+ * {@code details} payload's business content, so DV row-level access is not
+ * required).
+ *
+ * <p>On-demand runs available via the existing
+ * {@code POST /api/v1/batch/jobs/auditChainVerifier/run} endpoint
+ * ({@code BatchJobController}). Operators triggering the verifier during an
+ * incident get job-execution history recorded in the standard {@code
+ * BATCH_JOB_EXECUTION} tables.
+ */
+@Configuration
+public class AuditChainVerifierJobConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditChainVerifierJobConfig.class);
+
+    /** The canonical job name; matches the {@code /api/v1/batch/jobs/{name}/run} path. */
+    public static final String JOB_NAME = "auditChainVerifier";
+
+    /** 04:00 UTC daily — chosen to avoid business-hour I/O contention. */
+    private static final String DEFAULT_CRON = "0 0 4 * * *";
+
+    /**
+     * Per-tenant keyset pagination batch size. 1000 balances round-trip
+     * overhead (larger = fewer SELECTs) against memory footprint (smaller =
+     * lower peak heap per batch). At FABT's current scale every tenant fits
+     * in one batch; the pagination matters for future growth past ~10k
+     * audits per tenant.
+     */
+    static final int PAGE_SIZE = 1000;
+
+    private final JobRepository jobRepository;
+    private final JdbcTemplate jdbc;
+    private final AuditChainHasher chainHasher;
+    private final BatchJobScheduler batchJobScheduler;
+    private final MeterRegistry meterRegistry;
+
+    public AuditChainVerifierJobConfig(JobRepository jobRepository,
+                                       JdbcTemplate jdbc,
+                                       AuditChainHasher chainHasher,
+                                       BatchJobScheduler batchJobScheduler,
+                                       ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this.jobRepository = jobRepository;
+        this.jdbc = jdbc;
+        this.chainHasher = chainHasher;
+        this.batchJobScheduler = batchJobScheduler;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
+    }
+
+    @Bean
+    public Job auditChainVerifierJob() {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(verifyChainsStep())
+                .build();
+    }
+
+    @Bean
+    public Step verifyChainsStep() {
+        // ResourcelessTransactionManager: the tasklet opens its own per-tenant
+        // read tx via TenantContext.runWithContext. The outer step does not
+        // need to hold a DB tx; letting Spring Batch use a resourceless manager
+        // avoids joining an outer tx across tenants and keeps RLS binding
+        // clean.
+        return new StepBuilder("verifyChainsStep", jobRepository)
+                .tasklet(verifyChainsTasklet(), new ResourcelessTransactionManager())
+                .build();
+    }
+
+    @Bean
+    @TenantUnscoped("Spring Batch audit chain verifier — iterates every tenant's chain; per-tenant reads bind TenantContext internally")
+    public Tasklet verifyChainsTasklet() {
+        return (StepContribution contribution, ChunkContext chunkContext) -> {
+            Timer.Sample sample = meterRegistry == null ? null : Timer.start(meterRegistry);
+            Instant runStart = Instant.now();
+
+            List<UUID> tenantIds = jdbc.queryForList(
+                    "SELECT tenant_id FROM tenant_audit_chain_head ORDER BY tenant_id",
+                    UUID.class);
+
+            int tenantsVerified = 0;
+            int totalRows = 0;
+            int totalDrift = 0;
+
+            for (UUID tenantId : tenantIds) {
+                try {
+                    VerifyResult result = TenantContext.callWithContext(tenantId, false, () ->
+                            verifyTenantChain(tenantId));
+                    tenantsVerified++;
+                    totalRows += result.rowsVerified();
+                    totalDrift += result.driftCount();
+
+                    if (result.driftCount() > 0) {
+                        log.error("Audit chain drift detected for tenant={} — rowsVerified={}, drift={}",
+                                tenantId, result.rowsVerified(), result.driftCount());
+                        if (meterRegistry != null) {
+                            Counter.builder("fabt.audit.chain_verify.drift.count")
+                                    .tag("tenant_id", tenantId.toString())
+                                    .description("Audit rows whose stored row_hash disagrees with recomputed hash, by tenant")
+                                    .register(meterRegistry)
+                                    .increment(result.driftCount());
+                        }
+                    } else {
+                        log.info("Audit chain verified clean for tenant={} — rowsVerified={}",
+                                tenantId, result.rowsVerified());
+                    }
+                } catch (Exception e) {
+                    // A single tenant's verification failure should not block the rest.
+                    // Log loudly + continue.
+                    log.error("Audit chain verifier FAILED for tenant={}: {}",
+                            tenantId, e.getMessage(), e);
+                    if (meterRegistry != null) {
+                        Counter.builder("fabt.audit.chain_verify.error.count")
+                                .tag("tenant_id", tenantId.toString())
+                                .register(meterRegistry)
+                                .increment();
+                    }
+                }
+            }
+
+            String resultTag = totalDrift > 0 ? "drift_detected" : "pass";
+            if (meterRegistry != null) {
+                Counter.builder("fabt.audit.chain_verify.runs.count")
+                        .tag("result", resultTag)
+                        .description("Audit chain verifier runs, tagged by overall result")
+                        .register(meterRegistry)
+                        .increment();
+                Counter.builder("fabt.audit.chain_verify.rows_verified.count")
+                        .description("Total audit rows walked by the verifier across all tenants per run")
+                        .register(meterRegistry)
+                        .increment(totalRows);
+                if (sample != null) {
+                    sample.stop(Timer.builder("fabt.audit.chain_verify.duration.seconds")
+                            .description("Wall-clock duration of the audit chain verifier tasklet")
+                            .register(meterRegistry));
+                }
+            }
+
+            log.info("Audit chain verifier complete — tenants={}, rowsVerified={}, drift={}, started={}",
+                    tenantsVerified, totalRows, totalDrift, runStart);
+
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    /**
+     * Walk one tenant's audit chain via cursor-style keyset pagination and
+     * return the drift count.
+     *
+     * <p>Must be invoked with {@link TenantContext} bound to the tenant — the
+     * SELECT against {@code audit_events} relies on FORCE RLS binding
+     * {@code app.tenant_id} to admit rows for this tenant only.
+     *
+     * <p>Pagination invariant: rows are walked in {@code (timestamp, id)}
+     * order. Each batch's last row's {@code (timestamp, id)} becomes the
+     * cursor for the next batch via {@code (timestamp, id) > (?, ?)}. This
+     * gives O(1) memory per batch regardless of total per-tenant row count.
+     */
+    private VerifyResult verifyTenantChain(UUID tenantId) {
+        int drift = 0;
+        int totalRows = 0;
+        byte[] previousRowHash = null;
+        Instant cursorTimestamp = null;
+        UUID cursorId = null;
+
+        while (true) {
+            List<Map<String, Object>> batch = fetchBatch(tenantId, cursorTimestamp, cursorId);
+            if (batch.isEmpty()) break;
+
+            for (Map<String, Object> row : batch) {
+                UUID rowId = (UUID) row.get("id");
+                byte[] storedPrevHash = (byte[]) row.get("prev_hash");
+                byte[] storedRowHash = (byte[]) row.get("row_hash");
+
+                // Chain continuity: row N+1's prev_hash should equal row N's row_hash.
+                // Skip the check for the first hashed row we see across the whole
+                // walk — pre-V85 rows may precede, so there's no prior hash to
+                // compare against on the very first entry.
+                if (previousRowHash != null && !Arrays.equals(previousRowHash, storedPrevHash)) {
+                    log.error("Chain continuity gap at row={} tenant={}: previous row_hash did not match this row's prev_hash",
+                            rowId, tenantId);
+                    drift++;
+                }
+
+                // Re-hash the row and compare.
+                AuditEventEntity reconstructed = reconstructEntity(row);
+                String canonical = chainHasher.canonicalJson(reconstructed);
+                byte[] expected = sha256(concat(storedPrevHash,
+                        canonical.getBytes(java.nio.charset.StandardCharsets.UTF_8)));
+
+                if (!Arrays.equals(expected, storedRowHash)) {
+                    log.error("row_hash mismatch at row={} tenant={} — forensic evidence of tampering or hash-input drift",
+                            rowId, tenantId);
+                    drift++;
+                }
+
+                previousRowHash = storedRowHash;
+                // Update cursor to this row's (timestamp, id) for the next
+                // batch's keyset continuation.
+                cursorTimestamp = ((Timestamp) row.get("timestamp")).toInstant();
+                cursorId = rowId;
+            }
+
+            totalRows += batch.size();
+            // If the batch came back smaller than the page size, we've
+            // reached the tail — short-circuit rather than issuing a final
+            // empty query.
+            if (batch.size() < PAGE_SIZE) break;
+        }
+
+        // Chain-head alignment: tenant_audit_chain_head.last_hash should equal
+        // the most recent audit_events row's row_hash.
+        if (previousRowHash != null) {
+            byte[] chainHeadHash = jdbc.query(
+                    "SELECT last_hash FROM tenant_audit_chain_head WHERE tenant_id = ?",
+                    rs -> rs.next() ? rs.getBytes(1) : null,
+                    tenantId);
+            if (chainHeadHash != null && !Arrays.equals(chainHeadHash, previousRowHash)) {
+                log.error("Chain head mismatch for tenant={} — advanceChainHead failure or post-hoc tampering",
+                        tenantId);
+                drift++;
+            }
+        }
+
+        return new VerifyResult(totalRows, drift);
+    }
+
+    /**
+     * Fetch the next batch of audit rows for a tenant via keyset pagination.
+     * First call passes {@code cursorTimestamp = null} and {@code cursorId =
+     * null}, the query uses an unbounded {@code WHERE row_hash IS NOT NULL}
+     * clause. Subsequent calls pass the (timestamp, id) of the last row of
+     * the previous batch to continue from there.
+     */
+    private List<Map<String, Object>> fetchBatch(UUID tenantId, Instant cursorTimestamp, UUID cursorId) {
+        if (cursorTimestamp == null || cursorId == null) {
+            return jdbc.queryForList(
+                    "SELECT id, timestamp, tenant_id, actor_user_id, target_user_id, "
+                    + "action, details::text AS details, ip_address, prev_hash, row_hash "
+                    + "FROM audit_events "
+                    + "WHERE tenant_id = ? AND row_hash IS NOT NULL "
+                    + "ORDER BY timestamp, id "
+                    + "LIMIT " + PAGE_SIZE,
+                    tenantId);
+        }
+        // Keyset continuation: (timestamp, id) > (cursor_timestamp, cursor_id).
+        // PostgreSQL evaluates row constructors lexicographically, so this
+        // picks up at the row after the cursor. Index on (tenant_id,
+        // timestamp, id) would make this O(log n); even without, the planner
+        // applies the WHERE before the ORDER BY.
+        return jdbc.queryForList(
+                "SELECT id, timestamp, tenant_id, actor_user_id, target_user_id, "
+                + "action, details::text AS details, ip_address, prev_hash, row_hash "
+                + "FROM audit_events "
+                + "WHERE tenant_id = ? AND row_hash IS NOT NULL "
+                + "  AND (timestamp, id) > (?, ?) "
+                + "ORDER BY timestamp, id "
+                + "LIMIT " + PAGE_SIZE,
+                tenantId, Timestamp.from(cursorTimestamp), cursorId);
+    }
+
+    private static AuditEventEntity reconstructEntity(Map<String, Object> row) {
+        AuditEventEntity e = new AuditEventEntity();
+        e.setId((UUID) row.get("id"));
+        Timestamp ts = (Timestamp) row.get("timestamp");
+        if (ts != null) e.setTimestamp(ts.toInstant());
+        e.setTenantId((UUID) row.get("tenant_id"));
+        e.setActorUserId((UUID) row.get("actor_user_id"));
+        e.setTargetUserId((UUID) row.get("target_user_id"));
+        e.setAction((String) row.get("action"));
+        String detailsText = (String) row.get("details");
+        if (detailsText != null) e.setDetails(new JsonString(detailsText));
+        e.setIpAddress((String) row.get("ip_address"));
+        return e;
+    }
+
+    private static byte[] sha256(byte[] input) {
+        try {
+            return MessageDigest.getInstance("SHA-256").digest(input);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void registerWithScheduler() {
+        // dvAccess=false: verifier reads hash bytes + structural columns only,
+        // never the details payload's business content. DV row-level access
+        // is not required for chain verification.
+        batchJobScheduler.registerJob(JOB_NAME, auditChainVerifierJob(),
+                DEFAULT_CRON, false);
+    }
+
+    /**
+     * Per-tenant verification result returned by {@link #verifyTenantChain}.
+     */
+    public record VerifyResult(int rowsVerified, int driftCount) {}
+}

--- a/backend/src/main/java/org/fabt/shared/audit/AuditCanonicalJson.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditCanonicalJson.java
@@ -1,0 +1,96 @@
+package org.fabt.shared.audit;
+
+import tools.jackson.databind.MapperFeature;
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.SerializationFeature;
+import tools.jackson.databind.json.JsonMapper;
+
+/**
+ * Phase G slice G-2 — canonical JSON form for audit-chain hashing
+ * (multi-tenant-production-readiness §8.6a).
+ *
+ * <h2>Why this exists</h2>
+ *
+ * <p>The Phase G-1 chain writer ({@link AuditChainHasher}) computes
+ * {@code row_hash = SHA-256(prev_hash || canonical_json(row))} at audit
+ * INSERT time. The G-2 verifier ({@code AuditChainVerifierJobConfig}) must
+ * reproduce the identical hash over the row read back from the database.
+ *
+ * <p>The problem surfaced during G-1 testing:</p>
+ *
+ * <ul>
+ *   <li><b>Write path</b> — {@link AuditEventService} serialises the details
+ *       payload with Jackson using <em>insertion-order</em> keys and compact
+ *       (no-whitespace) output: {@code {"k":"v","other":1}}.</li>
+ *   <li><b>PostgreSQL JSONB storage</b> — the column is typed {@code JSONB},
+ *       which normalises on write: keys are stored <em>alphabetically
+ *       sorted</em>, and the {@code ::text} cast emits them with a
+ *       {@code ": "} separator: {@code {"k": "v", "other": 1}}.</li>
+ *   <li><b>Verify path</b> — the verifier reads {@code details::text} from
+ *       the DB and gets the JSONB-canonical form, which differs from the
+ *       Jackson output the writer hashed.</li>
+ * </ul>
+ *
+ * <p>This canonicaliser bridges the gap. It accepts EITHER form and produces
+ * a single stable representation: <b>alphabetically-sorted keys + compact
+ * whitespace</b>. Applied identically at writer AND verifier, both ends
+ * produce byte-identical input to SHA-256.
+ *
+ * <h2>Stability contract</h2>
+ *
+ * <p>Once the first audit row is hashed with this canonicaliser, the output
+ * form is permanent. A future change to field ordering, escape rules, or
+ * number rendering would invalidate every historical {@code row_hash} in the
+ * DB and every external anchor (Phase G-3). Any change requires recomputing
+ * hashes for every affected row AND re-signing the external anchor.
+ *
+ * <h2>Implementation</h2>
+ *
+ * <p>The canonical form is produced by a dedicated {@link JsonMapper}
+ * configured with {@link MapperFeature#SORT_PROPERTIES_ALPHABETICALLY} and
+ * {@link SerializationFeature#ORDER_MAP_ENTRIES_BY_KEYS}. JSON is parsed
+ * into an {@code Object} (nested {@code Map}/{@code List}/primitives), then
+ * re-serialised — whitespace is stripped by Jackson's default compact output
+ * and keys land in alphabetical order at every nesting level.
+ *
+ * <p>Stateless + thread-safe. The shared mapper instance has no per-call
+ * state.
+ */
+public final class AuditCanonicalJson {
+
+    /**
+     * Mapper configured for canonical output: sorted keys, compact (no
+     * pretty-print). Jackson's default compact serialisation produces
+     * exactly the {@code {"a":1,"b":2}} form we want — no additional
+     * feature flag needed for whitespace suppression.
+     */
+    private static final ObjectMapper CANONICAL_MAPPER = JsonMapper.builder()
+            .enable(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY)
+            .enable(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS)
+            .build();
+
+    private AuditCanonicalJson() {}
+
+    /**
+     * Transform an arbitrary JSON text into the canonical form: sorted keys
+     * + compact whitespace. Idempotent — canonicalising canonical input
+     * returns byte-identical output.
+     *
+     * @param jsonText any valid JSON text (Jackson-produced or PG-JSONB-cast
+     *                 or already-canonical). {@code null} input returns
+     *                 {@code null}.
+     * @return canonical JSON text, or {@code null} if input was {@code null}.
+     * @throws IllegalArgumentException if {@code jsonText} is not valid JSON
+     */
+    public static String canonicalize(String jsonText) {
+        if (jsonText == null) return null;
+        try {
+            Object parsed = CANONICAL_MAPPER.readValue(jsonText, Object.class);
+            return CANONICAL_MAPPER.writeValueAsString(parsed);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(
+                    "canonicalize received invalid JSON (len=" + jsonText.length()
+                    + "): " + e.getMessage(), e);
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/audit/AuditChainHasher.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditChainHasher.java
@@ -211,10 +211,12 @@ public class AuditChainHasher {
         if (entity.getDetails() == null || entity.getDetails().value() == null) {
             sb.append("null");
         } else {
-            // details.value() is already a canonical JSON string produced by
-            // ObjectMapper.writeValueAsString in the persister. Embed it
-            // verbatim (not escape-wrapped) — it's JSONB-valid by construction.
-            sb.append(entity.getDetails().value());
+            // Route details through the canonicaliser (G-2 §8.6a): writer gets
+            // Jackson-produced insertion-order JSON; verifier gets PG JSONB
+            // ::text (sorted keys + `": "` separator). AuditCanonicalJson
+            // re-serialises both into compact sorted form, so the hash input
+            // is byte-identical regardless of path.
+            sb.append(AuditCanonicalJson.canonicalize(entity.getDetails().value()));
         }
         sb.append(",\"ip_address\":").append(jsonStringOrNull(entity.getIpAddress()));
         sb.append('}');

--- a/backend/src/test/java/org/fabt/observability/batch/AuditChainVerifierIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/observability/batch/AuditChainVerifierIntegrationTest.java
@@ -1,0 +1,227 @@
+package org.fabt.observability.batch;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.fabt.BaseIntegrationTest;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventType;
+import org.fabt.shared.web.TenantContext;
+import org.fabt.testsupport.WithTenantContext;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.JobExecution;
+import org.springframework.batch.core.job.parameters.JobParameters;
+import org.springframework.batch.core.job.parameters.JobParametersBuilder;
+import org.springframework.batch.core.launch.JobLauncher;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Integration tests for the Phase G-2 audit chain verifier
+ * ({@code AuditChainVerifierJobConfig}).
+ *
+ * <h2>T1 — clean chain passes</h2>
+ * Seed a tenant, publish 3 audit events (all hashed by G-1), run the
+ * verifier job, assert {@code COMPLETED} status and zero drift-counter
+ * increment.
+ *
+ * <h2>T2 — tampered row detected (direct INSERT with wrong row_hash)</h2>
+ * Phase B V70 REVOKEd {@code UPDATE} + {@code DELETE} on {@code audit_events}
+ * from {@code fabt_app} — audit is append-only at the DB permission layer.
+ * To simulate direct-DB tampering (the attacker scenario the hash chain is
+ * designed to detect), the test INSERTs a row directly with a deliberately
+ * wrong {@code row_hash}. The verifier recomputes the expected hash from
+ * the row's content, sees the mismatch, increments the drift counter.
+ *
+ * <h2>T3 — chain-head mismatch detected (UPDATE on chain_head)</h2>
+ * Corrupts {@code tenant_audit_chain_head.last_hash} directly (V80 grants
+ * UPDATE on that table so the corruption SQL works under {@code fabt_app}
+ * without a REVOKE dance). The verifier's chain-head-alignment check catches it.
+ */
+class AuditChainVerifierIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired
+    private JobLauncher jobLauncher;
+
+    @Autowired
+    private Job auditChainVerifierJob;
+
+    @Autowired
+    private ApplicationEventPublisher eventPublisher;
+
+    @Autowired
+    private JdbcTemplate jdbc;
+
+    @Autowired
+    private MeterRegistry meterRegistry;
+
+    @Test
+    @DisplayName("T1 — clean chain: verifier COMPLETES with zero drift-counter increment")
+    void t1_cleanChainPassesVerification() throws Exception {
+        UUID tenantId = seedTenantAndChainHead("verify-clean-");
+        UUID actor = UUID.randomUUID();
+        String probeToken = "G2_V1_" + UUID.randomUUID();
+
+        TenantContext.runWithContext(tenantId, false, () -> {
+            for (int i = 1; i <= 3; i++) {
+                eventPublisher.publishEvent(new AuditEventRecord(
+                        actor, null, AuditEventType.TEST_PROBE,
+                        Map.of("probe_token", probeToken, "seq", i),
+                        null));
+            }
+        });
+
+        double driftBefore = driftCounterFor(tenantId);
+        JobExecution exec = runVerifier();
+
+        assertThat(exec.getStatus().toString())
+                .as("Verifier should complete cleanly when the chain is untampered")
+                .isEqualTo("COMPLETED");
+        assertThat(driftCounterFor(tenantId) - driftBefore)
+                .as("Clean chain must produce zero drift-counter increments")
+                .isEqualTo(0.0);
+    }
+
+    @Test
+    @DisplayName("T2 — tampered row detected: INSERT with wrong row_hash increments drift counter")
+    void t2_tamperedRowDetected() throws Exception {
+        UUID tenantId = seedTenantAndChainHead("verify-tamper-");
+        UUID actor = UUID.randomUUID();
+        String probeToken = "G2_V2_" + UUID.randomUUID();
+
+        // Write one properly-chained audit row first so the chain is
+        // non-empty when the tamper arrives.
+        TenantContext.runWithContext(tenantId, false, () -> {
+            eventPublisher.publishEvent(new AuditEventRecord(
+                    actor, null, AuditEventType.TEST_PROBE,
+                    Map.of("probe_token", probeToken, "seq", 1),
+                    null));
+        });
+
+        // Phase B V70 REVOKEs UPDATE on audit_events — we can't UPDATE existing rows
+        // under fabt_app. To simulate tamper, INSERT a new row with a deliberately
+        // wrong row_hash (valid 32 bytes so the CHECK constraint passes, but
+        // content won't match the recomputed hash). The verifier's row-hash
+        // recompute sees the mismatch and fires drift.
+        TenantContext.runWithContext(tenantId, false, () -> {
+            byte[] wrongRowHash = new byte[32];
+            for (int i = 0; i < 32; i++) wrongRowHash[i] = (byte) 0xAA;
+            byte[] arbitraryPrevHash = new byte[32]; // zeros; won't match real chain state
+
+            jdbc.update(
+                    "INSERT INTO audit_events "
+                    + "(id, timestamp, tenant_id, actor_user_id, target_user_id, "
+                    + " action, details, ip_address, prev_hash, row_hash) "
+                    + "VALUES (gen_random_uuid(), ?, ?, ?, NULL, ?, ?::jsonb, NULL, ?, ?)",
+                    Timestamp.from(Instant.now().plusSeconds(5)), // after the real row
+                    tenantId,
+                    actor,
+                    AuditEventType.TEST_PROBE.name(),
+                    "{\"probe_token\":\"" + probeToken + "\",\"tamper\":true}",
+                    arbitraryPrevHash,
+                    wrongRowHash);
+        });
+
+        double driftBefore = driftCounterFor(tenantId);
+        JobExecution exec = runVerifier();
+        assertThat(exec.getStatus().toString()).isEqualTo("COMPLETED");
+
+        double driftAfter = driftCounterFor(tenantId);
+        assertThat(driftAfter - driftBefore)
+                .as("Verifier MUST detect the fake-row-hash tamper and increment "
+                    + "fabt.audit.chain_verify.drift.count{tenant_id=%s}. Without this "
+                    + "assertion, the test only proves the verifier ran to completion — "
+                    + "not that it actually caught the tamper.", tenantId)
+                .isGreaterThanOrEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("T3 — chain-head mismatch detected: drift counter increments")
+    void t3_chainHeadMismatchDetected() throws Exception {
+        UUID tenantId = seedTenantAndChainHead("verify-head-");
+        UUID actor = UUID.randomUUID();
+        String probeToken = "G2_V3_" + UUID.randomUUID();
+
+        TenantContext.runWithContext(tenantId, false, () -> {
+            eventPublisher.publishEvent(new AuditEventRecord(
+                    actor, null, AuditEventType.TEST_PROBE,
+                    Map.of("probe_token", probeToken),
+                    null));
+        });
+
+        // Corrupt the chain head — set last_hash to a different 32-byte value.
+        // V80 grants UPDATE on tenant_audit_chain_head to fabt_app so this
+        // SQL works directly; the REVOKE on audit_events does not apply here.
+        byte[] wrongHash = new byte[32];
+        for (int i = 0; i < 32; i++) wrongHash[i] = (byte) 0xEE;
+        jdbc.update(
+                "UPDATE tenant_audit_chain_head SET last_hash = ? WHERE tenant_id = ?",
+                wrongHash, tenantId);
+
+        double driftBefore = driftCounterFor(tenantId);
+        JobExecution exec = runVerifier();
+        assertThat(exec.getStatus().toString())
+                .as("Verifier completes even when it detects drift — alerting is downstream")
+                .isEqualTo("COMPLETED");
+
+        double driftAfter = driftCounterFor(tenantId);
+        assertThat(driftAfter - driftBefore)
+                .as("Verifier MUST detect the chain-head corruption and increment the drift counter")
+                .isGreaterThanOrEqualTo(1.0);
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────
+
+    private JobExecution runVerifier() throws Exception {
+        JobParameters params = new JobParametersBuilder()
+                .addLong("runId", System.nanoTime())
+                .toJobParameters();
+        return jobLauncher.run(auditChainVerifierJob, params);
+    }
+
+    /**
+     * Reads the Micrometer drift counter value for a given tenant. Returns 0
+     * if the counter doesn't exist yet (first tamper for this tenant).
+     */
+    private double driftCounterFor(UUID tenantId) {
+        Counter counter = meterRegistry.find("fabt.audit.chain_verify.drift.count")
+                .tag("tenant_id", tenantId.toString())
+                .counter();
+        return counter == null ? 0.0 : counter.count();
+    }
+
+    /**
+     * Creates a tenant row directly via SQL (bypassing TenantLifecycleService
+     * so this test suite doesn't depend on the full lifecycle bootstrap) and
+     * inserts a tenant_audit_chain_head seed row with the 32-zero sentinel
+     * (matching what V80 backfill + TenantLifecycleService.create do).
+     */
+    private UUID seedTenantAndChainHead(String slugPrefix) {
+        UUID tenantId = UUID.randomUUID();
+        String slug = slugPrefix + tenantId.toString().substring(0, 8);
+        WithTenantContext.readAsSystem(() -> {
+            jdbc.update(
+                    "INSERT INTO tenant (id, slug, name, state, "
+                    + "jwt_key_generation, data_residency_region) "
+                    + "VALUES (?, ?, ?, 'ACTIVE', 1, 'us-any')",
+                    tenantId, slug, "G-2 verifier test");
+            jdbc.update(
+                    "INSERT INTO tenant_audit_chain_head (tenant_id, last_hash, last_row_id) "
+                    + "VALUES (?, decode('"
+                    + "0000000000000000000000000000000000000000000000000000000000000000"
+                    + "', 'hex'), NULL)",
+                    tenantId);
+            return null;
+        });
+        return tenantId;
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/audit/AuditCanonicalJsonTest.java
+++ b/backend/src/test/java/org/fabt/shared/audit/AuditCanonicalJsonTest.java
@@ -1,0 +1,120 @@
+package org.fabt.shared.audit;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Unit tests for {@link AuditCanonicalJson} — the canonical-form
+ * utility that bridges Jackson's insertion-order output and PostgreSQL
+ * JSONB's {@code ::text} output into a single hash-stable form.
+ *
+ * <p>See {@code AuditCanonicalJson} Javadoc for the stability contract.
+ * Every assertion here is load-bearing for Phase G audit-chain
+ * verification — a change that breaks any test would invalidate
+ * historical {@code row_hash} values and every external anchor.
+ */
+@DisplayName("AuditCanonicalJson — canonical form contract")
+class AuditCanonicalJsonTest {
+
+    @Test
+    @DisplayName("null input returns null")
+    void nullPassesThrough() {
+        assertThat(AuditCanonicalJson.canonicalize(null)).isNull();
+    }
+
+    @Test
+    @DisplayName("Jackson-style input is sorted + compacted")
+    void jacksonInsertionOrderIsSorted() {
+        // Jackson default: insertion order, compact.
+        String input = "{\"beta\":2,\"alpha\":1}";
+        assertThat(AuditCanonicalJson.canonicalize(input))
+                .isEqualTo("{\"alpha\":1,\"beta\":2}");
+    }
+
+    @Test
+    @DisplayName("PG JSONB ::text style (sorted + spaced) is compacted to canonical")
+    void pgJsonbFormIsNormalised() {
+        // PostgreSQL JSONB ::text: sorted keys + `": "` separator.
+        String input = "{\"alpha\": 1, \"beta\": 2}";
+        assertThat(AuditCanonicalJson.canonicalize(input))
+                .isEqualTo("{\"alpha\":1,\"beta\":2}");
+    }
+
+    @Test
+    @DisplayName("writer + verifier paths converge on identical canonical form")
+    void jacksonAndPgFormsProduceSameHashInput() {
+        // This is THE load-bearing invariant for G-2: the writer hashes
+        // canonicalize(jacksonOutput), the verifier hashes canonicalize(pgText).
+        // Both must produce byte-identical output.
+        String jacksonForm = "{\"zebra\":\"z\",\"alpha\":\"a\",\"mike\":\"m\"}";
+        String pgForm = "{\"alpha\": \"a\", \"mike\": \"m\", \"zebra\": \"z\"}";
+
+        assertThat(AuditCanonicalJson.canonicalize(jacksonForm))
+                .as("Jackson (insertion-order) and PG (sorted+spaced) forms must canonicalise identically")
+                .isEqualTo(AuditCanonicalJson.canonicalize(pgForm));
+    }
+
+    @Test
+    @DisplayName("nested objects: keys sorted at every level")
+    void nestedObjectsSortedRecursively() {
+        String input = "{\"b\":{\"y\":2,\"x\":1},\"a\":{\"n\":0,\"m\":-1}}";
+        String expected = "{\"a\":{\"m\":-1,\"n\":0},\"b\":{\"x\":1,\"y\":2}}";
+        assertThat(AuditCanonicalJson.canonicalize(input)).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("arrays preserve order (JSON arrays are ordered)")
+    void arraysPreserveOrder() {
+        String input = "{\"items\":[3,1,2]}";
+        assertThat(AuditCanonicalJson.canonicalize(input))
+                .isEqualTo("{\"items\":[3,1,2]}");
+    }
+
+    @Test
+    @DisplayName("JSON primitives round-trip")
+    void primitivesRoundTrip() {
+        assertThat(AuditCanonicalJson.canonicalize("\"hello\"")).isEqualTo("\"hello\"");
+        assertThat(AuditCanonicalJson.canonicalize("42")).isEqualTo("42");
+        assertThat(AuditCanonicalJson.canonicalize("true")).isEqualTo("true");
+        assertThat(AuditCanonicalJson.canonicalize("null")).isEqualTo("null");
+    }
+
+    @Test
+    @DisplayName("idempotent — canonicalising canonical output yields byte-identical result")
+    void idempotent() {
+        String input = "{\"z\":{\"b\":2,\"a\":1},\"m\":[3,1,2]}";
+        String once = AuditCanonicalJson.canonicalize(input);
+        String twice = AuditCanonicalJson.canonicalize(once);
+        assertThat(twice)
+                .as("canonicalize must be idempotent — writer re-hash and verifier re-hash must converge")
+                .isEqualTo(once);
+    }
+
+    @Test
+    @DisplayName("Unicode and JSON-escape characters preserved")
+    void unicodeAndEscapesPreserved() {
+        // Escapes: \n, \t, \", \\, Unicode BMP + supplementary.
+        String input = "{\"msg\":\"hello\\nworld\",\"quote\":\"say \\\"hi\\\"\"}";
+        String result = AuditCanonicalJson.canonicalize(input);
+        // Parse + reserialize should preserve the escape sequences.
+        assertThat(result).contains("\\n").contains("\\\"");
+    }
+
+    @Test
+    @DisplayName("invalid JSON throws IllegalArgumentException with context")
+    void invalidJsonThrowsWithContext() {
+        assertThatThrownBy(() -> AuditCanonicalJson.canonicalize("{not json"))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("invalid JSON");
+    }
+
+    @Test
+    @DisplayName("empty object and array pass through canonical form")
+    void emptyStructures() {
+        assertThat(AuditCanonicalJson.canonicalize("{}")).isEqualTo("{}");
+        assertThat(AuditCanonicalJson.canonicalize("[]")).isEqualTo("[]");
+    }
+}

--- a/backend/src/test/java/org/fabt/shared/audit/AuditChainHasherIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/audit/AuditChainHasherIntegrationTest.java
@@ -1,5 +1,7 @@
 package org.fabt.shared.audit;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -117,11 +119,11 @@ class AuditChainHasherIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("T2 — genesis row has zero-sentinel prev_hash and a 32-byte row_hash")
-    void t2_genesisHashStructuralProperties() throws Exception {
+    @DisplayName("T2 — genesis row_hash == SHA-256(zeros || canonical_json(row)) (full reconstruction)")
+    void t2_genesisHashFullReconstruction() throws Exception {
         UUID tenantId = seedTenantAndChainHead();
         UUID actor = UUID.randomUUID();
-        String probeToken = "G1_GENESIS_" + UUID.randomUUID();
+        String probeToken = "G2_GENESIS_" + UUID.randomUUID();
 
         TenantContext.runWithContext(tenantId, false, () -> {
             eventPublisher.publishEvent(new AuditEventRecord(
@@ -132,7 +134,9 @@ class AuditChainHasherIntegrationTest extends BaseIntegrationTest {
 
         Map<String, Object> row = WithTenantContext.readAs(tenantId, () ->
                 jdbc.queryForMap(
-                        "SELECT prev_hash, row_hash FROM audit_events "
+                        "SELECT id, timestamp, tenant_id, actor_user_id, target_user_id, "
+                        + "action, details::text AS details, ip_address, "
+                        + "prev_hash, row_hash FROM audit_events "
                         + "WHERE tenant_id = ? AND details ->> 'probe_token' = ?",
                         tenantId, probeToken));
 
@@ -146,19 +150,30 @@ class AuditChainHasherIntegrationTest extends BaseIntegrationTest {
                 .as("Genesis row_hash must be 32 bytes (SHA-256 digest)")
                 .isNotNull()
                 .hasSize(32);
-        assertThat(rowHash)
-                .as("Genesis row_hash must differ from the zero sentinel — hashing a "
-                    + "non-empty canonical_json with any input yields a non-zero digest "
-                    + "with overwhelming probability")
-                .isNotEqualTo(ZERO_SENTINEL);
 
-        // NOTE on full hash re-computation: asserting `row_hash == SHA-256(zeros || canonical_json(row))`
-        // requires a canonicalizer that matches the form stored in the DB. At write time the
-        // hasher consumes Jackson's JSON output for `details`; at verify time the DB returns
-        // PG's JSONB canonical form (`::text`) which has different whitespace + sorted keys.
-        // Bridging that gap is G-2's canonicalizer — tracked as §8.6 in
-        // multi-tenant-production-readiness/tasks.md. For G-1 we verify structural
-        // properties only; full round-trip verification lands with the verifier.
+        // G-2 full reconstruction: rebuild the entity from the stored DB row
+        // (details arrives as PG JSONB ::text form) and recompute SHA-256
+        // via the same canonicalJson path the writer used. The canonicaliser
+        // (§8.6a) normalises both forms so the hash input matches.
+        AuditEventEntity reconstructed = new AuditEventEntity();
+        reconstructed.setTenantId(tenantId);
+        reconstructed.setTimestamp(((java.sql.Timestamp) row.get("timestamp")).toInstant());
+        reconstructed.setActorUserId((UUID) row.get("actor_user_id"));
+        reconstructed.setTargetUserId((UUID) row.get("target_user_id"));
+        reconstructed.setAction((String) row.get("action"));
+        reconstructed.setDetails(new org.fabt.shared.config.JsonString((String) row.get("details")));
+        reconstructed.setIpAddress((String) row.get("ip_address"));
+
+        String canonical = chainHasher.canonicalJson(reconstructed);
+        byte[] canonicalBytes = canonical.getBytes(StandardCharsets.UTF_8);
+        byte[] expectedHash = MessageDigest.getInstance("SHA-256")
+                .digest(concat(ZERO_SENTINEL, canonicalBytes));
+
+        assertThat(rowHash)
+                .as("Genesis row_hash must equal SHA-256(zero-sentinel || canonical_json(row)). "
+                    + "If this fails, the canonicaliser form drifted between writer + re-computation "
+                    + "— the Phase G verifier would fail to validate historical rows.")
+                .isEqualTo(expectedHash);
     }
 
     @Test
@@ -245,6 +260,13 @@ class AuditChainHasherIntegrationTest extends BaseIntegrationTest {
             return null;
         });
         return tenantId;
+    }
+
+    private static byte[] concat(byte[] a, byte[] b) {
+        byte[] out = new byte[a.length + b.length];
+        System.arraycopy(a, 0, out, 0, a.length);
+        System.arraycopy(b, 0, out, a.length, b.length);
+        return out;
     }
 
     private static AuditEventEntity sampleEntity() {

--- a/deploy/prometheus/phase-g-chain-verify.rules.yml
+++ b/deploy/prometheus/phase-g-chain-verify.rules.yml
@@ -1,0 +1,133 @@
+# Prometheus alert rules — multi-tenant-production-readiness Phase G
+# slice G-2 (audit-chain verifier, tasks §8.6 + §8.15).
+#
+# Mount into a Prometheus instance that already scrapes the backend
+# actuator (`fabt-backend` job in prometheus.yml):
+#
+#     rule_files:
+#       - /etc/prometheus/rules/phase-g-chain-verify.rules.yml
+#
+# Every alert here is Phase G specific — the signals depend on Micrometer
+# counters emitted by AuditChainVerifierJobConfig's tasklet. Do NOT delete
+# without updating docs/security/phase-g-chain-verify-runbook.md
+# (forthcoming with G-6 docs slice).
+#
+# Prometheus exposes the Micrometer counters with dots converted to
+# underscores and a `_total` suffix:
+#   fabt.audit.chain_verify.drift.count{tenant_id="..."}
+#       -> fabt_audit_chain_verify_drift_count_total{tenant_id="..."}
+#   fabt.audit.chain_verify.runs.count{result="pass|drift_detected"}
+#       -> fabt_audit_chain_verify_runs_count_total{result="..."}
+#   fabt.audit.chain_verify.error.count{tenant_id="..."}
+#       -> fabt_audit_chain_verify_error_count_total{tenant_id="..."}
+#
+# Warroom authority: Phase G §8.6 + §8.15 — drift is a forensic signal
+# (tamper evidence or hash-input canonicalizer regression); any drift
+# warrants immediate page.
+
+groups:
+  - name: fabt_phase_g_chain_verify
+    interval: 30s
+    rules:
+
+      # ---- CRITICAL — audit chain drift detected -----------------------
+      # Fires whenever the verifier tasklet finds a row whose stored
+      # row_hash disagrees with the recomputed expected hash, OR the
+      # chain-continuity / chain-head-alignment invariants break for
+      # any tenant. Non-zero means one of:
+      #   (a) Tamper evidence — someone modified audit_events rows
+      #       directly (bypassing the application) and the chain
+      #       detected the drift
+      #   (b) Canonicalizer regression — a change to
+      #       AuditCanonicalJson.canonicalize or
+      #       AuditChainHasher.canonicalJson produced a different hash
+      #       input form than the writer used at ship time
+      #   (c) advanceChainHead failure in the writer path left a chain
+      #       gap (G-1 `fabt.audit.chain_advance_failed.count` counter
+      #       should also be non-zero in this case)
+      # All three warrant immediate forensic review.
+      - alert: FabtAuditChainDriftDetected
+        # env="prod" filter mirrors Phase C pattern — test harnesses
+        # (AuditChainVerifierIntegrationTest tamper tests) intentionally
+        # trigger drift on CI scrapes. Without this label, a Prometheus
+        # instance scraping both CI and prod would false-page.
+        expr: |
+          sum by (tenant_id) (
+            increase(fabt_audit_chain_verify_drift_count_total{env="prod"}[1h])
+          ) > 0
+        for: 0m
+        labels:
+          severity: critical
+          surface: phase-g-audit-chain
+          runbook: docs/security/phase-g-chain-verify-runbook.md
+        annotations:
+          summary: "Phase G: audit chain drift detected for tenant {{ $labels.tenant_id }}"
+          description: |
+            AuditChainVerifierJobConfig reported {{ $value | humanize }}
+            drift event(s) for tenant {{ $labels.tenant_id }} in the last
+            1h. Drift indicates one of (a) direct-SQL tampering with
+            audit_events, (b) canonicalizer regression, or (c) chain-head
+            advance failure in the writer path.
+
+            Triage:
+            1. Pull the last AuditChainVerifierJobConfig run's log —
+               includes the offending row id + timestamp.
+            2. Compare audit_events.row_hash against a fresh recompute
+               via AuditChainHasher.canonicalJson in a shell.
+            3. Check fabt.audit.chain_advance_failed.count for the same
+               tenant — if non-zero, suspect G-1 writer-path failure,
+               not tampering.
+            4. If canonicalizer regression is suspected, diff
+               AuditCanonicalJson.canonicalize output against the last
+               known-good release (git blame).
+            5. If tampering is suspected, engage Casey + Marcus per
+               the incident-response runbook (§8.15 triage tree).
+
+      # ---- WARN — verifier error for a specific tenant -----------------
+      # The verifier catches exceptions per-tenant so one bad tenant
+      # doesn't block the rest. A non-zero rate here means the verifier
+      # itself is failing to complete for that tenant (DB access error,
+      # RLS binding gap, etc.) — not the same thing as drift, but worth
+      # an investigation because it leaves that tenant's chain
+      # un-verified.
+      - alert: FabtAuditChainVerifierError
+        expr: |
+          sum by (tenant_id) (
+            increase(fabt_audit_chain_verify_error_count_total{env="prod"}[1h])
+          ) > 0
+        for: 15m
+        labels:
+          severity: warning
+          surface: phase-g-audit-chain
+          runbook: docs/security/phase-g-chain-verify-runbook.md
+        annotations:
+          summary: "Phase G: audit chain verifier errored out for tenant {{ $labels.tenant_id }}"
+          description: |
+            Verifier tasklet threw for tenant {{ $labels.tenant_id }} and
+            moved on without completing chain verification for that
+            tenant. That tenant's chain is currently UN-VERIFIED.
+
+            Triage: check the verifier's log for the per-tenant exception
+            message. Re-run on-demand via
+            `POST /api/v1/batch/jobs/auditChainVerifier/run` once the
+            underlying error is fixed.
+
+      # ---- WARN — verifier did not run in last 36 hours ----------------
+      # Defensive: cron is 0 0 4 * * * (daily at 04:00 UTC). If no run
+      # has happened in 36h, scheduler is wedged or the job is disabled
+      # — both leave the chain un-verified for an extended window.
+      - alert: FabtAuditChainVerifierStalled
+        expr: |
+          (time() - fabt_audit_chain_verify_runs_count_total_created{env="prod"}) > 129600
+        for: 1h
+        labels:
+          severity: warning
+          surface: phase-g-audit-chain
+          runbook: docs/security/phase-g-chain-verify-runbook.md
+        annotations:
+          summary: "Phase G: audit chain verifier has not run in over 36h"
+          description: |
+            No AuditChainVerifierJobConfig run has emitted runs_count in
+            over 36 hours. Expected cadence is daily at 04:00 UTC.
+            Check BatchJobScheduler state via GET /api/v1/batch/jobs;
+            verify cron is 0 0 4 * * * and enabled=true.


### PR DESCRIPTION
## Summary

Phase G slice G-2 (`multi-tenant-production-readiness` §8.6, §8.6a, §8.15). Closes the writer/verifier canonical-form gap surfaced during G-1 and ships the daily chain verifier.

## Scope

### Canonicalizer (§8.6a)
- **`AuditCanonicalJson`** — Jackson tree parse → sorted keys + compact output. Bridges Jackson insertion-order (writer) and PostgreSQL JSONB `::text` (verifier reading from DB) into a single stable form. Single source of truth, applied identically at both ends.
- **`AuditChainHasher.canonicalJson` retrofit** — `details` field now routed through `AuditCanonicalJson.canonicalize` before concatenation into the fixed-order record JSON. Hash input provably stable across Jackson/PG divergence.

### Verifier batch job
- **`AuditChainVerifierJobConfig`** — Spring Batch `@Configuration` in `org.fabt.observability.batch`. Daily cron `0 0 4 * * *`, `dvAccess=false`, registered via `BatchJobScheduler` on `ApplicationReadyEvent`.
  - **Cursor-style keyset pagination** — walks each tenant's audit rows in `(timestamp, id) > (?, ?)` batches of 1000. Constant memory regardless of per-tenant volume (per Corey's up-front directive, not deferred).
  - Per-row recompute: `SHA-256(prev_hash || canonical_json(row))` compared to stored `row_hash`.
  - Chain continuity check: row N+1's `prev_hash` must equal row N's `row_hash`.
  - Chain-head alignment check: last row's `row_hash` must equal `tenant_audit_chain_head.last_hash` (catches G-1's `advanceChainHead` 0-rows gap).
  - Emits `fabt.audit.chain_verify.drift.count{tenant_id}` on detection; completes cleanly regardless (alerting is downstream).
  - On-demand runs via existing `POST /api/v1/batch/jobs/auditChainVerifier/run`.

### Prometheus alerts
- **`deploy/prometheus/phase-g-chain-verify.rules.yml`** — three alerts:
  - `FabtAuditChainDriftDetected` — CRITICAL, fires on any drift in the last 1h (env=prod filter).
  - `FabtAuditChainVerifierError` — WARN, fires per-tenant if the verifier tasklet errored.
  - `FabtAuditChainVerifierStalled` — WARN, fires if no verifier run has completed in >36h.

### Tests (14 new)
- **`AuditCanonicalJsonTest`** — 10 unit tests: null pass-through, Jackson sorting, PG-form normalisation, writer/verifier convergence, nested recursion, arrays preserve order, primitives round-trip, idempotency, Unicode + escape chars, invalid-JSON fail-fast, empty structures.
- **`AuditChainHasherIntegrationTest.t2_genesisHashFullReconstruction`** — upgraded from G-1's structural-properties form. Full SHA-256 round-trip: DB read → canonical form via `AuditCanonicalJson` → recompute → match stored `row_hash`. Proves end-to-end hash stability.
- **`AuditChainVerifierIntegrationTest`** — 3 ITs with `MeterRegistry`-backed drift assertions:
  - T1 clean chain zero drift counter
  - T2 tampered row (direct INSERT with wrong row_hash) — drift ≥ 1
  - T3 chain-head corruption (UPDATE on `tenant_audit_chain_head`) — drift ≥ 1

## Warroom design choices captured during this slice

- **Spring Batch over `@Scheduled`** — initial plan was `@Scheduled`; user pushed back (precedent: `BedHoldsReconciliationJobConfig`, `referralEscalation`). Benefits: consistent operator observability via `BATCH_JOB_EXECUTION`, restart semantics, on-demand trigger endpoint already exists. Saved as `feedback_spring_batch_for_scheduled_work.md`.
- **`observability.batch` home, not `shared.audit.batch`** — ArchUnit rule forbids `shared.*` from depending on domain modules (including `analytics.BatchJobScheduler`).
- **Pagination up-front, not deferred** — per user directive. Keyset cursor, not offset.
- **T2 tamper simulation uses INSERT, not UPDATE** — Phase B V70 REVOKEs `UPDATE`/`DELETE` on `audit_events` from `fabt_app`. Saved as `feedback_audit_events_revoke_update.md`.
- **Verifier reads wrapped in `TransactionTemplate`** — plain `JdbcTemplate` auto-commits each statement, losing `set_config(app.tenant_id, ?, is_local=true)` binding. Phase B FORCE RLS then returns zero rows. `TenantContext.callWithContext(...) { txTemplate.execute(...) }` preserves the B11 ordering invariant while giving all per-tenant reads the same connection with the GUC bound.

## Test plan

- [x] `mvn -o verify` — **1134/1134 green**
- [x] Canonicalizer unit — 10/10 green
- [x] G-1 T2 upgraded to full SHA-256 reconstruction — green
- [x] Verifier IT T1 clean chain, T2 INSERT tamper, T3 chain-head corruption — all three green with drift counter assertions
- [x] `ArchitectureTest.shared_non_security_should_not_depend_on_modules` — green (verifier is in `observability.batch`, not `shared`)
- [x] Legal scan clean

## Unblocks

- Slice G-3 (OCI Object Storage weekly anchor) — verifier provides the local integrity signal; anchor provides external tamper-evidence.
- Slice G-4 (`platform_admin_access_log` + `@PlatformAdminOnly`) — still awaits #141 role-split decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)