### PR TITLE
chore(release): v0.52.0 release-prep — Phase G slices 0–3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,116 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [v0.52.0] — Phase G slices 0–3: tamper-evident audit chain + OCI external anchor
+
+**Backend-code release.** Backend JAR bumped `0.51.0 → 0.52.0`. Flyway HWM
+advances `V84 → V85` (one new migration). New runtime dependency: OCI Java
+SDK 3.85.0. Operator action required: provision an OCI Object Storage
+bucket with a 7-year locked retention rule + service principal + key
+deployment per `docs/security/phase-g-anchor-operator-setup.md`. Deploy
+runbook: `docs/oracle-update-notes-v0.52.0.md`.
+
+**Important window**: the OCI retention rule's lock-activation date is
+**14 days after rule creation**. Deploy promptly so the bucket sees real
+production data during the validation window — once locked, the bucket is
+committed for 7 years.
+
+### Added
+
+- **`AuditEventType` enum migration (G-0, closes #98).** `AuditEventRecord.action`
+  typed from `String` to `org.fabt.shared.audit.AuditEventType`. 44 enum cases
+  cover every action emitted across FABT plus a `TEST_PROBE` sentinel for
+  audit-infrastructure tests. Compile-time typo prevention; wire-name
+  stability pinned by `AuditEventTypeTest` so `.name()` of every case is
+  contract-stable across releases. Ships an ArchUnit rule (Family G-0) that
+  forbids production references to `TEST_PROBE`. `AuditEventRecord` compact
+  constructor now rejects null action — null-action audit rows are
+  forensically meaningless.
+
+- **Per-tenant audit hash chain (G-1).** Every `audit_events` INSERT becomes
+  a link in a per-tenant SHA-256 chain, computed inside the writer's
+  transaction. Two persister paths (`AuditEventPersister` REQUIRED +
+  `DetachedAuditPersister` REQUIRES_NEW) both call `AuditChainHasher` to
+  read the previous head with `SELECT ... FOR UPDATE` (per-tenant
+  serialisation), compute `row_hash = SHA-256(prev_hash || canonical_json(row))`,
+  stamp the entity, save, then UPDATE `tenant_audit_chain_head`. Atomic with
+  the audit row INSERT; rollback rolls both back. SYSTEM_TENANT_ID orphans
+  skip hashing by design.
+
+- **Canonical JSON utility + retrofit (G-2 §8.6a).** `AuditCanonicalJson`
+  bridges Jackson insertion-order output (writer) and PostgreSQL JSONB
+  `::text` form (verifier reading from DB) into a single hash-stable form.
+  Applied identically at both ends so the verifier reproduces the writer's
+  hash bit-for-bit. Single source of truth for the canonical form.
+
+- **Daily audit-chain verifier (G-2 §8.6 + §8.15).** Spring Batch job in
+  `org.fabt.observability.batch.AuditChainVerifierJobConfig` re-walks every
+  tenant's chain in cursor-style keyset pagination (constant memory),
+  recomputes every row_hash, checks chain continuity (row N+1's prev_hash
+  matches row N's row_hash), and verifies chain-head alignment. Daily cron
+  `0 0 4 * * *`. Three Prometheus alerts: `FabtAuditChainDriftDetected`
+  (CRITICAL), `FabtAuditChainVerifierError` (WARN), `FabtAuditChainVerifierStalled`
+  (WARN, >36h since last run). On-demand via existing
+  `POST /api/v1/batch/jobs/auditChainVerifier/run`.
+
+- **Weekly OCI Object Storage external anchor (G-3 §8.5).** Spring Batch
+  job uploads `{tenant_id, last_hash_hex, last_row_id, anchored_at, run_id,
+  anchor_format_version="v1"}` to OCI on Mondays 05:00 UTC. Bucket has a
+  7-year locked retention rule (Oracle-enforced WORM); IAM policy
+  explicitly omits `OBJECT_DELETE` and `OBJECT_OVERWRITE`; service
+  principal has only `can-use-api-keys`. Default disabled
+  (`fabt.oci.audit-anchor.enabled=false`); production opts in via 9
+  `FABT_OCI_AUDIT_ANCHOR_*` env vars + a private-key bind-mount. Two new
+  Prometheus alerts: `FabtAuditAnchorUploadFailing` (WARN),
+  `FabtAuditAnchorStalled` (WARN, >10 days since last run). Operator
+  runbook: `docs/security/phase-g-anchor-operator-setup.md`.
+
+- **Flyway V85.** Adds nullable `prev_hash BYTEA` and `row_hash BYTEA`
+  columns to `audit_events`, plus a 32-byte CHECK constraint on each.
+  Pre-V85 historical rows have NULL hashes (verifier skips them by
+  design). Metadata-only ALTER on small tables; near-instant on FABT
+  prod scale.
+
+### Changed
+
+- Microsecond truncation on `AuditEventEntity.timestamp` so DB round-trip
+  matches the original value (PostgreSQL TIMESTAMPTZ is microsecond
+  precision; without truncation, nanoseconds are dropped and the verifier
+  computes a different hash).
+
+- `.gitignore` extended for crypto-key file patterns: `*.pem`, `*.key`,
+  `*.p8`, `*.p12`, `*.pfx`, `*.jks`, `*-private-key*`, `.fabt-oci-keys/`,
+  `oci-keys/`. Defense-in-depth against accidental key commits.
+
+### Deprecated
+
+- `AuditEventTypes` constants class — superseded by `AuditEventType` enum.
+  Removed in this release; new code MUST use `AuditEventType.<CASE>`.
+
+### Tests
+
+- 100+ new tests across the four slices: `AuditEventTypeTest` (56 cases),
+  `AuditChainHasherIntegrationTest`, `AuditChainVerifierIntegrationTest`,
+  `AuditCanonicalJsonTest`, `AnchorPayloadShapeTest`,
+  `AuditChainAnchorJobTaskletTest`, `OciAuditAnchorDisabledByDefaultTest`,
+  `AuditChainAnchorJobConfigDisabledTest`, `FamilyG0ArchitectureTest`,
+  `AuditEventRecordLiteralGuardrailTest`, `AuditEventG0RoundTripIntegrationTest`.
+  Full backend regression: 1147/1147 green.
+
+### Operational notes
+
+- **OCI retention rule lock activates 14 days after rule creation.** Deploy
+  promptly so production audit anchors flow through the bucket during the
+  validation window — once locked, the bucket is committed for 7 years.
+- New env vars must be set BEFORE the backend starts when `fabt.oci.audit-anchor.enabled=true`
+  — the config validates required properties at boot and fails fast on any
+  missing value. No risk to non-OCI builds (default `enabled=false`).
+- Compose chain extended with `~/fabt-secrets/docker-compose.prod-v0.52-oci-anchor.yml`
+  to bind-mount the service-principal private key into the backend container
+  at `/etc/fabt/oci/audit-anchor.pem`.
+
+---
+
 ## [v0.51.0] — Phase F F-6: real crypto-shred via per-tenant wrapped DEKs
 
 **Backend-code release.** First since v0.49 (v0.50 was ops-tier). Backend

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.fabt</groupId>
     <artifactId>finding-a-bed-tonight</artifactId>
-    <version>0.51.0</version>
+    <version>0.52.0</version>
     <name>Finding A Bed Tonight</name>
     <description>Open-source shelter bed availability platform</description>
 

--- a/docs/oracle-update-notes-v0.52.0.md
+++ b/docs/oracle-update-notes-v0.52.0.md
@@ -1,0 +1,362 @@
+# Oracle Deploy Notes — v0.52.0
+
+**Tag:** v0.52.0
+**Branch:** `main` post-merge of PRs #153 (G-0), #154 (G-1), #155 (G-2), #156 (G-3)
+**Theme:** Phase G slices 0–3 — tamper-evident audit chain + OCI Object Storage external anchor.
+
+---
+
+## 1. Consulted Memories
+
+- `feedback_runbook_template_v1.md` — every oracle-update-notes follows the v1 template shape
+- `feedback_runbook_compose_chain.md` — prod docker compose up needs ALL override files in order
+- `feedback_no_guessing_deployment.md` — read deploy docs first, never guess on the Oracle VM
+- `feedback_never_print_rendered_secrets.md` — never cat / head / grep secret-containing config files
+- `feedback_release_after_scans.md` — don't tag releases until CI scans are green
+- `feedback_smoke_config_on_prod.md` — post-deploy smoke uses correct Playwright invocation
+- `feedback_oci_versioning_vs_retention.md` — bucket cannot have both versioning and retention rule
+- `feedback_oci_idcs_user_activation_email.md` — Identity Domains activation email is irrelevant for service principals
+- `feedback_audit_events_revoke_update.md` — V70 REVOKE on audit_events; verifier IT uses INSERT not UPDATE
+- `feedback_spring_batch_for_scheduled_work.md` — Spring Batch pattern for scheduled work
+- `project_phase_g_implementation_plan.md` — Phase G slice plan, G-0 through G-3 merged status
+
+## 2. Scope & Non-Scope
+
+### What ships
+
+- Backend JAR `0.51.0 → 0.52.0`
+- Flyway HWM `V84 → V85` (one new migration: `audit_events ADD prev_hash, row_hash` + 32-byte CHECK constraints)
+- New runtime dependency: OCI Java SDK 3.85.0 (~ 3 MB across `objectstorage` + `httpclient-jersey3`)
+- New observability metrics:
+  - `fabt.audit.chain_verify.runs.count{result}`
+  - `fabt.audit.chain_verify.drift.count{tenant_id}`
+  - `fabt.audit.chain_verify.error.count{tenant_id}`
+  - `fabt.audit.chain_verify.duration.seconds`
+  - `fabt.audit.chain_verify.rows_verified.count`
+  - `fabt.audit.chain_missing_head.count`
+  - `fabt.audit.chain_advance_failed.count`
+  - `fabt.audit.anchor.upload.count{result, tenant_id}` (when OCI enabled)
+  - `fabt.audit.anchor.tenants_anchored.count` (when OCI enabled)
+  - `fabt.audit.anchor.duration.seconds` (when OCI enabled)
+- New Prometheus rule file: `deploy/prometheus/phase-g-chain-verify.rules.yml` (5 alerts)
+- New Spring Batch jobs registered with `BatchJobScheduler`:
+  - `auditChainVerifier` — daily 04:00 UTC, `dvAccess=false`
+  - `auditChainAnchor` — weekly Mondays 05:00 UTC, `dvAccess=false`, **only when OCI enabled**
+- New operator runbook: `docs/security/phase-g-anchor-operator-setup.md` (8-section playbook)
+
+### What does NOT change in this deploy
+
+- Frontend (no rebuild)
+- Nginx config (no rebuild)
+- Postgres image / pgaudit image (no rebuild)
+- Alertmanager config (rule file added, alertmanager itself unchanged)
+- Prometheus config (rule file added; reload required, image unchanged)
+- Grafana dashboards (panels exist; new metrics auto-appear in queries)
+- Existing Flyway migrations (V85 is purely additive ALTER, no historical-data rewrite)
+
+### What v0.52.0 enables but does NOT use in prod yet
+
+- The OCI external anchor activates ONLY if `FABT_OCI_AUDIT_ANCHOR_ENABLED=true` is set in `~/fabt-secrets/.env.prod`. If you deploy v0.52.0 without setting it, the chain hashing + verifier still run (G-1 + G-2), but no anchors flow to OCI.
+- Recommended: enable OCI on this deploy. The 14-day OCI retention-rule lock window starts the day the rule was created and locks **2026-05-09 02:16 UTC**. After that the bucket is committed for 7 years; we want real anchors flowing in for at least a few cycles before lock.
+
+## 3. Service-Recreate Matrix
+
+| Service | Recreate | Why |
+|---|---|---|
+| backend | YES | New JAR, new env vars, new private-key bind-mount |
+| postgres | NO | V85 is metadata-only; no image / config change |
+| nginx | NO | No frontend or routing changes |
+| prometheus | YES (or `kill -HUP`) | New rule file mount |
+| alertmanager | NO | Routing unchanged |
+| grafana | NO | Auto-discovers new metrics |
+
+## 4. Pre-Deploy Gates
+
+### G1. CI green on main
+
+```bash
+gh run list --repo ccradle/finding-a-bed-tonight --branch main --limit 5 \
+  --json conclusion,name,createdAt
+```
+
+Expected: most recent run on main shows `conclusion=success` for `Backend (Java 25 + Maven)`, `Legal Language Scan`, `Flyway HWM guard`, `pgaudit image tests`, `DV Access Control Canary`. E2E may show pass/skip — acceptable for a backend-only deploy.
+
+### G2. Flyway HWM verification
+
+Confirm production is currently at V84 (= post-v0.51.0):
+
+```bash
+ssh <VM_USER>@<VM_IP>
+docker exec -it fabt-postgres psql -U fabt -d fabt -c \
+  "SELECT MAX(installed_rank) AS hwm FROM flyway_schema_history;"
+# Expected: hwm = 84
+```
+
+If hwm < 84, this is not a v0.51.0-baseline VM — STOP and resolve before proceeding.
+
+### G3. OCI bucket sanity (the 14-day window check)
+
+```bash
+# From operator workstation
+oci os retention-rule list --namespace-name idtfwmx114rw --bucket-name fabt-audit-anchor --output table
+```
+
+Expected: one rule named `fabt-7yr-worm`, `time-rule-locked` set to `2026-05-09T02:16:17.000Z` (or thereabouts — the exact timestamp from rule creation).
+
+### G4. Private key on the VM
+
+```bash
+# On the VM
+ls -la ~/fabt-secrets/oci/audit-anchor.pem
+# Expected: -rw------- 1 <VM_USER> <VM_USER>  ~1700  <date>  audit-anchor.pem
+```
+
+If the file is absent, deploy the key per `docs/security/phase-g-anchor-operator-setup.md` step 3 BEFORE proceeding.
+
+### G5. Env vars staged in `~/fabt-secrets/.env.prod`
+
+The 9 new lines must be present (see `docs/security/phase-g-anchor-operator-setup.md` section 4).
+
+```bash
+# On the VM — check WITHOUT cat'ing the file (per feedback_never_print_rendered_secrets)
+grep -c "FABT_OCI_AUDIT_ANCHOR" ~/fabt-secrets/.env.prod
+# Expected: 9
+```
+
+If the count is anything else, fix the env file before deploy.
+
+### G6. New compose override file present
+
+```bash
+# On the VM
+ls -la ~/fabt-secrets/docker-compose.prod-v0.52-oci-anchor.yml
+# Expected: file exists, ~300 bytes
+```
+
+If absent, the bind-mount won't happen and the backend will fail-fast at startup with "OCI private key not readable at configured path."
+
+### G7. pg_dump backup
+
+V85 is a metadata-only ALTER but the backup hygiene rule applies:
+
+```bash
+mkdir -p ~/fabt-backups
+docker exec fabt-postgres pg_dump -U fabt -d fabt -Fc \
+  > ~/fabt-backups/fabt-$(date -u +%Y%m%dT%H%M%SZ)-pre-v0.52.dump
+ls -lh ~/fabt-backups/ | tail -1
+```
+
+## 5. Deploy Steps
+
+### 1. Preserve last-good image tag
+
+```bash
+ssh <VM_USER>@<VM_IP>
+docker tag fabt-backend:latest fabt-backend:v0.51.0
+docker images fabt-backend
+```
+
+### 2. Pull latest main
+
+```bash
+cd ~/finding-a-bed-tonight
+git fetch origin main
+git pull --ff-only origin main
+git log --oneline -5
+# Expected: top commit is the v0.52.0 release-prep merge
+```
+
+### 3. Verify pom.xml version bump
+
+```bash
+grep -A 2 "<artifactId>finding-a-bed-tonight" backend/pom.xml | head -4
+# Expected: <version>0.52.0</version>
+```
+
+### 4. mvn clean + build backend JAR + build backend image
+
+```bash
+cd ~/finding-a-bed-tonight/backend
+mvn clean package -DskipTests
+ls -la target/*.jar | tail -2
+# Expected: target/finding-a-bed-tonight-0.52.0.jar (~ 100+ MB fat jar)
+
+cd ~/finding-a-bed-tonight
+docker build --no-cache -f infra/docker/Dockerfile.backend -t fabt-backend:latest .
+docker images fabt-backend | head -3
+```
+
+(`--no-cache` per the v0.48.0 lesson — three no-op traps were caught during a live deploy because Docker honored a stale layer.)
+
+### 5. Force-recreate backend (triggers Flyway V85)
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f ~/fabt-secrets/docker-compose.prod.yml \
+  -f ~/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml \
+  -f ~/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml \
+  -f ~/fabt-secrets/docker-compose.prod-v0.52-oci-anchor.yml \
+  --env-file ~/fabt-secrets/.env.prod \
+  up -d --force-recreate backend
+```
+
+**Order matters** — later override files win. The v0.52 override goes last.
+
+### 6. Wait for backend health
+
+```bash
+for i in {1..30}; do
+  status=$(docker inspect --format='{{.State.Health.Status}}' fabt-backend 2>/dev/null || echo "starting")
+  echo "$i: $status"
+  if [ "$status" = "healthy" ]; then break; fi
+  sleep 5
+done
+```
+
+If the container fails to come up healthy, check logs:
+
+```bash
+docker logs fabt-backend --tail 100 2>&1 | grep -E "ERROR|FATAL|OCI audit-anchor"
+```
+
+Common failure: `OCI private key not readable at configured path` — confirm the bind-mount fired (G4 + G6 above).
+
+### 7. Reload Prometheus to pick up the new rule file
+
+If your prometheus has `--web.enable-lifecycle`:
+
+```bash
+curl -X POST http://localhost:9090/-/reload
+```
+
+Otherwise:
+
+```bash
+docker compose -f docker-compose.yml -f ~/fabt-secrets/docker-compose.prod.yml \
+  restart prometheus
+```
+
+Confirm the new rule loaded:
+
+```bash
+curl -sS http://localhost:9090/api/v1/rules | jq '.data.groups[].name' | grep -iE "phase_g|chain"
+# Expected: fabt_phase_g_chain_verify, fabt_phase_g_anchor_upload
+```
+
+## 6. Post-Deploy Gates
+
+### Version check
+
+```bash
+curl -sS https://findabed.org/api/v1/version | jq '.version'
+# Expected: "0.52.0"
+```
+
+### Flyway HWM advanced
+
+```bash
+docker exec fabt-postgres psql -U fabt -d fabt -c \
+  "SELECT MAX(installed_rank) AS hwm FROM flyway_schema_history;"
+# Expected: hwm = 85
+```
+
+### V85 columns present + CHECK constraints active
+
+```bash
+docker exec fabt-postgres psql -U fabt -d fabt -c "\d audit_events" \
+  | grep -E "prev_hash|row_hash"
+# Expected: prev_hash | bytea  ; row_hash | bytea
+```
+
+### audit_events rows written post-deploy have hashes
+
+Trigger a real audit row by causing any audit-emitting action (e.g., a coordinator viewing an admin page). Then:
+
+```bash
+docker exec fabt-postgres psql -U fabt -d fabt -c "
+  SELECT action, prev_hash IS NOT NULL AS has_prev, row_hash IS NOT NULL AS has_row
+  FROM audit_events
+  WHERE timestamp > NOW() - INTERVAL '5 minutes'
+  ORDER BY timestamp DESC LIMIT 5;
+"
+# Expected: has_prev=t and has_row=t for every row (assuming non-SYSTEM_TENANT_ID)
+```
+
+### Trigger the verifier on-demand and confirm zero drift
+
+```bash
+COC_ADMIN_JWT="<paste a fresh PLATFORM_ADMIN JWT>"
+curl -X POST -H "Authorization: Bearer $COC_ADMIN_JWT" \
+  https://findabed.org/api/v1/batch/jobs/auditChainVerifier/run
+
+# Wait ~5s, then check execution
+curl -H "Authorization: Bearer $COC_ADMIN_JWT" \
+  https://findabed.org/api/v1/batch/jobs/auditChainVerifier/executions | jq '.[0]'
+# Expected: status=COMPLETED, exitCode=COMPLETED
+```
+
+Drift counter must be zero in Prometheus immediately after:
+
+```bash
+curl -sS http://localhost:9090/api/v1/query \
+  --data-urlencode "query=sum(fabt_audit_chain_verify_drift_count_total)" | jq
+# Expected: result=[] OR value=0
+```
+
+### Trigger the anchor on-demand and confirm OCI upload
+
+```bash
+curl -X POST -H "Authorization: Bearer $COC_ADMIN_JWT" \
+  https://findabed.org/api/v1/batch/jobs/auditChainAnchor/run
+
+curl -H "Authorization: Bearer $COC_ADMIN_JWT" \
+  https://findabed.org/api/v1/batch/jobs/auditChainAnchor/executions | jq '.[0]'
+# Expected: status=COMPLETED
+```
+
+Confirm objects landed in the bucket from your operator workstation:
+
+```bash
+oci os object list --namespace-name idtfwmx114rw --bucket-name fabt-audit-anchor \
+  --prefix "audit-anchors/" --output table | tail -10
+# Expected: one object per active tenant with non-zero chain head
+```
+
+### Playwright smoke (v0.50 lesson — correct invocation)
+
+```bash
+cd ~/finding-a-bed-tonight/e2e/playwright
+FABT_BASE_URL=https://findabed.org \
+  npx playwright test --config=deploy/playwright.config.ts \
+  smoke-prod
+```
+
+Test 13/14 flake = rate-limit, not a regression. Acceptable.
+
+## 7. Rollback Matrix
+
+| Failure mode | Rollback action |
+|---|---|
+| Backend fails to start (e.g., OCI key not readable) | Re-tag previous image: `docker tag fabt-backend:v0.51.0 fabt-backend:latest` then re-deploy step 5. Disable OCI by removing `FABT_OCI_AUDIT_ANCHOR_ENABLED=true` from `.env.prod`. |
+| V85 migration fails (extremely unlikely — metadata-only) | Restore from `~/fabt-backups/fabt-*.dump` via `pg_restore`. |
+| Verifier fires false-positive drift | Disable just the auditChainVerifier job: `POST /api/v1/batch/jobs/auditChainVerifier/disable`. Investigate via verifier logs. The chain-hashing writer keeps running; verifier disable is operationally inert. |
+| OCI upload failures | Disable just the auditChainAnchor job (same endpoint pattern). Then debug the OCI service principal credentials per `docs/security/phase-g-anchor-operator-setup.md` section 7. |
+| Any unrecoverable issue | Roll the JAR + DB back to v0.51.0; re-tag; recreate. Note: V85 columns will be on the table but unused under the v0.51 JAR (the JAR doesn't reference them). Safe to leave. |
+
+## 8. Post-Deploy Housekeeping
+
+- Update `project_live_deployment_status.md` memory with new HWM (V85), backend image hash, and OCI-enabled state
+- Verify the OCI bucket has objects from this deploy's anchor run BEFORE the **2026-05-09 02:16 UTC** lock activation
+- If anything is wrong with the bucket configuration, the rule can still be deleted before lock — DO NOT WAIT past 2026-05-09
+- Add a calendar reminder for 2026-05-08 to verify the bucket state once more before lock
+
+## What's New in v0.52.0 (release notes summary)
+
+See `CHANGELOG.md` `[v0.52.0]` section for the complete list. Highlights:
+
+- Tamper-evident audit chain (G-0 + G-1): every audit row carries `prev_hash` + `row_hash`, computed in the writer's transaction, atomic with the audit INSERT
+- Daily verifier (G-2): re-walks every tenant's chain, recomputes hashes, detects drift via Prometheus alerts
+- Weekly external anchor (G-3): uploads chain-head tuples to OCI Object Storage with 7-year locked WORM retention; even a full DB compromise can't tamper with anchored hashes
+- Sentinel-aware: `SYSTEM_TENANT_ID` orphans skip hashing; pre-V85 historical rows skipped from verification by NULL-hash filter
+- Default disabled OCI integration: dev/CI/local builds never touch OCI; production opts in via env vars


### PR DESCRIPTION
## Summary

Release-prep for v0.52.0. Three files:

- **`backend/pom.xml`** — version bump `0.51.0 → 0.52.0`
- **`CHANGELOG.md`** — `[v0.52.0]` entry covering all four shipped Phase G slices (G-0 enum migration, G-1 chain hashing, G-2 canonicalizer + verifier, G-3 OCI external anchor)
- **`docs/oracle-update-notes-v0.52.0.md`** — full deploy runbook following the v1 template

## Critical operational note (deploy timing)

The OCI Object Storage retention rule's lock activates **2026-05-09 02:16 UTC**. We want real production audit anchors flowing through the bucket during the 14-day grace period so any bucket misconfiguration can be fixed before the lock. **Deploy v0.52.0 promptly** (target tonight, per Corey's call).

## Scope of v0.52.0

- Backend JAR `0.51.0 → 0.52.0`
- Flyway HWM `V84 → V85` (one new migration: audit_events `+prev_hash, +row_hash` BYTEA columns + 32-byte CHECK constraints)
- New runtime dep: OCI Java SDK 3.85.0
- New Spring Batch jobs (registered with `BatchJobScheduler`): `auditChainVerifier` (daily 04:00 UTC), `auditChainAnchor` (weekly Mon 05:00 UTC, OCI-gated)
- New Prometheus rules (5 alerts in `phase-g-chain-verify.rules.yml`)
- New operator runbook: `docs/security/phase-g-anchor-operator-setup.md`
- Default-disabled OCI integration: dev/CI/local builds untouched

## Pre-deploy operator checklist (covered in detail in the runbook)

- [ ] CI green on main (verified via `gh run list`)
- [ ] Prod Postgres at HWM V84
- [ ] OCI bucket retention rule still in 14-day grace (expected lock at 2026-05-09 02:16 UTC)
- [ ] Private key deployed to `~/fabt-secrets/oci/audit-anchor.pem` mode 600
- [ ] 9 `FABT_OCI_AUDIT_ANCHOR_*` env vars staged in `~/fabt-secrets/.env.prod`
- [ ] New compose override `~/fabt-secrets/docker-compose.prod-v0.52-oci-anchor.yml` created
- [ ] pg_dump backup taken to `~/fabt-backups/`

## Test plan

- [x] All four feature PRs (#153, #154, #155, #156) merged with green CI
- [x] Local full backend regression: 1147/1147 green
- [x] Legal language scan clean for new content (one pre-existing 'certified' flag in older CHANGELOG entry; unchanged)

## Post-merge

After this PR merges:
1. Tag `v0.52.0` from main
2. Build + deploy per the runbook
3. Trigger on-demand `auditChainAnchor` run within the 14-day OCI grace window
4. Confirm objects in the OCI bucket before 2026-05-09 02:16 UTC

🤖 Generated with [Claude Code](https://claude.com/claude-code)