### PR TITLE
Slice G-3: OCI Object Storage external audit-chain anchor

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,6 +65,18 @@ yarn-error.log*
 .env.*.local
 *.env
 .env.rehearsal
+
+# Cryptographic keys + secret material — never commit
+# Phase G-3 OCI service-principal private key + general crypto hygiene
+*.pem
+*.key
+*.p8
+*.p12
+*.pfx
+*.jks
+*-private-key*
+.fabt-oci-keys/
+oci-keys/
 # Rehearsal rendered config (contains stub credentials)
 .fabt-rehearsal/
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -23,6 +23,7 @@
         <logstash-logback.version>9.0</logstash-logback.version>
         <testcontainers.version>2.0.4</testcontainers.version>
         <resilience4j.version>2.4.0</resilience4j.version>
+        <oci-java-sdk.version>3.85.0</oci-java-sdk.version>
     </properties>
 
     <dependencies>
@@ -145,6 +146,19 @@
             <groupId>io.github.resilience4j</groupId>
             <artifactId>resilience4j-spring-boot4</artifactId>
             <version>${resilience4j.version}</version>
+        </dependency>
+
+        <!-- OCI Object Storage — Phase G-3 audit-chain external anchor -->
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-objectstorage</artifactId>
+            <version>${oci-java-sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.oracle.oci.sdk</groupId>
+            <artifactId>oci-java-sdk-common-httpclient-jersey3</artifactId>
+            <version>${oci-java-sdk.version}</version>
+            <scope>runtime</scope>
         </dependency>
         <dependency>
             <groupId>io.github.resilience4j</groupId>

--- a/backend/src/main/java/org/fabt/observability/anchor/AuditChainAnchorService.java
+++ b/backend/src/main/java/org/fabt/observability/anchor/AuditChainAnchorService.java
@@ -1,0 +1,176 @@
+package org.fabt.observability.anchor;
+
+import java.io.ByteArrayInputStream;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
+import java.util.HexFormat;
+import java.util.UUID;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.PutObjectRequest;
+import com.oracle.bmc.objectstorage.responses.PutObjectResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Service;
+
+/**
+ * Phase G-3 — Builds the canonical anchor payload for one tenant + uploads
+ * it to OCI Object Storage. Stateless; one method per tenant per run.
+ *
+ * <h2>Anchor payload shape (load-bearing — do not change without coordinated
+ * verifier update)</h2>
+ *
+ * <pre>{@code
+ * {
+ *   "anchor_format_version": "v1",
+ *   "tenant_id": "...",
+ *   "last_hash_hex": "...",
+ *   "last_row_id": "...",
+ *   "anchored_at": "2026-04-25T05:00:00Z",
+ *   "run_id": "..."
+ * }
+ * }</pre>
+ *
+ * <p>Future schema changes increment {@code anchor_format_version} so a
+ * forensic reader can dispatch on the version. The first published payload
+ * pins this shape forever — operators reading historical anchors must be
+ * able to reconstruct every previous version.
+ *
+ * <h2>Object key shape</h2>
+ *
+ * <p>{@code audit-anchors/yyyy/MM/dd/{tenant_id}-{run_id}.json}.
+ *
+ * <p>Date prefix simplifies forensic retrieval ("show me all anchors from a
+ * specific week"). One run produces one object per tenant — no overwrite
+ * concerns even if versioning is suspended (each run id is unique).
+ *
+ * <h2>Security posture</h2>
+ *
+ * <ul>
+ *   <li>Uses ONLY {@code PutObject}. The IAM policy on the tenancy explicitly
+ *       omits {@code OBJECT_DELETE} and {@code OBJECT_OVERWRITE}; even if
+ *       this code attempted them, the bucket would refuse.</li>
+ *   <li>Bucket has a 7-year locked retention rule (Oracle-enforced WORM).</li>
+ *   <li>This service never reads the OCI private key directly. The SDK
+ *       reads it via {@code SimpleAuthenticationDetailsProvider}.</li>
+ * </ul>
+ *
+ * <p>Bean is conditional on {@code fabt.oci.audit-anchor.enabled=true} —
+ * matches the {@link OciAuditAnchorConfig} gating so the service and its
+ * dependencies are co-existent.
+ */
+@Service
+@ConditionalOnProperty(prefix = "fabt.oci.audit-anchor", name = "enabled", havingValue = "true")
+public class AuditChainAnchorService {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditChainAnchorService.class);
+    public static final String ANCHOR_FORMAT_VERSION = "v1";
+
+    private final ObjectStorage objectStorage;
+    private final OciAuditAnchorProperties props;
+
+    public AuditChainAnchorService(ObjectStorage objectStorage, OciAuditAnchorProperties props) {
+        this.objectStorage = objectStorage;
+        this.props = props;
+    }
+
+    /**
+     * Build the canonical JSON payload for a single tenant's anchor row.
+     * Deterministic field order; SHA-256 of the byte representation can be
+     * cross-verified post-upload for tamper-detection on the OCI side.
+     *
+     * @param tenantId    the tenant whose chain head is being anchored
+     * @param lastHash    32-byte chain-head hash (rendered hex-lowercase)
+     * @param lastRowId   the {@code audit_events.id} of the row this hash
+     *                    corresponds to (may be null only for tenants whose
+     *                    chain has just been seeded — pre-V85 case is filtered
+     *                    by the caller)
+     * @param anchoredAt  the wall-clock time the anchor row was assembled
+     * @param runId       a UUID identifying the verifier run this anchor
+     *                    belongs to (allows correlating anchors back to a
+     *                    specific job execution in {@code BATCH_JOB_EXECUTION})
+     */
+    public String buildAnchorPayload(UUID tenantId, byte[] lastHash, UUID lastRowId,
+                                      Instant anchoredAt, UUID runId) {
+        if (lastHash == null || lastHash.length != 32) {
+            throw new IllegalArgumentException(
+                    "lastHash must be exactly 32 bytes (SHA-256 digest); got "
+                    + (lastHash == null ? "null" : lastHash.length + " bytes"));
+        }
+        StringBuilder sb = new StringBuilder(256);
+        sb.append('{');
+        sb.append("\"anchor_format_version\":\"").append(ANCHOR_FORMAT_VERSION).append("\",");
+        sb.append("\"tenant_id\":\"").append(tenantId).append("\",");
+        sb.append("\"last_hash_hex\":\"").append(HexFormat.of().formatHex(lastHash)).append("\",");
+        sb.append("\"last_row_id\":");
+        if (lastRowId == null) {
+            sb.append("null");
+        } else {
+            sb.append('"').append(lastRowId).append('"');
+        }
+        sb.append(',');
+        sb.append("\"anchored_at\":\"").append(anchoredAt.toString()).append("\",");
+        sb.append("\"run_id\":\"").append(runId).append('"');
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /**
+     * Build the object-storage key for a given anchor row.
+     */
+    public String buildObjectKey(UUID tenantId, Instant anchoredAt, UUID runId) {
+        DateTimeFormatter datePath = DateTimeFormatter.ofPattern("yyyy/MM/dd")
+                .withZone(java.time.ZoneOffset.UTC);
+        return "audit-anchors/" + datePath.format(anchoredAt)
+                + "/" + tenantId + "-" + runId + ".json";
+    }
+
+    /**
+     * Upload a single tenant's anchor row to OCI Object Storage.
+     *
+     * @return SHA-256 hex of the uploaded payload bytes — useful for
+     *         operator verification (cross-reference with the
+     *         {@code Content-MD5}/{@code etag} returned by OCI for additional
+     *         transit-integrity confidence).
+     * @throws RuntimeException if the upload fails. The caller (batch
+     *         tasklet) catches per-tenant and continues; the failure is
+     *         metric-logged so Prometheus can alert on sustained failure.
+     */
+    public AnchorUploadResult uploadAnchor(UUID tenantId, byte[] lastHash, UUID lastRowId,
+                                            Instant anchoredAt, UUID runId) {
+        String payload = buildAnchorPayload(tenantId, lastHash, lastRowId, anchoredAt, runId);
+        byte[] payloadBytes = payload.getBytes(StandardCharsets.UTF_8);
+        String objectKey = buildObjectKey(tenantId, anchoredAt, runId);
+        String payloadSha256 = sha256Hex(payloadBytes);
+
+        PutObjectRequest req = PutObjectRequest.builder()
+                .namespaceName(props.namespace())
+                .bucketName(props.bucket())
+                .objectName(objectKey)
+                .contentType("application/json")
+                .contentLength((long) payloadBytes.length)
+                .putObjectBody(new ByteArrayInputStream(payloadBytes))
+                .build();
+
+        PutObjectResponse resp = objectStorage.putObject(req);
+        log.info("OCI audit-anchor uploaded: tenant={} key={} size={}B etag={} payloadSha256={}",
+                tenantId, objectKey, payloadBytes.length, resp.getETag(), payloadSha256);
+        return new AnchorUploadResult(objectKey, resp.getETag(), payloadSha256);
+    }
+
+    private static String sha256Hex(byte[] input) {
+        try {
+            byte[] digest = MessageDigest.getInstance("SHA-256").digest(input);
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    /** Returned by {@link #uploadAnchor}. */
+    public record AnchorUploadResult(String objectKey, String etag, String payloadSha256) {}
+}

--- a/backend/src/main/java/org/fabt/observability/anchor/OciAuditAnchorConfig.java
+++ b/backend/src/main/java/org/fabt/observability/anchor/OciAuditAnchorConfig.java
@@ -1,0 +1,107 @@
+package org.fabt.observability.anchor;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.function.Supplier;
+
+import com.oracle.bmc.Region;
+import com.oracle.bmc.auth.AuthenticationDetailsProvider;
+import com.oracle.bmc.auth.SimpleAuthenticationDetailsProvider;
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.ObjectStorageClient;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Phase G-3 — OCI Object Storage client configuration for the external
+ * audit-chain anchor.
+ *
+ * <p><b>Active only when {@code fabt.oci.audit-anchor.enabled=true}</b>. In
+ * any other profile (dev, CI, local) the {@code @ConditionalOnProperty} keeps
+ * the entire OCI integration off — no SDK initialisation, no key file read,
+ * no network reachability assumptions. This is the same pattern used by
+ * other optional FABT integrations (e.g. webhook delivery in test mode).
+ *
+ * <p><b>Private key handling</b>: the SDK's {@code SimpleAuthenticationDetailsProvider}
+ * accepts a {@code Supplier<InputStream>} that yields the PEM bytes. We
+ * supply a lazy file-reader keyed off the configured path. The key contents
+ * never enter Java heap until SDK auth handshake; we never log, surface, or
+ * persist the bytes ourselves.
+ *
+ * <p>Region is resolved via {@link Region#fromRegionId} from the configured
+ * {@code region} property (e.g. {@code us-ashburn-1}). The endpoint is
+ * derived by the SDK; we do not hardcode endpoint URLs.
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "fabt.oci.audit-anchor", name = "enabled", havingValue = "true")
+@EnableConfigurationProperties(OciAuditAnchorProperties.class)
+public class OciAuditAnchorConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(OciAuditAnchorConfig.class);
+
+    @Bean
+    public AuthenticationDetailsProvider ociAuthenticationDetailsProvider(OciAuditAnchorProperties props) {
+        validateRequired("region", props.region());
+        validateRequired("tenancyOcid", props.tenancyOcid());
+        validateRequired("userOcid", props.userOcid());
+        validateRequired("fingerprint", props.fingerprint());
+        validateRequired("privateKeyPath", props.privateKeyPath());
+
+        File keyFile = new File(props.privateKeyPath());
+        if (!keyFile.exists() || !keyFile.canRead()) {
+            throw new IllegalStateException(
+                    "OCI private key not readable at configured path. "
+                    + "Verify FABT_OCI_PRIVATE_KEY_PATH points to the deployed "
+                    + "service-principal key file with mode 600 owned by the "
+                    + "FABT process user. (Path is logged here without contents.)");
+        }
+
+        // Supplier reads the file lazily on each SDK auth event. The SDK
+        // closes the InputStream after consumption.
+        Supplier<InputStream> keySupplier = () -> {
+            try {
+                return new FileInputStream(keyFile);
+            } catch (IOException e) {
+                throw new IllegalStateException(
+                        "Failed to open OCI private key file at the configured path "
+                        + "(contents not logged).", e);
+            }
+        };
+
+        log.info("OCI audit-anchor: building authentication provider for region={} tenancy={} user={} fingerprint=[redacted]",
+                props.region(), props.tenancyOcid(), props.userOcid());
+
+        return SimpleAuthenticationDetailsProvider.builder()
+                .tenantId(props.tenancyOcid())
+                .userId(props.userOcid())
+                .fingerprint(props.fingerprint())
+                .privateKeySupplier(keySupplier)
+                .region(Region.fromRegionId(props.region()))
+                .build();
+    }
+
+    @Bean(destroyMethod = "close")
+    public ObjectStorage ociObjectStorageClient(AuthenticationDetailsProvider auth,
+                                                OciAuditAnchorProperties props) {
+        validateRequired("namespace", props.namespace());
+        validateRequired("bucket", props.bucket());
+        validateRequired("compartmentOcid", props.compartmentOcid());
+        log.info("OCI audit-anchor: ObjectStorageClient configured for namespace={} bucket={}",
+                props.namespace(), props.bucket());
+        return ObjectStorageClient.builder().build(auth);
+    }
+
+    private static void validateRequired(String name, String value) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(
+                    "OCI audit-anchor enabled but required property '" + name + "' is missing or blank. "
+                    + "Set fabt.oci.audit-anchor." + name + " (or the FABT_OCI_* env var) before enabling.");
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/observability/anchor/OciAuditAnchorProperties.java
+++ b/backend/src/main/java/org/fabt/observability/anchor/OciAuditAnchorProperties.java
@@ -1,0 +1,48 @@
+package org.fabt.observability.anchor;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * Phase G-3 — Configuration for the OCI Object Storage external audit-chain
+ * anchor. Bound from {@code fabt.oci.audit-anchor.*} properties (typically
+ * sourced from {@code FABT_OCI_*} environment variables on prod).
+ *
+ * <p>Default {@link #enabled()} is {@code false} — dev, CI, and local builds
+ * skip OCI integration entirely. Production overrides via env var.
+ *
+ * <p><b>No defaults for OCIDs / keys / endpoints</b> — these MUST be set via
+ * env vars on the machine that runs the verifier. Hardcoded production values
+ * in source would (1) leak tenancy identity into the public repo and (2) tie
+ * the code to a specific OCI tenancy. Operators substitute their own values
+ * per the runbook.
+ *
+ * <p><b>Private key path is a filesystem reference, never the key itself.</b>
+ * The OCI Java SDK reads the file via {@code SimpleAuthenticationDetailsProvider}
+ * from the configured path. This module never reads the key contents
+ * directly.
+ */
+@ConfigurationProperties(prefix = "fabt.oci.audit-anchor")
+public record OciAuditAnchorProperties(
+        boolean enabled,
+        String region,
+        String tenancyOcid,
+        String userOcid,
+        String fingerprint,
+        String privateKeyPath,
+        String namespace,
+        String bucket,
+        String compartmentOcid,
+        /**
+         * Spring Batch cron expression for the weekly anchor job. Defaults
+         * to Monday 05:00 UTC ({@code 0 0 5 * * MON}) per Phase G design.md
+         * — well outside business hours and after the daily verifier (which
+         * runs at 04:00 UTC). Override via {@code fabt.oci.audit-anchor.cron}.
+         */
+        String cron) {
+
+    public OciAuditAnchorProperties {
+        if (cron == null || cron.isBlank()) {
+            cron = "0 0 5 * * MON";
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/observability/batch/AuditChainAnchorJobConfig.java
+++ b/backend/src/main/java/org/fabt/observability/batch/AuditChainAnchorJobConfig.java
@@ -1,0 +1,190 @@
+package org.fabt.observability.batch;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Timer;
+import org.fabt.analytics.config.BatchJobScheduler;
+import org.fabt.observability.anchor.AuditChainAnchorService;
+import org.fabt.observability.anchor.OciAuditAnchorProperties;
+import org.fabt.shared.security.TenantUnscoped;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.batch.core.job.Job;
+import org.springframework.batch.core.job.builder.JobBuilder;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.scope.context.ChunkContext;
+import org.springframework.batch.core.step.Step;
+import org.springframework.batch.core.step.StepContribution;
+import org.springframework.batch.core.step.builder.StepBuilder;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.batch.infrastructure.repeat.RepeatStatus;
+import org.springframework.batch.infrastructure.support.transaction.ResourcelessTransactionManager;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.event.EventListener;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+/**
+ * Phase G-3 — Spring Batch job that uploads weekly audit-chain anchors to
+ * OCI Object Storage (multi-tenant-production-readiness §8.5).
+ *
+ * <p><b>Conditional on {@code fabt.oci.audit-anchor.enabled=true}</b>. When
+ * disabled, the {@code @Configuration} class is not loaded; the job is
+ * never registered with {@link BatchJobScheduler}; no OCI dependencies
+ * are required at runtime. Dev / CI / local builds are entirely unaffected.
+ *
+ * <p>For each tenant in {@code tenant_audit_chain_head}, the tasklet:
+ * <ol>
+ *   <li>Reads the tenant's {@code last_hash} + {@code last_row_id} (under
+ *       SYSTEM context — chain head table has no RLS per V80)</li>
+ *   <li>Skips tenants whose chain head still has the 32-byte zero sentinel
+ *       (no audits written yet) — anchoring an empty chain is forensically
+ *       useless</li>
+ *   <li>Calls {@link AuditChainAnchorService#uploadAnchor} which performs
+ *       the OCI {@code PutObject}</li>
+ *   <li>Emits success / failure counters tagged by tenant</li>
+ * </ol>
+ *
+ * <p>Per-tenant failure is logged + metric-counted; the run continues for
+ * remaining tenants. Sustained failure rate is alerted via the Prometheus
+ * rule {@code FabtAuditAnchorUploadFailing} in
+ * {@code deploy/prometheus/phase-g-chain-verify.rules.yml}.
+ *
+ * <p>On-demand runs available via the existing
+ * {@code POST /api/v1/batch/jobs/auditChainAnchor/run} endpoint
+ * ({@code BatchJobController}).
+ */
+@Configuration
+@ConditionalOnProperty(prefix = "fabt.oci.audit-anchor", name = "enabled", havingValue = "true")
+public class AuditChainAnchorJobConfig {
+
+    private static final Logger log = LoggerFactory.getLogger(AuditChainAnchorJobConfig.class);
+
+    /** Job name; matches the {@code /api/v1/batch/jobs/{name}/run} path. */
+    public static final String JOB_NAME = "auditChainAnchor";
+
+    /** 32-byte zero sentinel — the V80 / TenantLifecycleService.create seed. */
+    private static final byte[] ZERO_SENTINEL = new byte[32];
+
+    private final JobRepository jobRepository;
+    private final JdbcTemplate jdbc;
+    private final AuditChainAnchorService anchorService;
+    private final BatchJobScheduler batchJobScheduler;
+    private final OciAuditAnchorProperties props;
+    private final MeterRegistry meterRegistry;
+
+    public AuditChainAnchorJobConfig(JobRepository jobRepository,
+                                      JdbcTemplate jdbc,
+                                      AuditChainAnchorService anchorService,
+                                      BatchJobScheduler batchJobScheduler,
+                                      OciAuditAnchorProperties props,
+                                      ObjectProvider<MeterRegistry> meterRegistryProvider) {
+        this.jobRepository = jobRepository;
+        this.jdbc = jdbc;
+        this.anchorService = anchorService;
+        this.batchJobScheduler = batchJobScheduler;
+        this.props = props;
+        this.meterRegistry = meterRegistryProvider.getIfAvailable();
+    }
+
+    @Bean
+    public Job auditChainAnchorJob() {
+        return new JobBuilder(JOB_NAME, jobRepository)
+                .start(anchorTenantsStep())
+                .build();
+    }
+
+    @Bean
+    public Step anchorTenantsStep() {
+        return new StepBuilder("anchorTenantsStep", jobRepository)
+                .tasklet(anchorTenantsTasklet(), new ResourcelessTransactionManager())
+                .build();
+    }
+
+    @Bean
+    @TenantUnscoped("Audit-anchor uploader — iterates every tenant's chain head; chain_head table has no RLS (V80) so no per-tenant binding is needed")
+    public Tasklet anchorTenantsTasklet() {
+        return (StepContribution contribution, ChunkContext chunkContext) -> {
+            Timer.Sample sample = meterRegistry == null ? null : Timer.start(meterRegistry);
+            Instant runStart = Instant.now();
+            UUID runId = UUID.randomUUID();
+
+            // tenant_audit_chain_head has no RLS; safe to read across all tenants.
+            List<Map<String, Object>> rows = jdbc.queryForList(
+                    "SELECT tenant_id, last_hash, last_row_id FROM tenant_audit_chain_head ORDER BY tenant_id");
+
+            int succeeded = 0;
+            int failed = 0;
+            int skipped = 0;
+
+            for (Map<String, Object> row : rows) {
+                UUID tenantId = (UUID) row.get("tenant_id");
+                byte[] lastHash = (byte[]) row.get("last_hash");
+                UUID lastRowId = (UUID) row.get("last_row_id");
+
+                if (lastHash == null || java.util.Arrays.equals(lastHash, ZERO_SENTINEL)) {
+                    // Chain not yet bumped past the zero-sentinel seed — no
+                    // audits to anchor. Skip silently.
+                    skipped++;
+                    continue;
+                }
+
+                try {
+                    anchorService.uploadAnchor(tenantId, lastHash, lastRowId, runStart, runId);
+                    succeeded++;
+                    if (meterRegistry != null) {
+                        Counter.builder("fabt.audit.anchor.upload.count")
+                                .tag("result", "success")
+                                .description("OCI audit-anchor upload outcomes")
+                                .register(meterRegistry)
+                                .increment();
+                    }
+                } catch (Exception e) {
+                    failed++;
+                    log.error("OCI audit-anchor upload FAILED for tenant={} runId={}: {}",
+                            tenantId, runId, e.getMessage(), e);
+                    if (meterRegistry != null) {
+                        Counter.builder("fabt.audit.anchor.upload.count")
+                                .tag("result", "failure")
+                                .tag("tenant_id", tenantId.toString())
+                                .description("OCI audit-anchor upload outcomes")
+                                .register(meterRegistry)
+                                .increment();
+                    }
+                }
+            }
+
+            if (meterRegistry != null) {
+                Counter.builder("fabt.audit.anchor.tenants_anchored.count")
+                        .description("Tenants whose chain head was successfully anchored to OCI in this run")
+                        .register(meterRegistry)
+                        .increment(succeeded);
+                if (sample != null) {
+                    sample.stop(Timer.builder("fabt.audit.anchor.duration.seconds")
+                            .description("Wall-clock duration of the OCI audit-anchor batch job")
+                            .register(meterRegistry));
+                }
+            }
+
+            log.info("OCI audit-anchor batch complete — runId={} succeeded={} failed={} skipped={} startedAt={}",
+                    runId, succeeded, failed, skipped, runStart);
+
+            return RepeatStatus.FINISHED;
+        };
+    }
+
+    @EventListener(ApplicationReadyEvent.class)
+    public void registerWithScheduler() {
+        // dvAccess=false: anchor service reads chain-head metadata + uploads
+        // hash bytes; never reads audit_events details payload.
+        batchJobScheduler.registerJob(JOB_NAME, auditChainAnchorJob(), props.cron(), false);
+    }
+}

--- a/backend/src/test/java/org/fabt/observability/anchor/AnchorPayloadShapeTest.java
+++ b/backend/src/test/java/org/fabt/observability/anchor/AnchorPayloadShapeTest.java
@@ -1,0 +1,157 @@
+package org.fabt.observability.anchor;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import com.oracle.bmc.objectstorage.requests.PutObjectRequest;
+import com.oracle.bmc.objectstorage.responses.PutObjectResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link AuditChainAnchorService} — pinned anchor payload shape
+ * and OCI client interaction. No Spring context, no real OCI calls.
+ *
+ * <p><b>Why pin the payload shape</b>: every anchor uploaded to OCI is
+ * immutable for 7 years (locked retention rule). A future schema change
+ * means the bucket holds payloads in two formats — forensic readers must
+ * handle both. The {@code anchor_format_version} field is the dispatch key.
+ * Changing the v1 shape after first ship is a migration event.
+ */
+@DisplayName("AuditChainAnchorService — payload shape + OCI interaction contract")
+class AnchorPayloadShapeTest {
+
+    private static final UUID TENANT = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ROW    = UUID.fromString("22222222-2222-2222-2222-222222222222");
+    private static final UUID RUN    = UUID.fromString("33333333-3333-3333-3333-333333333333");
+    private static final Instant T   = Instant.parse("2026-04-27T05:00:00Z");
+
+    private static OciAuditAnchorProperties props() {
+        return new OciAuditAnchorProperties(
+                true,
+                "us-ashburn-1",
+                "ocid1.tenancy.oc1..test",
+                "ocid1.user.oc1..test",
+                "aa:bb:cc",
+                "/dev/null",
+                "test-namespace",
+                "test-bucket",
+                "ocid1.compartment.oc1..test",
+                null);
+    }
+
+    private static byte[] sampleHash() {
+        byte[] h = new byte[32];
+        for (int i = 0; i < 32; i++) h[i] = (byte) i;
+        return h;
+    }
+
+    @Test
+    @DisplayName("v1 payload has exactly the 6 fields in the contracted order")
+    void v1PayloadShapePinned() {
+        AuditChainAnchorService svc = new AuditChainAnchorService(mock(ObjectStorage.class), props());
+        String payload = svc.buildAnchorPayload(TENANT, sampleHash(), ROW, T, RUN);
+
+        // Exact bit-for-bit pin. If this assertion ever fails, you are
+        // about to make a change that requires a migration of every
+        // historical anchor in the bucket.
+        String expected = "{"
+                + "\"anchor_format_version\":\"v1\","
+                + "\"tenant_id\":\"11111111-1111-1111-1111-111111111111\","
+                + "\"last_hash_hex\":\"000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f\","
+                + "\"last_row_id\":\"22222222-2222-2222-2222-222222222222\","
+                + "\"anchored_at\":\"2026-04-27T05:00:00Z\","
+                + "\"run_id\":\"33333333-3333-3333-3333-333333333333\""
+                + "}";
+        assertThat(payload).isEqualTo(expected);
+    }
+
+    @Test
+    @DisplayName("null last_row_id renders as JSON null, not empty string")
+    void nullLastRowIdRenderedAsJsonNull() {
+        AuditChainAnchorService svc = new AuditChainAnchorService(mock(ObjectStorage.class), props());
+        String payload = svc.buildAnchorPayload(TENANT, sampleHash(), null, T, RUN);
+        assertThat(payload).contains("\"last_row_id\":null");
+        assertThat(payload).doesNotContain("\"last_row_id\":\"\"");
+    }
+
+    @Test
+    @DisplayName("invalid hash length rejected with clear message")
+    void invalidHashLengthRejected() {
+        AuditChainAnchorService svc = new AuditChainAnchorService(mock(ObjectStorage.class), props());
+        assertThatThrownBy(() -> svc.buildAnchorPayload(TENANT, new byte[31], ROW, T, RUN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("32 bytes");
+        assertThatThrownBy(() -> svc.buildAnchorPayload(TENANT, null, ROW, T, RUN))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("32 bytes");
+    }
+
+    @Test
+    @DisplayName("object key follows audit-anchors/yyyy/MM/dd/{tenant}-{run}.json shape")
+    void objectKeyShapePinned() {
+        AuditChainAnchorService svc = new AuditChainAnchorService(mock(ObjectStorage.class), props());
+        String key = svc.buildObjectKey(TENANT, T, RUN);
+        assertThat(key).isEqualTo(
+                "audit-anchors/2026/04/27/11111111-1111-1111-1111-111111111111-33333333-3333-3333-3333-333333333333.json");
+    }
+
+    @Test
+    @DisplayName("uploadAnchor calls PutObject exactly once with the contracted request shape — no DELETE attempt")
+    void uploadCallsPutObjectOnly() {
+        ObjectStorage client = mock(ObjectStorage.class);
+        PutObjectResponse resp = PutObjectResponse.builder().eTag("test-etag").build();
+        when(client.putObject(any(PutObjectRequest.class))).thenReturn(resp);
+
+        AuditChainAnchorService svc = new AuditChainAnchorService(client, props());
+        AuditChainAnchorService.AnchorUploadResult result =
+                svc.uploadAnchor(TENANT, sampleHash(), ROW, T, RUN);
+
+        ArgumentCaptor<PutObjectRequest> captor = ArgumentCaptor.forClass(PutObjectRequest.class);
+        verify(client, times(1)).putObject(captor.capture());
+
+        PutObjectRequest req = captor.getValue();
+        assertThat(req.getNamespaceName()).isEqualTo("test-namespace");
+        assertThat(req.getBucketName()).isEqualTo("test-bucket");
+        assertThat(req.getObjectName()).isEqualTo(
+                "audit-anchors/2026/04/27/11111111-1111-1111-1111-111111111111-33333333-3333-3333-3333-333333333333.json");
+        assertThat(req.getContentType()).isEqualTo("application/json");
+
+        assertThat(result.objectKey()).isEqualTo(req.getObjectName());
+        assertThat(result.etag()).isEqualTo("test-etag");
+        assertThat(result.payloadSha256())
+                .as("SHA-256 hex of the uploaded payload bytes — 64 hex chars")
+                .matches("^[0-9a-f]{64}$");
+    }
+
+    @Test
+    @DisplayName("delete + overwrite paths are NEVER invoked from uploadAnchor")
+    void noDeleteOrOverwritePaths() {
+        // Belt-and-braces: even if a future refactor adds a delete branch,
+        // this test catches it. The IAM policy on the tenancy already
+        // refuses these operations, but defense in depth.
+        ObjectStorage client = mock(ObjectStorage.class);
+        PutObjectResponse resp = PutObjectResponse.builder().eTag("test-etag").build();
+        when(client.putObject(any(PutObjectRequest.class))).thenReturn(resp);
+
+        AuditChainAnchorService svc = new AuditChainAnchorService(client, props());
+        svc.uploadAnchor(TENANT, sampleHash(), ROW, T, RUN);
+
+        verify(client, never()).deleteObject(any());
+        // No "rename" / "overwrite" semantic in the SDK; PutObject would
+        // overwrite by default — but the IAM policy blocks
+        // OBJECT_OVERWRITE. Our happy-path uses a unique object key
+        // (tenant + run UUID), so overwrite never happens by construction.
+    }
+}

--- a/backend/src/test/java/org/fabt/observability/anchor/AuditChainAnchorJobConfigDisabledTest.java
+++ b/backend/src/test/java/org/fabt/observability/anchor/AuditChainAnchorJobConfigDisabledTest.java
@@ -1,0 +1,50 @@
+package org.fabt.observability.anchor;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.observability.batch.AuditChainAnchorJobConfig;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link AuditChainAnchorJobConfig} is NOT loaded when the
+ * anchor integration is disabled (the default in dev/CI/test profiles).
+ *
+ * <p>If this test ever fails, the anchor batch job is loading without the
+ * required OCI configuration and would crash at startup in any environment
+ * lacking real OCI credentials. Load-bearing safety property.
+ */
+@DisplayName("AuditChainAnchorJobConfig — not loaded when OCI integration disabled")
+class AuditChainAnchorJobConfigDisabledTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    @DisplayName("AuditChainAnchorJobConfig bean does not exist when fabt.oci.audit-anchor.enabled is unset")
+    void jobConfigNotLoadedWhenDisabled() {
+        String[] beanNames = context.getBeanNamesForType(AuditChainAnchorJobConfig.class);
+        assertThat(beanNames)
+                .as("AuditChainAnchorJobConfig must not load in dev/CI/test profiles "
+                    + "(fabt.oci.audit-anchor.enabled is unset). If this fails, the OCI "
+                    + "batch job is being instantiated without credentials and will crash "
+                    + "at startup in any environment without a real OCI bucket.")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("auditChainAnchor job is not registered with the batch scheduler")
+    void jobNotRegisteredWithScheduler() {
+        // BatchJobScheduler exposes registered job names via getCurrentCrons().
+        // The 'auditChainAnchor' name should be ABSENT when the OCI config is
+        // disabled — registerWithScheduler is gated on the same conditional
+        // as the @Configuration class itself.
+        var scheduler = context.getBean(org.fabt.analytics.config.BatchJobScheduler.class);
+        assertThat(scheduler.getCurrentCrons())
+                .as("auditChainAnchor must not be registered with BatchJobScheduler when OCI is disabled")
+                .doesNotContainKey(AuditChainAnchorJobConfig.JOB_NAME);
+    }
+}

--- a/backend/src/test/java/org/fabt/observability/anchor/AuditChainAnchorJobTaskletTest.java
+++ b/backend/src/test/java/org/fabt/observability/anchor/AuditChainAnchorJobTaskletTest.java
@@ -1,0 +1,189 @@
+package org.fabt.observability.anchor;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.simple.SimpleMeterRegistry;
+import org.fabt.analytics.config.BatchJobScheduler;
+import org.fabt.observability.batch.AuditChainAnchorJobConfig;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.batch.core.repository.JobRepository;
+import org.springframework.batch.core.step.tasklet.Tasklet;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Tasklet-level test for {@link AuditChainAnchorJobConfig#anchorTenantsTasklet()}.
+ *
+ * <p>Closes Riley's must-fix gap from the G-3 warroom review: per-tenant loop,
+ * zero-sentinel skip, per-tenant failure isolation, and counter-emission shape
+ * were not previously covered. This test wires the JobConfig with mocked
+ * dependencies (no Spring context, no DB) and invokes the Tasklet directly.
+ *
+ * <p>What it pins:
+ * <ol>
+ *   <li>Tenants with last_hash == zero-sentinel are SKIPPED (no upload call)</li>
+ *   <li>Tenants with non-zero last_hash trigger {@code uploadAnchor} exactly once</li>
+ *   <li>One tenant's failure does NOT abort the run for remaining tenants</li>
+ *   <li>Success counter increments by tenants-uploaded count</li>
+ *   <li>Failure counter is tagged by tenant_id</li>
+ *   <li>tenants_anchored.count reports the success count, not the total</li>
+ * </ol>
+ */
+@DisplayName("AuditChainAnchorJobConfig — tasklet per-tenant behavior")
+class AuditChainAnchorJobTaskletTest {
+
+    private static final byte[] ZERO_SENTINEL = new byte[32];
+    private static final UUID TENANT_A = UUID.fromString("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa");
+    private static final UUID TENANT_B = UUID.fromString("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb");
+    private static final UUID TENANT_C = UUID.fromString("cccccccc-cccc-cccc-cccc-cccccccccccc");
+    private static final UUID ROW_A = UUID.fromString("11111111-1111-1111-1111-111111111111");
+    private static final UUID ROW_B = UUID.fromString("22222222-2222-2222-2222-222222222222");
+
+    private JdbcTemplate jdbc;
+    private AuditChainAnchorService anchorService;
+    private MeterRegistry meterRegistry;
+    private BatchJobScheduler scheduler;
+    private AuditChainAnchorJobConfig config;
+
+    @BeforeEach
+    void setup() {
+        jdbc = mock(JdbcTemplate.class);
+        anchorService = mock(AuditChainAnchorService.class);
+        meterRegistry = new SimpleMeterRegistry();
+        scheduler = mock(BatchJobScheduler.class);
+
+        OciAuditAnchorProperties props = new OciAuditAnchorProperties(
+                true, "us-ashburn-1",
+                "ocid1.tenancy.oc1..test", "ocid1.user.oc1..test",
+                "aa:bb", "/dev/null",
+                "test-namespace", "test-bucket",
+                "ocid1.compartment.oc1..test", null);
+
+        @SuppressWarnings("unchecked")
+        ObjectProvider<MeterRegistry> meterProvider = mock(ObjectProvider.class);
+        when(meterProvider.getIfAvailable()).thenReturn(meterRegistry);
+
+        config = new AuditChainAnchorJobConfig(
+                mock(JobRepository.class), jdbc, anchorService, scheduler, props, meterProvider);
+    }
+
+    @Test
+    @DisplayName("zero-sentinel tenant is skipped; non-zero tenant uploads exactly once")
+    void zeroSentinelSkippedNonZeroUploaded() throws Exception {
+        byte[] realHash = nonZeroHash(0x42);
+        when(jdbc.queryForList(anyString())).thenReturn(List.of(
+                rowMap(TENANT_A, ZERO_SENTINEL, null),     // skip
+                rowMap(TENANT_B, realHash, ROW_B)          // upload
+        ));
+
+        Tasklet tasklet = config.anchorTenantsTasklet();
+        tasklet.execute(null, null);
+
+        verify(anchorService, never()).uploadAnchor(eq(TENANT_A), any(), any(), any(), any());
+        verify(anchorService, times(1)).uploadAnchor(eq(TENANT_B), eq(realHash), eq(ROW_B), any(), any());
+
+        assertThat(counterValue("fabt.audit.anchor.upload.count", "result", "success")).isEqualTo(1.0);
+        assertThat(counterValue("fabt.audit.anchor.tenants_anchored.count", null, null)).isEqualTo(1.0);
+    }
+
+    @Test
+    @DisplayName("one tenant's failure does not abort the run; failure counter tagged by tenant")
+    void perTenantFailureIsolation() throws Exception {
+        byte[] hashA = nonZeroHash(0x11);
+        byte[] hashB = nonZeroHash(0x22);
+        byte[] hashC = nonZeroHash(0x33);
+        when(jdbc.queryForList(anyString())).thenReturn(List.of(
+                rowMap(TENANT_A, hashA, ROW_A),
+                rowMap(TENANT_B, hashB, ROW_B),
+                rowMap(TENANT_C, hashC, null)
+        ));
+
+        // Tenant B's upload throws; A and C succeed.
+        lenient().when(anchorService.uploadAnchor(eq(TENANT_A), any(), any(), any(), any()))
+                .thenReturn(new AuditChainAnchorService.AnchorUploadResult("k-a", "etag-a", "sha-a"));
+        when(anchorService.uploadAnchor(eq(TENANT_B), any(), any(), any(), any()))
+                .thenThrow(new RuntimeException("simulated OCI 503"));
+        lenient().when(anchorService.uploadAnchor(eq(TENANT_C), any(), any(), any(), any()))
+                .thenReturn(new AuditChainAnchorService.AnchorUploadResult("k-c", "etag-c", "sha-c"));
+
+        Tasklet tasklet = config.anchorTenantsTasklet();
+        tasklet.execute(null, null);
+
+        verify(anchorService, times(1)).uploadAnchor(eq(TENANT_A), any(), any(), any(), any());
+        verify(anchorService, times(1)).uploadAnchor(eq(TENANT_B), any(), any(), any(), any());
+        verify(anchorService, atLeastOnce()).uploadAnchor(eq(TENANT_C), any(), any(), any(), any());
+
+        // 2 successes, 1 failure tagged by tenant
+        assertThat(counterValue("fabt.audit.anchor.upload.count", "result", "success")).isEqualTo(2.0);
+        Counter failureCounter = meterRegistry.find("fabt.audit.anchor.upload.count")
+                .tag("result", "failure")
+                .tag("tenant_id", TENANT_B.toString())
+                .counter();
+        assertThat(failureCounter)
+                .as("Failure counter must be tagged with the failing tenant_id")
+                .isNotNull();
+        assertThat(failureCounter.count()).isEqualTo(1.0);
+
+        // tenants_anchored reports successes only
+        assertThat(counterValue("fabt.audit.anchor.tenants_anchored.count", null, null)).isEqualTo(2.0);
+    }
+
+    @Test
+    @DisplayName("empty chain head table — tasklet completes cleanly with no uploads")
+    void emptyChainHeadTable() throws Exception {
+        when(jdbc.queryForList(anyString())).thenReturn(List.of());
+
+        Tasklet tasklet = config.anchorTenantsTasklet();
+        tasklet.execute(null, null);
+
+        verify(anchorService, never()).uploadAnchor(any(), any(), any(), any(), any());
+        assertThat(counterValue("fabt.audit.anchor.upload.count", "result", "success")).isEqualTo(0.0);
+        assertThat(counterValue("fabt.audit.anchor.tenants_anchored.count", null, null)).isEqualTo(0.0);
+    }
+
+    // ─── helpers ─────────────────────────────────────────────────────────
+
+    private static Map<String, Object> rowMap(UUID tenantId, byte[] lastHash, UUID lastRowId) {
+        // HashMap (not Map.of) — Map.of rejects null values, but lastRowId
+        // is legitimately null for chain heads where last_row_id has not
+        // been bumped past the V80 NULL seed.
+        Map<String, Object> row = new java.util.HashMap<>();
+        row.put("tenant_id", tenantId);
+        row.put("last_hash", lastHash);
+        row.put("last_row_id", lastRowId);
+        return row;
+    }
+
+    private static byte[] nonZeroHash(int seed) {
+        byte[] h = new byte[32];
+        for (int i = 0; i < 32; i++) h[i] = (byte) ((seed + i) & 0xFF);
+        return h;
+    }
+
+    private double counterValue(String name, String tagKey, String tagValue) {
+        var find = meterRegistry.find(name);
+        if (tagKey != null && tagValue != null) {
+            find = find.tag(tagKey, tagValue);
+        }
+        Counter c = find.counter();
+        return c == null ? 0.0 : c.count();
+    }
+}

--- a/backend/src/test/java/org/fabt/observability/anchor/OciAuditAnchorDisabledByDefaultTest.java
+++ b/backend/src/test/java/org/fabt/observability/anchor/OciAuditAnchorDisabledByDefaultTest.java
@@ -1,0 +1,52 @@
+package org.fabt.observability.anchor;
+
+import com.oracle.bmc.objectstorage.ObjectStorage;
+import org.fabt.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that the OCI audit-anchor integration is OFF by default.
+ *
+ * <p>The test profile does not set {@code fabt.oci.audit-anchor.enabled},
+ * so {@link OciAuditAnchorConfig} (and the {@code AuditChainAnchorJobConfig}
+ * + {@code AuditChainAnchorService} that depend on it) should not load.
+ * No {@link ObjectStorage} bean should exist; no {@code auditChainAnchor}
+ * batch job should be registered.
+ *
+ * <p>This is the load-bearing safety property: developers, CI runners, and
+ * local dev environments never need OCI credentials, never make OCI network
+ * calls, and never accidentally write to a real bucket.
+ */
+@DisplayName("OCI audit-anchor — disabled by default in dev/CI/test profiles")
+class OciAuditAnchorDisabledByDefaultTest extends BaseIntegrationTest {
+
+    @Autowired
+    private ApplicationContext context;
+
+    @Test
+    @DisplayName("ObjectStorage bean does not exist when fabt.oci.audit-anchor.enabled is unset")
+    void noObjectStorageBeanWhenDisabled() {
+        // The condition is: bean exists ONLY if fabt.oci.audit-anchor.enabled=true.
+        // Test profile leaves it unset (defaulting to false), so the bean
+        // must not be present.
+        String[] beanNames = context.getBeanNamesForType(ObjectStorage.class);
+        assertThat(beanNames)
+                .as("ObjectStorage bean must not be loaded in dev/CI/test "
+                    + "— fabt.oci.audit-anchor.enabled is not set in this profile")
+                .isEmpty();
+    }
+
+    @Test
+    @DisplayName("AuditChainAnchorService does not exist when disabled")
+    void noAnchorServiceWhenDisabled() {
+        String[] beanNames = context.getBeanNamesForType(AuditChainAnchorService.class);
+        assertThat(beanNames)
+                .as("AuditChainAnchorService must not be loaded when OCI integration is off")
+                .isEmpty();
+    }
+}

--- a/deploy/prometheus/phase-g-chain-verify.rules.yml
+++ b/deploy/prometheus/phase-g-chain-verify.rules.yml
@@ -131,3 +131,71 @@ groups:
             over 36 hours. Expected cadence is daily at 04:00 UTC.
             Check BatchJobScheduler state via GET /api/v1/batch/jobs;
             verify cron is 0 0 4 * * * and enabled=true.
+
+  # =====================================================================
+  # Phase G-3 — OCI Object Storage external anchor (§8.5)
+  # =====================================================================
+  - name: fabt_phase_g_anchor_upload
+    interval: 30s
+    rules:
+
+      # ---- WARN — sustained anchor upload failures ---------------------
+      # Fires when the OCI audit-anchor uploader sees any failures over a
+      # 1h window. Per-failure tagged with tenant_id (cardinality bounded
+      # to tenants that actually fail). Causes:
+      #   (a) OCI region outage / network reachability issue
+      #   (b) Service-principal credentials expired or rotated
+      #       (FABT_OCI_KEY_FINGERPRINT no longer matches the uploaded key)
+      #   (c) Bucket retention rule / IAM policy regression denied PutObject
+      #   (d) Bucket name / namespace misconfigured
+      # Anchor failures do not affect tenant operations — only forensic
+      # tamper-evidence — so WARN is the right severity unless failures
+      # are sustained for several days (then escalate manually).
+      - alert: FabtAuditAnchorUploadFailing
+        expr: |
+          sum by (tenant_id) (
+            increase(fabt_audit_anchor_upload_count_total{result="failure",env="prod"}[1h])
+          ) > 0
+        for: 30m
+        labels:
+          severity: warning
+          surface: phase-g-anchor
+          runbook: docs/security/phase-g-chain-verify-runbook.md
+        annotations:
+          summary: "Phase G: OCI audit-anchor upload failing for tenant {{ $labels.tenant_id }}"
+          description: |
+            AuditChainAnchorService.uploadAnchor reported {{ $value | humanize }}
+            failures for tenant {{ $labels.tenant_id }} in the last 1h. The
+            anchor for this tenant in this week's batch is missing or partial.
+
+            Triage:
+            1. Pull the verifier batch log for the most recent
+               auditChainAnchor run via GET /api/v1/batch/jobs/auditChainAnchor/executions
+            2. Check OCI Object Storage bucket via the OCI console — is the
+               bucket reachable? Has the retention rule's lock activation
+               passed (2026-05-09 02:16 UTC) and locked any unintended state?
+            3. Check FABT_OCI_KEY_FINGERPRINT matches the active API key on
+               the service-principal user (oci iam user api-key list)
+            4. Re-run on demand once the underlying error is fixed:
+               POST /api/v1/batch/jobs/auditChainAnchor/run
+
+      # ---- WARN — anchor job has not run in 10 days --------------------
+      # Cadence is weekly Monday 05:00 UTC. >10 days means the scheduler
+      # is wedged or the job is disabled — leaving the chain un-anchored
+      # externally for an extended window.
+      - alert: FabtAuditAnchorStalled
+        expr: |
+          (time() - fabt_audit_anchor_tenants_anchored_count_total_created{env="prod"}) > 864000
+        for: 1h
+        labels:
+          severity: warning
+          surface: phase-g-anchor
+          runbook: docs/security/phase-g-chain-verify-runbook.md
+        annotations:
+          summary: "Phase G: OCI audit-anchor job has not produced an upload in over 10 days"
+          description: |
+            No auditChainAnchor run has emitted tenants_anchored_count in
+            over 10 days. Expected cadence is weekly Monday 05:00 UTC.
+            Check BatchJobScheduler via GET /api/v1/batch/jobs; verify
+            cron is 0 0 5 * * MON and enabled=true; verify
+            fabt.oci.audit-anchor.enabled=true is set on the running JVM.

--- a/docs/security/phase-g-anchor-operator-setup.md
+++ b/docs/security/phase-g-anchor-operator-setup.md
@@ -1,0 +1,292 @@
+# Phase G-3 — OCI Object Storage Audit-Anchor Setup (Operator)
+
+This runbook covers provisioning the OCI infrastructure that the FABT audit-chain external anchor (Phase G-3, `multi-tenant-production-readiness` §8.5) writes to. It is operator-facing — the developer has shipped the code; this document is what the operator runs at deploy time to wire the service to a real OCI bucket.
+
+**Audience**: an operator who manages the FABT prod tenancy, has OCI CLI configured, and has tenancy-admin permissions in their target Oracle Cloud account.
+
+**Prerequisites**:
+
+- `oci` CLI installed and authenticated to the target tenancy
+- `openssl` available (key generation)
+- The FABT VM running v0.53+ (the version that ships `AuditChainAnchorJobConfig`)
+
+---
+
+## 1. What gets provisioned
+
+| Resource | Name | Purpose |
+|---|---|---|
+| Compartment | `fabt-audit` | Blast-radius isolation for audit-anchor resources |
+| Bucket | `fabt-audit-anchor` | Receives weekly anchor JSON objects |
+| Retention rule | `fabt-7yr-worm` | 7-year locked WORM (Oracle-enforced; lock activates 14 days after rule creation) |
+| User | `fabt-audit-anchor-svc` | Service principal — no human login |
+| Group | `fabt-audit-anchor-writers` | Holds the service principal |
+| Policy | `fabt-audit-anchor-policy` | Append-only access; explicitly omits `OBJECT_DELETE` and `OBJECT_OVERWRITE` |
+| API key | RSA-2048 keypair | Authenticates the FABT app to OCI |
+
+**Cost**: $0/month at FABT's scale (well under OCI Always Free limits — 10 GB Object Storage, 50,000 writes/month). Anchor payloads are ~256 bytes each; one upload per tenant per week.
+
+---
+
+## 2. Provisioning commands
+
+The commands below assume PowerShell on Windows or bash; adapt line-continuation (`` ` `` for PowerShell, `\` for bash) as needed. Each phase ends with output that the operator captures for the FABT app's environment variables.
+
+### 2.1 Discover tenancy info
+
+```bash
+oci iam region-subscription list --query 'data[?"is-home-region"==`true`].{Region:"region-name"}' --output table
+oci os ns get
+oci iam compartment list --all --include-root
+```
+
+Capture: home region (e.g. `us-ashburn-1`), namespace string, root compartment OCID (the `id` of the row whose `compartment-id` is `null`).
+
+### 2.2 Create the compartment
+
+```bash
+oci iam compartment create \
+  --compartment-id <TENANCY_OCID> \
+  --name "fabt-audit" \
+  --description "FABT audit-chain external anchor (Phase G-3)"
+```
+
+Capture the new compartment OCID.
+
+### 2.3 Create the bucket
+
+```bash
+oci os bucket create \
+  --compartment-id <COMPARTMENT_OCID> \
+  --name "fabt-audit-anchor" \
+  --storage-tier Standard \
+  --public-access-type NoPublicAccess \
+  --object-events-enabled false
+```
+
+**Do NOT enable versioning** — OCI rejects retention-rule creation on a versioning-enabled bucket. The locked retention rule is the stronger primitive for our threat model (Oracle-enforced immutability vs. soft "all versions retained"). If versioning is on by default on your tenancy, suspend it before proceeding to 2.6:
+
+```bash
+oci os bucket update \
+  --namespace-name <NAMESPACE> \
+  --bucket-name "fabt-audit-anchor" \
+  --versioning Suspended
+```
+
+### 2.4 Create the IAM service principal + group + policy
+
+```bash
+oci iam user create \
+  --name "fabt-audit-anchor-svc" \
+  --description "Service principal: FABT writes weekly audit-chain anchors. No human login." \
+  --email "fabt-audit-anchor-svc+noreply@<your-domain>"
+
+oci iam group create \
+  --name "fabt-audit-anchor-writers" \
+  --description "Append-only access to fabt-audit-anchor bucket. No delete, no overwrite."
+
+oci iam group add-user --group-id <GROUP_OCID> --user-id <USER_OCID>
+```
+
+Policy (write the statements to a file, then create — single quotes inside JSON cause CLI parsing issues otherwise):
+
+```bash
+cat > /tmp/fabt-policy.json <<'EOF'
+[
+  "Allow group fabt-audit-anchor-writers to inspect buckets in compartment fabt-audit",
+  "Allow group fabt-audit-anchor-writers to read buckets in compartment fabt-audit where target.bucket.name='fabt-audit-anchor'",
+  "Allow group fabt-audit-anchor-writers to manage objects in compartment fabt-audit where all { target.bucket.name='fabt-audit-anchor', any { request.permission='OBJECT_CREATE', request.permission='OBJECT_INSPECT', request.permission='OBJECT_READ' } }"
+]
+EOF
+
+oci iam policy create \
+  --compartment-id <TENANCY_OCID> \
+  --name "fabt-audit-anchor-policy" \
+  --description "FABT audit-anchor service principal — append-only access to fabt-audit-anchor bucket" \
+  --statements file:///tmp/fabt-policy.json
+
+rm /tmp/fabt-policy.json
+```
+
+The policy explicitly omits `OBJECT_DELETE` and `OBJECT_OVERWRITE`; even if the service-principal credentials leak, the bucket refuses any tampering with anchored hashes.
+
+### 2.5 Lock down service-principal capabilities
+
+Default OCI users have every credential type enabled (console password, SMTP, OAuth2, etc.). Disable everything except `can-use-api-keys`:
+
+```bash
+oci iam user update-user-capabilities \
+  --user-id <USER_OCID> \
+  --can-use-console-password false \
+  --can-use-auth-tokens false \
+  --can-use-customer-secret-keys false \
+  --can-use-smtp-credentials false \
+  --can-use-db-credentials false \
+  --can-use-o-auth2-client-credentials false
+```
+
+### 2.6 Generate and upload the API keypair
+
+```bash
+mkdir -p ~/.fabt-oci-keys && chmod 700 ~/.fabt-oci-keys
+openssl genrsa -out ~/.fabt-oci-keys/fabt-audit-anchor.pem 2048
+chmod 600 ~/.fabt-oci-keys/fabt-audit-anchor.pem
+openssl rsa -pubout -in ~/.fabt-oci-keys/fabt-audit-anchor.pem -out ~/.fabt-oci-keys/fabt-audit-anchor.pub
+
+oci iam user api-key upload \
+  --user-id <USER_OCID> \
+  --key-file ~/.fabt-oci-keys/fabt-audit-anchor.pub
+```
+
+Capture the fingerprint from the response.
+
+**Critical**: the private key (`fabt-audit-anchor.pem`) is what gets deployed to the FABT VM. **Never commit it to git** — the FABT repo's `.gitignore` covers `*.pem` patterns, but treat it as a credential regardless.
+
+### 2.7 Apply the locked WORM retention rule
+
+```bash
+LOCK_AT=$(date -u -d '+14 days 1 hour' +'%Y-%m-%dT%H:%M:%S.000Z')
+
+oci os retention-rule create \
+  --namespace-name <NAMESPACE> \
+  --bucket-name "fabt-audit-anchor" \
+  --display-name "fabt-7yr-worm" \
+  --time-amount 7 \
+  --time-unit YEARS \
+  --time-rule-locked "$LOCK_AT"
+```
+
+**Critical operational note**: between rule creation and the timestamp in `LOCK_AT` (14 days + 1 hour), the rule is still mutable. If you discover a bucket misconfiguration during that window, you can delete the rule and start over. After the lock activates, the rule is immutable for the 7-year retention duration.
+
+---
+
+## 3. Deploy the private key to the FABT VM
+
+```bash
+# On the operator workstation:
+scp ~/.fabt-oci-keys/fabt-audit-anchor.pem fabt-prod:/tmp/audit-anchor.pem
+
+# On the FABT VM:
+sudo mkdir -p /var/lib/fabt/oci
+sudo mv /tmp/audit-anchor.pem /var/lib/fabt/oci/audit-anchor.pem
+sudo chown fabt:fabt /var/lib/fabt/oci/audit-anchor.pem
+sudo chmod 600 /var/lib/fabt/oci/audit-anchor.pem
+sudo chmod 700 /var/lib/fabt/oci
+```
+
+Substitute `fabt:fabt` with whatever user/group the FABT JVM runs as.
+
+---
+
+## 4. Set environment variables on the FABT VM
+
+Add to the FABT app's `.env` (or systemd unit, or whatever the deployment uses):
+
+```bash
+FABT_OCI_AUDIT_ANCHOR_ENABLED=true
+FABT_OCI_AUDIT_ANCHOR_REGION=<region from 2.1>
+FABT_OCI_AUDIT_ANCHOR_NAMESPACE=<namespace from 2.1>
+FABT_OCI_AUDIT_ANCHOR_TENANCY_OCID=<tenancy OCID from 2.1>
+FABT_OCI_AUDIT_ANCHOR_USER_OCID=<service principal user OCID from 2.4>
+FABT_OCI_AUDIT_ANCHOR_FINGERPRINT=<API key fingerprint from 2.6>
+FABT_OCI_AUDIT_ANCHOR_PRIVATE_KEY_PATH=/var/lib/fabt/oci/audit-anchor.pem
+FABT_OCI_AUDIT_ANCHOR_BUCKET=fabt-audit-anchor
+FABT_OCI_AUDIT_ANCHOR_COMPARTMENT_OCID=<compartment OCID from 2.2>
+```
+
+Restart the FABT app. On boot, you'll see:
+
+```
+INFO  o.f.o.anchor.OciAuditAnchorConfig - OCI audit-anchor: building authentication provider for region=us-ashburn-1 tenancy=ocid1.tenancy... user=ocid1.user... fingerprint=[redacted]
+INFO  o.f.o.anchor.OciAuditAnchorConfig - OCI audit-anchor: ObjectStorageClient configured for namespace=... bucket=fabt-audit-anchor
+INFO  o.f.a.config.BatchJobScheduler - Registered batch job 'auditChainAnchor' with cron '0 0 5 * * MON' (dvAccess=false)
+```
+
+---
+
+## 5. Verify with an on-demand run
+
+Don't wait for next Monday — trigger the job manually:
+
+```bash
+curl -X POST -H "Authorization: Bearer <PLATFORM_ADMIN_JWT>" \
+  https://findabed.org/api/v1/batch/jobs/auditChainAnchor/run
+```
+
+Then check execution history:
+
+```bash
+curl -H "Authorization: Bearer <PLATFORM_ADMIN_JWT>" \
+  https://findabed.org/api/v1/batch/jobs/auditChainAnchor/executions
+```
+
+Confirm `status=COMPLETED` and check the FABT logs for `OCI audit-anchor uploaded:` lines, one per tenant with a non-zero chain head.
+
+Verify objects landed in the bucket:
+
+```bash
+oci os object list --namespace-name <NAMESPACE> --bucket-name "fabt-audit-anchor" --prefix "audit-anchors/" --output table
+```
+
+Expected: one object per tenant per run, key shape `audit-anchors/yyyy/MM/dd/{tenant_id}-{run_id}.json`.
+
+---
+
+## 6. The 14-day lock activation window
+
+After step 2.7, you have a 14-day grace period to verify the bucket configuration. **Use it.** Run at least one anchor batch (step 5), confirm objects appear with the right shape, confirm the retention rule cannot be bypassed via attempted overwrites or deletes (the IAM policy prevents these from the service principal anyway, but verify by attempting from your admin OCI CLI session — they should fail).
+
+After the lock activates (`LOCK_AT` from step 2.7), the bucket is committed for 7 years. Migration off OCI Object Storage during that window means archiving the existing bucket as-is and pointing future writes elsewhere; you cannot delete or overwrite anchored content.
+
+---
+
+## 7. Recovery scenarios
+
+### Anchor upload failures (`FabtAuditAnchorUploadFailing` alert)
+
+See alert annotations in `deploy/prometheus/phase-g-chain-verify.rules.yml`. Common causes:
+
+- API key fingerprint drift after key rotation — re-upload the public key + update `FABT_OCI_AUDIT_ANCHOR_FINGERPRINT`
+- Bucket name typo — confirm `fabt-audit-anchor` exact spelling
+- Region mismatch — `FABT_OCI_AUDIT_ANCHOR_REGION` must match the bucket's home region
+
+### Lost private key
+
+The private key is local to the operator workstation (path: `~/.fabt-oci-keys/fabt-audit-anchor.pem`) AND on the FABT VM (path: `/var/lib/fabt/oci/audit-anchor.pem`). If both are lost, generate a new keypair, upload the new public key, retire the old API key:
+
+```bash
+# Generate new keypair (steps 2.6 again)
+# Upload new public key
+oci iam user api-key upload --user-id <USER_OCID> --key-file ~/.fabt-oci-keys/fabt-audit-anchor.pub
+
+# Get the fingerprint of the OLD key
+oci iam user api-key list --user-id <USER_OCID>
+
+# Delete the OLD key (after the new one is verified working)
+oci iam user api-key delete --user-id <USER_OCID> --fingerprint <OLD_FINGERPRINT> --force
+```
+
+---
+
+## 8. Forensic retrieval (incident response)
+
+To pull the anchor history for a tenant during an investigation:
+
+```bash
+oci os object list \
+  --namespace-name <NAMESPACE> \
+  --bucket-name "fabt-audit-anchor" \
+  --prefix "audit-anchors/" \
+  --output json | jq '.data[] | select(.name | contains("<TENANT_OCID>")) | .name'
+
+# Then fetch a specific anchor:
+oci os object get \
+  --namespace-name <NAMESPACE> \
+  --bucket-name "fabt-audit-anchor" \
+  --name "audit-anchors/yyyy/MM/dd/{tenant_id}-{run_id}.json" \
+  --file ./anchor.json
+
+cat ./anchor.json | jq '.'
+```
+
+The JSON payload contains `last_hash_hex` (the chain-head hash at anchor time). Compare against the live `tenant_audit_chain_head.last_hash` for that tenant. Mismatch on a row whose `audit_events.timestamp` predates the anchor's `anchored_at` timestamp = forensic evidence of post-anchor tampering.


### PR DESCRIPTION
## Summary

Phase G slice G-3 (`multi-tenant-production-readiness` §8.5). Weekly Spring Batch job uploads per-tenant chain-head tuples to an OCI Object Storage bucket with a 7-year locked retention rule (Oracle-enforced WORM). Provides forensic tamper-evidence beyond the database — anchored hashes survive a full DB compromise, including a state-restoration attack against the verifier (G-2) itself.

**Default disabled.** Dev/CI/local builds skip OCI integration entirely via `@ConditionalOnProperty(prefix="fabt.oci.audit-anchor", name="enabled", havingValue="true")`. Production opts in by setting `fabt.oci.audit-anchor.enabled=true` plus the 8 `FABT_OCI_*` env vars per the operator runbook.

## Threat model

| Attack | Caught by |
|---|---|
| App-level audit row insert with arbitrary content | G-1 chain hashing — next row's `prev_hash` mismatch |
| DB-level UPDATE/DELETE on `audit_events` | G-2 daily verifier recomputes row_hash, compares to stored |
| DB-level UPDATE on `tenant_audit_chain_head` | G-2 chain-head alignment check |
| **Full DB rollback to pre-tamper state** (the chain looks self-consistent) | **G-3 — the OCI anchor** records hashes the attacker can't reach |
| App-level admin issuing `DELETE` against the bucket | OCI IAM policy refuses (no `OBJECT_DELETE` permission) |
| Compromised OCI service-principal key tries to overwrite | IAM policy refuses (no `OBJECT_OVERWRITE` permission) |
| OCI tenancy admin tries to delete the bucket | Locked retention rule refuses for 7 years |

## Scope

### Code (`backend/src/main/java/org/fabt/observability/`)
- **`anchor/OciAuditAnchorProperties`** — `@ConfigurationProperties` record with 9 fields (region, OCIDs, key path, namespace, bucket, compartment, cron). Cron defaults to `0 0 5 * * MON`.
- **`anchor/OciAuditAnchorConfig`** — `@ConditionalOnProperty` config that builds `ObjectStorageClient` via `SimpleAuthenticationDetailsProvider` with a **lazy file-stream private-key supplier**. Key bytes never enter Java heap as a String; FABT code never reads the `.pem` contents directly. Boot logs explicitly redact the fingerprint.
- **`anchor/AuditChainAnchorService`** — builds canonical v1 anchor JSON, uploads via `PutObject` only. Object key shape: `audit-anchors/yyyy/MM/dd/{tenant_id}-{run_id}.json`. Never calls `deleteObject`. Returns SHA-256 hex of payload bytes for operator verification.
- **`batch/AuditChainAnchorJobConfig`** — Spring Batch job. Tasklet iterates `tenant_audit_chain_head`, skips zero-sentinel chain heads (no audits yet), per-tenant exception isolation, success/failure counters tagged appropriately. On-demand via existing `POST /api/v1/batch/jobs/auditChainAnchor/run`.

### Maven
- `oci-java-sdk-objectstorage` 3.85.0 (compile)
- `oci-java-sdk-common-httpclient-jersey3` 3.85.0 (runtime)

### Observability
- `fabt.audit.anchor.upload.count{result=success|failure[,tenant_id]}`
- `fabt.audit.anchor.tenants_anchored.count`
- `fabt.audit.anchor.duration.seconds`
- New Prometheus rules (`phase-g-chain-verify.rules.yml`):
  - **`FabtAuditAnchorUploadFailing`** — WARN, 1h failure window
  - **`FabtAuditAnchorStalled`** — WARN, >10 days no run

### Operator runbook
**`docs/security/phase-g-anchor-operator-setup.md`** — 8-section playbook covering OCI compartment + bucket + IAM + retention rule provisioning, key deployment, env-var checklist, on-demand verification, **14-day lock-activation window callout** (critical operational note), recovery scenarios, forensic retrieval.

### Secrets posture
- **Zero hardcoded OCIDs/credentials in source** — every value comes from env vars
- **`.gitignore` extended**: `*.pem`, `*.key`, `*.p8`, `*.p12`, `*.pfx`, `*.jks`, `*-private-key*`, `.fabt-oci-keys/`, `oci-keys/`
- **Tests use Mockito ObjectStorage** — no real OCI calls in CI
- **Private key off-limits**: never read by Claude during development; SDK handles via lazy file-stream supplier

## Tests (15 new, all green)

- **`AnchorPayloadShapeTest`** (6 unit tests):
  - Bit-for-bit v1 payload pin
  - Null `last_row_id` renders as JSON null (not empty string)
  - Invalid hash length rejected with clear message
  - Object key shape (`audit-anchors/yyyy/MM/dd/{tenant}-{run}.json`)
  - `PutObject` exact-call request shape
  - No-delete invariant (`verify(client, never()).deleteObject(any())`)
- **`AuditChainAnchorJobTaskletTest`** (3 tasklet tests with `SimpleMeterRegistry`):
  - Zero-sentinel chain head skipped; non-zero uploaded exactly once
  - Per-tenant failure isolation (1 of 3 throws, other 2 still upload, failure counter tagged by tenant)
  - Empty `tenant_audit_chain_head` — tasklet completes cleanly with no uploads
- **`OciAuditAnchorDisabledByDefaultTest`** (2 ITs): `ObjectStorage` + `AuditChainAnchorService` beans absent in default test profile
- **`AuditChainAnchorJobConfigDisabledTest`** (2 ITs): job config not loaded, scheduler doesn't register `auditChainAnchor`

## Test plan

- [x] `mvn -o verify` — **1147/1147 green**
- [x] All new tests green (15/15)
- [x] Legal scan clean
- [x] No OCIDs/secrets in committed files (manual grep + `.gitignore` patterns extended)

## Sequencing — deploy after merge

This PR completes G-0 → G-3. Combined, those four slices form a complete tamper-evidence story (typed events → chain hashing → daily verifier → external anchor). Operationally, **the OCI bucket's retention rule locks on 2026-05-09 02:16 UTC** — a 14-day grace period from rule creation. Recommend deploying v0.52.0 promptly after merge so real audit anchors flow through the bucket during the validation window.

G-4 (platform admin access log) gates on issue #141 (PLATFORM_OPERATOR role split). G-5 (OTel baggage) is independent and can ship in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)