### PR TITLE
G-4.2: platform login + MFA + JWT + V88 lockout + iss-routed dispatch

### DIFF
--- a/backend/src/main/java/org/fabt/auth/platform/PlatformAuthExceptionHandler.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformAuthExceptionHandler.java
@@ -1,0 +1,31 @@
+package org.fabt.auth.platform;
+
+import java.util.Map;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+/**
+ * Maps {@link PlatformJwtException} thrown from {@link PlatformAuthController}
+ * (and any future {@code @PlatformAdminOnly} endpoint that calls
+ * {@link PlatformJwtService#validateToken(String)} directly) into HTTP 401.
+ *
+ * <p>Scoped via {@code @RestControllerAdvice(assignableTypes = ...)} would
+ * over-constrain to one controller; scoped via {@code basePackages} keeps
+ * the mapping local to the platform-auth surface so a general
+ * {@code IllegalArgumentException} elsewhere doesn't accidentally land here.
+ */
+@RestControllerAdvice(basePackages = "org.fabt.auth.platform")
+public class PlatformAuthExceptionHandler {
+
+    @ExceptionHandler(PlatformJwtException.class)
+    public ResponseEntity<Map<String, String>> handleJwtException(PlatformJwtException ex) {
+        // Detail (which field of validation failed) stays in server logs only —
+        // the wire body is a stable opaque code so the response does not leak
+        // which validation step rejected the token (warroom M6).
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(Map.of("error", "invalid_platform_token"));
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformAuthService.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformAuthService.java
@@ -1,0 +1,361 @@
+package org.fabt.auth.platform;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.security.SecureRandom;
+import java.util.ArrayList;
+import java.util.HexFormat;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import org.fabt.auth.platform.repository.PlatformUserRepository;
+import org.fabt.auth.service.PasswordService;
+import org.fabt.auth.service.TotpService;
+
+/**
+ * Orchestrates platform_user authentication: password verify, forced
+ * MFA-on-first-login, TOTP/backup-code MFA verify on subsequent logins,
+ * and per-account MFA failure tracking with auto-lockout at 5 fails / 15 min
+ * (warroom-hardened).
+ *
+ * <p>Per design Decision 4 (forced MFA-on-first-login):
+ * <ol>
+ *   <li>{@link #login(String, String)} — password check; returns one of three
+ *       outcomes: {@code MFA_SETUP_REQUIRED} (operator never enrolled),
+ *       {@code MFA_VERIFY_REQUIRED} (operator has TOTP, must verify), or
+ *       {@code REJECTED} (bad creds, locked, anonymized). Rejected paths
+ *       run a decoy bcrypt verify so the timing of "bad email" /
+ *       "account locked" matches "bad password" — closes the enumeration
+ *       oracle (warroom M2).</li>
+ *   <li>{@link #setupMfa(UUID)} — issues TOTP secret + 10 backup codes via
+ *       a single SECURITY DEFINER call ({@code platform_user_setup_mfa})
+ *       so a partial failure can never leave a secret without codes
+ *       (warroom A1). Refuses if the user is already enrolled
+ *       (warroom A4).</li>
+ *   <li>{@link #confirmMfaSetup(UUID, String)} — verifies first TOTP code,
+ *       flips {@code mfa_enabled = true}, records the TOTP code as used
+ *       to seed replay-protection.</li>
+ *   <li>{@link #verifyMfa(UUID, String)} — verifies TOTP-or-backup-code on
+ *       subsequent logins. <b>Replay-protected</b> (warroom M1) — a TOTP
+ *       code accepted within the last 90 seconds is rejected on second
+ *       presentation. On miss, increments the per-account failure counter
+ *       via {@code platform_user_record_failure}; transition-to-locked is
+ *       WARN-logged (warroom J3).</li>
+ * </ol>
+ *
+ * <p>Per design Decision 12, backup codes are stored as SHA-256(salt || code)
+ * — NOT bcrypt. Backup codes are random short strings, used at most once;
+ * bcrypt's slow-compare adds latency during recovery without defending
+ * against any attack the entropy doesn't already cover.
+ *
+ * <p>Per spec line 99-104, per-account lockout fires only on
+ * {@code /login/mfa-verify} failures (the MFA challenge phase). Per-account
+ * password-attempt protection is delegated to the per-IP rate limit on
+ * {@code /login} (G-4.2 task 3.8).
+ */
+@Service
+public class PlatformAuthService {
+
+    private static final Logger log = LoggerFactory.getLogger(PlatformAuthService.class);
+
+    private static final int BACKUP_CODE_COUNT = 10;
+    private static final int BACKUP_CODE_LENGTH = 10;
+    private static final String BACKUP_CODE_CHARS = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    private static final int BACKUP_CODE_SALT_BYTES = 16;
+
+    /** 5 fails within 15 minutes locks the account (Decision 5). */
+    static final int LOCKOUT_WINDOW_MIN = 15;
+    static final int LOCKOUT_THRESHOLD = 5;
+
+    /**
+     * TOTP replay-protection window. RFC 6238 30-sec step + ±1 step drift =
+     * 89-second acceptance window; 90s rejection window covers the entire
+     * acceptance surface for the most-recently-used code.
+     */
+    static final int TOTP_REPLAY_WINDOW_SECONDS = 90;
+
+    private final PlatformUserRepository userRepository;
+    private final PasswordService passwordService;
+    private final TotpService totpService;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    /**
+     * Decoy bcrypt hash used to equalize timing on the "bad email" /
+     * "account locked" rejection paths (warroom M2). The decoy is generated
+     * at construction time over a random secret no caller will ever know;
+     * a {@code passwordService.matches(presentedPassword, decoyHash)} call
+     * costs the same as a real verify, so the wall-clock timing of all
+     * REJECTED outcomes is indistinguishable.
+     */
+    private final String decoyPasswordHash;
+
+    public PlatformAuthService(PlatformUserRepository userRepository,
+                               PasswordService passwordService,
+                               TotpService totpService) {
+        this.userRepository = userRepository;
+        this.passwordService = passwordService;
+        this.totpService = totpService;
+        byte[] decoySeed = new byte[32];
+        new SecureRandom().nextBytes(decoySeed);
+        this.decoyPasswordHash = passwordService.hash(
+                HexFormat.of().formatHex(decoySeed));
+    }
+
+    /**
+     * Step 1 of every platform login. Looks up the user by email, password-
+     * verifies, and decides whether to issue an MFA-setup or MFA-verify
+     * scoped token (caller composes the actual JWT via
+     * {@link PlatformJwtService}).
+     *
+     * <p>The {@link LoginOutcome#REJECTED} path is deliberately
+     * indistinguishable across all failure modes — bad email, bad password,
+     * locked account, anonymized row — to deny enumeration attacks. Timing
+     * is equalized via a decoy bcrypt verify on the no-real-hash paths.
+     *
+     * <p>Note: this method does NOT increment a per-account failure
+     * counter. Per-account lockout is MFA-specific (Decision 5); password
+     * brute-force is throttled by the per-IP rate limit on the {@code /login}
+     * endpoint (G-4.2 task 3.8).
+     */
+    public LoginResult login(String email, String password) {
+        Optional<PlatformUser> opt = userRepository.findByEmail(email);
+        if (opt.isEmpty()) {
+            passwordService.matches(password, decoyPasswordHash);
+            return LoginResult.rejected();
+        }
+        PlatformUser user = opt.get();
+        if (!user.isLoginAllowed()) {
+            passwordService.matches(password, decoyPasswordHash);
+            return LoginResult.rejected();
+        }
+        if (!passwordService.matches(password, user.getPasswordHash())) {
+            return LoginResult.rejected();
+        }
+        if (user.isMfaEnabled()) {
+            return LoginResult.mfaVerifyRequired(user);
+        }
+        return LoginResult.mfaSetupRequired(user);
+    }
+
+    /**
+     * Generates a fresh TOTP secret + 10 backup codes for an operator who
+     * has presented a valid {@code scope=mfa-setup} token. Persists the
+     * plaintext TOTP secret + the 10 SHA-256(salt || code) hashes in a
+     * single SECURITY DEFINER call.
+     *
+     * @throws IllegalStateException if the operator is already enrolled
+     *     (defense against stale-token replay) or has no email.
+     */
+    public MfaSetup setupMfa(UUID userId) {
+        PlatformUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "platform_user not found: " + userId));
+        if (user.getEmail() == null) {
+            throw new IllegalStateException(
+                    "platform_user has no email — bootstrap activation incomplete");
+        }
+        if (user.isMfaEnabled()) {
+            throw new IllegalStateException(
+                    "MFA already enrolled for this user — refusing replay of mfa-setup token");
+        }
+
+        String secret = totpService.generateSecret();
+        String qrUri = totpService.generateQrUri(secret, user.getEmail());
+
+        List<String> plaintextCodes = new ArrayList<>(BACKUP_CODE_COUNT);
+        UUID[] ids = new UUID[BACKUP_CODE_COUNT];
+        String[] hashes = new String[BACKUP_CODE_COUNT];
+        byte[][] salts = new byte[BACKUP_CODE_COUNT][];
+        for (int i = 0; i < BACKUP_CODE_COUNT; i++) {
+            String code = generateBackupCode();
+            byte[] salt = new byte[BACKUP_CODE_SALT_BYTES];
+            secureRandom.nextBytes(salt);
+            plaintextCodes.add(code);
+            ids[i] = UUID.randomUUID();
+            hashes[i] = sha256SaltedHex(salt, code);
+            salts[i] = salt;
+        }
+
+        boolean inserted = userRepository.setupMfaAtomic(userId, secret, ids, hashes, salts);
+        if (!inserted) {
+            // Race: another concurrent setup just enrolled, OR the row was
+            // anonymized. Refuse without disclosing which.
+            throw new IllegalStateException(
+                    "MFA setup refused — user already enrolled or row missing");
+        }
+
+        log.info("Platform operator MFA setup initiated userId={} — TOTP enrollment pending confirm",
+                userId);
+        return new MfaSetup(secret, qrUri, plaintextCodes);
+    }
+
+    /**
+     * Confirms the first TOTP code after MFA setup. On success:
+     * {@code mfa_enabled = true}; the next login goes through the
+     * {@link #verifyMfa(UUID, String)} path. Records the TOTP code as
+     * used for replay-protection (so a leaked first-confirm code can't be
+     * presented again at /mfa-verify within 90s). Returns true on success,
+     * false on an invalid TOTP code.
+     */
+    public boolean confirmMfaSetup(UUID userId, String totpCode) {
+        PlatformUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "platform_user not found: " + userId));
+        if (user.isMfaEnabled()) {
+            return true;
+        }
+        if (user.getMfaSecret() == null) {
+            throw new IllegalStateException(
+                    "Cannot confirm MFA setup before /mfa-setup has been called");
+        }
+        if (!totpService.verifyCode(user.getMfaSecret(), totpCode)) {
+            return false;
+        }
+        userRepository.updateCredentials(userId, null, null, true, null);
+        userRepository.recordTotpUse(userId, totpCode);
+        userRepository.recordLogin(userId);
+        log.info("Platform operator MFA setup confirmed userId={} — mfa_enabled=true", userId);
+        return true;
+    }
+
+    /**
+     * Verifies an MFA challenge on subsequent logins. Order:
+     * <ol>
+     *   <li><b>Replay check</b> — the most-recently-used TOTP within the
+     *       last 90 seconds is rejected on re-presentation (warroom M1).
+     *       This counts as a failure.</li>
+     *   <li>TOTP — if the presented code matches the secret, success.</li>
+     *   <li>Backup code — if any unused code matches, success +
+     *       mark used.</li>
+     *   <li>None matched — record failure; if 5/15-min threshold met,
+     *       account is auto-locked + WARN-logged.</li>
+     * </ol>
+     *
+     * @return true iff TOTP-or-backup-code verified
+     */
+    public boolean verifyMfa(UUID userId, String code) {
+        PlatformUser user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "platform_user not found: " + userId));
+        if (!user.isMfaEnabled() || user.getMfaSecret() == null) {
+            recordFailureAndMaybeLock(userId);
+            return false;
+        }
+        if (userRepository.wasTotpRecentlyUsed(userId, code, TOTP_REPLAY_WINDOW_SECONDS)) {
+            log.warn("Platform operator TOTP replay rejected userId={}", userId);
+            recordFailureAndMaybeLock(userId);
+            return false;
+        }
+        if (totpService.verifyCode(user.getMfaSecret(), code)) {
+            userRepository.recordTotpUse(userId, code);
+            userRepository.clearFailures(userId);
+            userRepository.recordLogin(userId);
+            return true;
+        }
+        if (verifyBackupCode(userId, code)) {
+            userRepository.clearFailures(userId);
+            userRepository.recordLogin(userId);
+            return true;
+        }
+        recordFailureAndMaybeLock(userId);
+        return false;
+    }
+
+    private void recordFailureAndMaybeLock(UUID userId) {
+        boolean nowLocked = userRepository.recordFailure(
+                userId, LOCKOUT_WINDOW_MIN, LOCKOUT_THRESHOLD);
+        if (nowLocked) {
+            log.warn("PLATFORM_USER_LOCKED_OUT userId={} threshold={} windowMin={}",
+                    userId, LOCKOUT_THRESHOLD, LOCKOUT_WINDOW_MIN);
+        }
+    }
+
+    private boolean verifyBackupCode(UUID userId, String presentedCode) {
+        if (presentedCode == null || presentedCode.isBlank()) {
+            return false;
+        }
+        String normalized = presentedCode.toUpperCase().trim();
+        List<PlatformUserRepository.BackupCodeRow> rows =
+                userRepository.findUnusedBackupCodes(userId);
+        for (PlatformUserRepository.BackupCodeRow row : rows) {
+            String candidateHash = sha256SaltedHex(row.codeSalt(), normalized);
+            if (constantTimeEquals(candidateHash, row.codeHash())) {
+                userRepository.markBackupCodeUsed(row.id());
+                log.info("Platform operator MFA backup code consumed userId={} codeId={}",
+                        userId, row.id());
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private String generateBackupCode() {
+        StringBuilder sb = new StringBuilder(BACKUP_CODE_LENGTH);
+        for (int i = 0; i < BACKUP_CODE_LENGTH; i++) {
+            sb.append(BACKUP_CODE_CHARS.charAt(secureRandom.nextInt(BACKUP_CODE_CHARS.length())));
+        }
+        return sb.toString();
+    }
+
+    static String sha256SaltedHex(byte[] salt, String code) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            md.update(salt);
+            byte[] digest = md.digest(code.getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(digest);
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("SHA-256 not available", e);
+        }
+    }
+
+    private static boolean constantTimeEquals(String a, String b) {
+        if (a == null || b == null) {
+            return false;
+        }
+        return MessageDigest.isEqual(
+                a.getBytes(StandardCharsets.UTF_8),
+                b.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Re-reads a {@link PlatformUser} for token issuance after an MFA flow
+     * has succeeded. Throws {@link PlatformJwtException} (mapped to 401) if
+     * the row vanished between the JWT issue and the verify step (the row
+     * would have to be anonymized concurrently — an operational incident,
+     * not an internal-error case so it must NOT 500).
+     */
+    public PlatformUser lookupForToken(UUID userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new PlatformJwtException(
+                        "platform_user no longer present"));
+    }
+
+    public enum LoginOutcome {
+        MFA_SETUP_REQUIRED,
+        MFA_VERIFY_REQUIRED,
+        REJECTED
+    }
+
+    public record LoginResult(LoginOutcome outcome, PlatformUser user) {
+        public static LoginResult mfaSetupRequired(PlatformUser user) {
+            return new LoginResult(LoginOutcome.MFA_SETUP_REQUIRED, user);
+        }
+
+        public static LoginResult mfaVerifyRequired(PlatformUser user) {
+            return new LoginResult(LoginOutcome.MFA_VERIFY_REQUIRED, user);
+        }
+
+        public static LoginResult rejected() {
+            return new LoginResult(LoginOutcome.REJECTED, null);
+        }
+    }
+
+    public record MfaSetup(String secret, String qrUri, List<String> plaintextBackupCodes) {
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformJwtException.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformJwtException.java
@@ -1,0 +1,25 @@
+package org.fabt.auth.platform;
+
+/**
+ * Thrown when an {@code iss = "fabt-platform"} JWT fails validation —
+ * malformed, wrong alg, kid mismatch, signature invalid, or expired.
+ *
+ * <p>Distinct from the tenant-side {@code IllegalArgumentException} +
+ * {@code CrossTenantJwtException} hierarchy used by
+ * {@link org.fabt.auth.service.JwtService} so that the iss-routed
+ * {@code JwtDecoder} dispatch in {@code SecurityConfig} (G-4.2 task 3.9) can
+ * funnel platform-token failures through their own exception handler
+ * without entangling the tenant cross-check semantics.
+ *
+ * <p>Maps to HTTP 401 at the auth-controller / security-filter boundary.
+ */
+public class PlatformJwtException extends RuntimeException {
+
+    public PlatformJwtException(String message) {
+        super(message);
+    }
+
+    public PlatformJwtException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformJwtService.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformJwtService.java
@@ -1,0 +1,302 @@
+package org.fabt.auth.platform;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.SecretKey;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
+import org.springframework.stereotype.Service;
+
+/**
+ * Issues + validates {@code iss = "fabt-platform"} JWTs for
+ * {@link PlatformUser} sessions (Phase G-4 / issue #141).
+ *
+ * <h2>Why a separate service from {@link org.fabt.auth.service.JwtService}</h2>
+ *
+ * <p>Per design Decision 3, platform JWTs and tenant JWTs are kept on
+ * separate validation paths so that the Phase A4 D25 cross-tenant cross-check
+ * — kid resolves to a tenant; body claim {@code tenantId} must match —
+ * remains a 1-branch invariant rather than growing 3-branch logic to
+ * accommodate "platform tokens have no tenant." See {@code JwtService}
+ * line 409-424 for the tenant cross-check; that code is bypassed entirely
+ * for platform tokens because it is never reached.
+ *
+ * <h2>Token shapes</h2>
+ *
+ * <ul>
+ *   <li><b>Access</b> (15 min) — issued after MFA verification. Full
+ *       {@code PLATFORM_OPERATOR} authority. Carries
+ *       {@code mfaVerified=true} so downstream code can require MFA-fresh
+ *       sessions on sensitive actions.</li>
+ *   <li><b>MFA-setup</b> (10 min) — issued on first password auth when
+ *       {@code mfa_enabled = false}. Carries {@code scope = "mfa-setup"},
+ *       NO roles. Per Marcus's hard constraint: the
+ *       {@code PlatformAuthController} MUST server-validate the scope claim
+ *       before honoring an MFA-setup request — URL-path-only enforcement is
+ *       not enough because a confused-deputy bug could replay the token at
+ *       another endpoint.</li>
+ *   <li><b>MFA-verify</b> (5 min) — issued on subsequent password auth when
+ *       {@code mfa_enabled = true}, BEFORE the operator submits the TOTP
+ *       code. Carries {@code scope = "mfa-verify"}, NO roles. Exchanged at
+ *       {@code POST /auth/platform/login/mfa-verify} for a real access
+ *       token.</li>
+ * </ul>
+ *
+ * <h2>Signature</h2>
+ *
+ * <p>HMAC-SHA256 over {@code base64url(header) + "." + base64url(payload)}.
+ * Key sourced from {@link PlatformKeyRotationService#findActiveKey()} —
+ * one active row in {@code platform_key_material}, kid in JWT header
+ * matches the row's kid.
+ *
+ * <h2>Validation order</h2>
+ *
+ * <ol>
+ *   <li>Header parse + {@code alg == "HS256"} whitelist (defends
+ *       CVE-2015-9235 family — alg=none + algorithm confusion).</li>
+ *   <li>{@code kid} present + parses as UUID-or-string; resolves against
+ *       the active row in {@code platform_key_material}. Mismatch =
+ *       {@link PlatformJwtException}.</li>
+ *   <li>Constant-time signature compare via {@link MessageDigest#isEqual}.</li>
+ *   <li>Payload parse + {@code iss == "fabt-platform"} + {@code exp} in
+ *       future.</li>
+ * </ol>
+ *
+ * <p>No claims cache here. Platform endpoints are low-traffic (operator
+ * actions, not tenant request volume); the per-request HMAC is cheap and
+ * caching adds revocation complexity for negligible benefit.
+ */
+@Service
+public class PlatformJwtService {
+
+    public static final String ISSUER = "fabt-platform";
+    public static final String ROLE_PLATFORM_OPERATOR = "PLATFORM_OPERATOR";
+
+    public static final String SCOPE_MFA_SETUP = "mfa-setup";
+    public static final String SCOPE_MFA_VERIFY = "mfa-verify";
+
+    private static final String ALGORITHM = "HmacSHA256";
+    private static final long ACCESS_TOKEN_TTL_SECONDS = 15L * 60;
+    private static final long MFA_SETUP_TOKEN_TTL_SECONDS = 10L * 60;
+    private static final long MFA_VERIFY_TOKEN_TTL_SECONDS = 5L * 60;
+
+    private final PlatformKeyRotationService keyService;
+    private final ObjectMapper objectMapper;
+
+    public PlatformJwtService(PlatformKeyRotationService keyService, ObjectMapper objectMapper) {
+        this.keyService = keyService;
+        this.objectMapper = objectMapper;
+    }
+
+    public long getAccessTokenExpirySeconds() {
+        return ACCESS_TOKEN_TTL_SECONDS;
+    }
+
+    /**
+     * Generates a full-authority access token for a platform_user that has
+     * completed MFA verification. The {@code mfaVerified=true} claim is the
+     * authoritative signal that the operator presented a valid TOTP/backup
+     * code on this login flow; downstream code may inspect it for sensitive
+     * actions that should refuse pre-MFA tokens.
+     */
+    public String generateAccessToken(PlatformUser user) {
+        Instant now = Instant.now();
+        Instant exp = now.plusSeconds(ACCESS_TOKEN_TTL_SECONDS);
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("iss", ISSUER);
+        payload.put("sub", user.getId().toString());
+        payload.put("roles", List.of(ROLE_PLATFORM_OPERATOR));
+        payload.put("mfaVerified", true);
+        payload.put("ver", 0);
+        payload.put("iat", now.getEpochSecond());
+        payload.put("exp", exp.getEpochSecond());
+        return signPlatformToken(payload);
+    }
+
+    /**
+     * Generates an MFA-setup token issued on first-password-success when
+     * the operator has not yet enrolled MFA. {@code scope = "mfa-setup"};
+     * the {@code PlatformAuthController} server-validates the scope claim
+     * before accepting MFA setup requests.
+     */
+    public String generateMfaSetupToken(PlatformUser user) {
+        return generateScopedToken(user, SCOPE_MFA_SETUP, MFA_SETUP_TOKEN_TTL_SECONDS);
+    }
+
+    /**
+     * Generates an MFA-verify token issued on subsequent-password-success
+     * before TOTP entry. {@code scope = "mfa-verify"}; the
+     * {@code PlatformAuthController} accepts this only at the
+     * {@code /auth/platform/login/mfa-verify} endpoint and only if the
+     * scope claim matches.
+     */
+    public String generateMfaVerifyToken(PlatformUser user) {
+        return generateScopedToken(user, SCOPE_MFA_VERIFY, MFA_VERIFY_TOKEN_TTL_SECONDS);
+    }
+
+    private String generateScopedToken(PlatformUser user, String scope, long ttlSeconds) {
+        Instant now = Instant.now();
+        Instant exp = now.plusSeconds(ttlSeconds);
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("iss", ISSUER);
+        payload.put("sub", user.getId().toString());
+        payload.put("scope", scope);
+        payload.put("iat", now.getEpochSecond());
+        payload.put("exp", exp.getEpochSecond());
+        return signPlatformToken(payload);
+    }
+
+    /**
+     * Validates a platform JWT end-to-end and returns the parsed claims.
+     * Throws {@link PlatformJwtException} on any failure — caller maps to
+     * HTTP 401.
+     */
+    public PlatformJwtClaims validateToken(String token) {
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            throw new PlatformJwtException("Invalid platform JWT format");
+        }
+
+        Map<String, Object> header;
+        try {
+            byte[] headerBytes = Base64.getUrlDecoder().decode(parts[0]);
+            header = objectMapper.readValue(headerBytes, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new PlatformJwtException("Invalid platform JWT header", e);
+        }
+        if (!"HS256".equals(header.get("alg"))) {
+            throw new PlatformJwtException(
+                    "Unsupported alg for platform JWT: " + header.get("alg"));
+        }
+
+        Object kidObj = header.get("kid");
+        if (kidObj == null) {
+            throw new PlatformJwtException("Platform JWT missing kid header");
+        }
+        String presentedKid = kidObj.toString();
+
+        PlatformKeyRotationService.ActiveKey active = keyService.findActiveKey();
+        if (!active.kid().equals(presentedKid)) {
+            throw new PlatformJwtException(
+                    "Platform JWT kid does not match active platform_key_material row");
+        }
+
+        String signingInput = parts[0] + "." + parts[1];
+        byte[] expected = hmac(active.key(), signingInput.getBytes(StandardCharsets.UTF_8));
+        byte[] actual;
+        try {
+            actual = Base64.getUrlDecoder().decode(parts[2]);
+        } catch (IllegalArgumentException e) {
+            throw new PlatformJwtException("Invalid platform JWT signature encoding", e);
+        }
+        if (!MessageDigest.isEqual(expected, actual)) {
+            throw new PlatformJwtException("Invalid platform JWT signature");
+        }
+
+        Map<String, Object> payload;
+        try {
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(parts[1]);
+            payload = objectMapper.readValue(payloadBytes, new TypeReference<>() {});
+        } catch (Exception e) {
+            throw new PlatformJwtException("Invalid platform JWT payload", e);
+        }
+
+        if (!ISSUER.equals(payload.get("iss"))) {
+            throw new PlatformJwtException(
+                    "Platform JWT iss must be " + ISSUER + ", got: " + payload.get("iss"));
+        }
+
+        Object expObj = payload.get("exp");
+        if (!(expObj instanceof Number)) {
+            throw new PlatformJwtException("Platform JWT missing exp");
+        }
+        Instant expInstant = Instant.ofEpochSecond(((Number) expObj).longValue());
+        if (Instant.now().isAfter(expInstant)) {
+            throw new PlatformJwtException("Platform JWT has expired");
+        }
+
+        UUID sub;
+        try {
+            sub = UUID.fromString((String) payload.get("sub"));
+        } catch (Exception e) {
+            throw new PlatformJwtException("Platform JWT sub is not a UUID", e);
+        }
+
+        String[] roles = null;
+        Object rolesObj = payload.get("roles");
+        if (rolesObj instanceof List<?> rolesList) {
+            roles = rolesList.stream().map(Object::toString).toArray(String[]::new);
+        }
+        boolean mfaVerified = Boolean.TRUE.equals(payload.get("mfaVerified"));
+        String scope = payload.get("scope") instanceof String s ? s : null;
+        Instant iat = payload.get("iat") instanceof Number n
+                ? Instant.ofEpochSecond(n.longValue()) : null;
+        return new PlatformJwtClaims(sub, roles, mfaVerified, scope, iat, expInstant);
+    }
+
+    private String signPlatformToken(Map<String, Object> payload) {
+        PlatformKeyRotationService.ActiveKey active = keyService.findActiveKey();
+        try {
+            Map<String, String> header = new LinkedHashMap<>();
+            header.put("alg", "HS256");
+            header.put("typ", "JWT");
+            header.put("kid", active.kid());
+
+            String headerJson = objectMapper.writeValueAsString(header);
+            String payloadJson = objectMapper.writeValueAsString(payload);
+            String headerEncoded = base64UrlEncode(headerJson.getBytes(StandardCharsets.UTF_8));
+            String payloadEncoded = base64UrlEncode(payloadJson.getBytes(StandardCharsets.UTF_8));
+
+            String signingInput = headerEncoded + "." + payloadEncoded;
+            byte[] sig = hmac(active.key(), signingInput.getBytes(StandardCharsets.UTF_8));
+            return signingInput + "." + base64UrlEncode(sig);
+        } catch (Exception e) {
+            throw new IllegalStateException("Failed to sign platform JWT", e);
+        }
+    }
+
+    private static byte[] hmac(SecretKey key, byte[] data) {
+        try {
+            Mac mac = Mac.getInstance(ALGORITHM);
+            mac.init(key);
+            return mac.doFinal(data);
+        } catch (Exception e) {
+            throw new IllegalStateException("HMAC-SHA256 computation failed", e);
+        }
+    }
+
+    private static String base64UrlEncode(byte[] data) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    /**
+     * Parsed claims from a validated platform JWT.
+     *
+     * @param sub          platform_user id
+     * @param roles        array of role names; {@code ["PLATFORM_OPERATOR"]} for access tokens, null/empty for scoped tokens
+     * @param mfaVerified  true for access tokens issued post-MFA; false / unset on scoped tokens
+     * @param scope        scope claim — {@code "mfa-setup"} or {@code "mfa-verify"} for scoped tokens, null on access tokens
+     * @param issuedAt     iat as Instant
+     * @param expiresAt    exp as Instant
+     */
+    public record PlatformJwtClaims(
+            UUID sub,
+            String[] roles,
+            boolean mfaVerified,
+            String scope,
+            Instant issuedAt,
+            Instant expiresAt) {
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformKeyRotationService.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformKeyRotationService.java
@@ -1,0 +1,173 @@
+package org.fabt.auth.platform;
+
+import java.time.Duration;
+import java.util.UUID;
+
+import javax.crypto.SecretKey;
+import javax.crypto.spec.SecretKeySpec;
+
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Service;
+
+import org.fabt.shared.security.KeyDerivationService;
+
+/**
+ * Owns the {@code platform_key_material} table for the iss=fabt-platform
+ * JWT signing key (Phase G-4 / issue #141).
+ *
+ * <h2>First-boot bootstrap</h2>
+ *
+ * <p>On {@link ApplicationReadyEvent}, ensures exactly one active row exists
+ * in {@code platform_key_material}. If none does, derives a 32-byte key via
+ * {@link KeyDerivationService#derivePlatformJwtKeyBytes(UUID)} (HKDF-SHA256
+ * over the master KEK, salted by the new row id) and inserts it through the
+ * {@code platform_key_material_create_first_active} SECURITY DEFINER function
+ * — {@code fabt_app} cannot {@code INSERT} directly per the V87 REVOKE.
+ *
+ * <p>The race window between two app instances starting concurrently is
+ * handled by the partial unique index {@code platform_key_material_one_active}
+ * (V87:119): the second insert returns {@code false} and the second instance
+ * proceeds with whatever the first wrote.
+ *
+ * <h2>JWT-time read path</h2>
+ *
+ * <p>{@link #findActiveKey()} returns the active row for use by the platform
+ * JWT signer / verifier. Reads go through plain {@code SELECT} — V87 grants
+ * {@code SELECT} on the table to {@code fabt_app} (write privileges are
+ * revoked, so no SECURITY DEFINER wrap is needed for reads).
+ *
+ * <h2>Rotation</h2>
+ *
+ * <p>v0.53 ships single-generation. Future rotation tooling will mint a new
+ * row with {@code generation=N+1, active=true} and flip the previous row to
+ * {@code active=false} inside one transaction; the unique index prevents
+ * two-active states. Manual break-glass procedure is documented in the
+ * runbook.
+ */
+@Service
+public class PlatformKeyRotationService {
+
+    private static final Logger log = LoggerFactory.getLogger(PlatformKeyRotationService.class);
+
+    private static final String CACHE_KEY = "active";
+
+    private final JdbcTemplate jdbc;
+    private final KeyDerivationService keyDerivationService;
+
+    /**
+     * Caches the single active row so platform JWT sign + verify don't
+     * round-trip the DB on every call (warroom A2). 5-minute TTL is short
+     * enough that a manual rotation (operator UPDATEs the table) is picked
+     * up within ~5 min without an explicit invalidation API; the bootstrap
+     * path also evicts on insert. Bounded at 1 entry — this is a single-row
+     * cache, not a multi-key map.
+     */
+    @org.fabt.shared.security.TenantUnscopedCache("Platform JWT signing key — exactly one active row, no tenant scope")
+    private final Cache<String, ActiveKey> activeKeyCache = Caffeine.newBuilder()
+            .maximumSize(1)
+            .expireAfterWrite(Duration.ofMinutes(5))
+            .build();
+
+    public PlatformKeyRotationService(JdbcTemplate jdbc, KeyDerivationService keyDerivationService) {
+        this.jdbc = jdbc;
+        this.keyDerivationService = keyDerivationService;
+    }
+
+    /**
+     * First-boot bootstrap. Idempotent — a no-op when an active row already
+     * exists. Called once per app start via {@link ApplicationReadyEvent}.
+     *
+     * <p>Deliberately INFO-level on success so ops can grep deploy logs for
+     * the canonical "PLATFORM_KEY_BOOTSTRAPPED" string when verifying a
+     * fresh-cluster deploy.
+     */
+    @EventListener(ApplicationReadyEvent.class)
+    public void ensureActiveKey() {
+        Integer activeCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM platform_key_material WHERE active = true",
+                Integer.class);
+        if (activeCount != null && activeCount > 0) {
+            log.debug("platform_key_material: active row present, skipping bootstrap");
+            return;
+        }
+
+        UUID keyId = UUID.randomUUID();
+        String kid = UUID.randomUUID().toString();
+        byte[] keyBytes = keyDerivationService.derivePlatformJwtKeyBytes(keyId);
+
+        Boolean inserted = jdbc.queryForObject(
+                "SELECT platform_key_material_create_first_active(?, ?, ?)",
+                Boolean.class, keyId, kid, keyBytes);
+
+        if (Boolean.TRUE.equals(inserted)) {
+            log.info("PLATFORM_KEY_BOOTSTRAPPED keyId={} kid={} generation=1 — "
+                    + "subsequent iss=fabt-platform JWTs will sign with this key",
+                    keyId, kid);
+        } else {
+            log.info("platform_key_material: another instance won the bootstrap race; "
+                    + "active row already in place");
+        }
+        // Either path may have changed the active row from this JVM's
+        // viewpoint — evict so the next read hits the new state.
+        activeKeyCache.invalidateAll();
+    }
+
+    /**
+     * Reads the single active row from {@code platform_key_material}.
+     *
+     * @throws IllegalStateException if no active row exists. The bootstrap
+     *     event listener runs at startup; an empty result here means either
+     *     (a) startup never completed or (b) the row was manually deleted —
+     *     both are operational incidents, not normal-flow conditions.
+     */
+    public ActiveKey findActiveKey() {
+        ActiveKey cached = activeKeyCache.getIfPresent(CACHE_KEY);
+        if (cached != null) {
+            return cached;
+        }
+        ActiveKey loaded = loadActiveKey();
+        activeKeyCache.put(CACHE_KEY, loaded);
+        return loaded;
+    }
+
+    private ActiveKey loadActiveKey() {
+        try {
+            return jdbc.queryForObject(
+                    "SELECT id, generation, kid, key_bytes "
+                            + "FROM platform_key_material WHERE active = true",
+                    (rs, rowNum) -> new ActiveKey(
+                            (UUID) rs.getObject("id"),
+                            rs.getInt("generation"),
+                            rs.getString("kid"),
+                            new SecretKeySpec(rs.getBytes("key_bytes"), "HmacSHA256")));
+        } catch (EmptyResultDataAccessException e) {
+            throw new IllegalStateException(
+                    "No active row in platform_key_material — bootstrap should have run "
+                            + "at startup. Investigate app startup logs.", e);
+        }
+    }
+
+    /**
+     * Test-visible cache reset hook. Production code does not call this —
+     * the bootstrap path evicts on insert and the 5-min TTL handles
+     * operator-initiated rotation within an acceptable window.
+     */
+    void invalidateCacheForTest() {
+        activeKeyCache.invalidateAll();
+    }
+
+    /**
+     * Active platform JWT signing key as returned to JWT signer / verifier.
+     * The {@code key} is bound to {@code HmacSHA256} (the platform JWT alg).
+     */
+    public record ActiveKey(UUID id, int generation, String kid, SecretKey key) {
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformLockoutCronJob.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformLockoutCronJob.java
@@ -1,0 +1,54 @@
+package org.fabt.auth.platform;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.fabt.auth.platform.repository.PlatformUserRepository;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Periodically clears expired auto-lockouts on {@code platform_user} rows
+ * whose {@code locked_out_at} has aged past the lockout window.
+ *
+ * <p>Without this cron, an operator who triggers the 5-fail/15-min lockout
+ * stays locked forever — bug, not feature (warroom C2). Runs every 60s,
+ * which is fine-grained enough that a recovering operator's wait is bounded
+ * by ~16 min worst case (15 min lockout window + up to 60s for the next
+ * cron tick).
+ *
+ * <p>Skipped under the {@code test} profile to keep
+ * {@code SpringBootTest} integration runs deterministic (cron interference
+ * with explicit lockout assertions in {@code PlatformAuthIntegrationTest}
+ * would produce flakes). Tests that need to exercise the unlock path call
+ * {@link PlatformUserRepository#unlockExpired(int)} directly.
+ *
+ * <p>Calls {@code platform_user_unlock_expired(15)} which UPDATEs
+ * matching rows in one statement (partial-indexed scan). At platform-user
+ * scale (1-100 rows ever) this is sub-millisecond; the hot-path concern
+ * here is correctness of the predicate, not throughput.
+ */
+@Component
+@ConditionalOnProperty(name = "fabt.platform.lockout-cron.enabled", havingValue = "true",
+        matchIfMissing = true)
+public class PlatformLockoutCronJob {
+
+    private static final Logger log = LoggerFactory.getLogger(PlatformLockoutCronJob.class);
+
+    /** Mirrors {@link PlatformAuthService#LOCKOUT_WINDOW_MIN}. */
+    private static final int LOCKOUT_WINDOW_MIN = 15;
+
+    private final PlatformUserRepository userRepository;
+
+    public PlatformLockoutCronJob(PlatformUserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Scheduled(fixedRate = 60_000)
+    public void unlockExpired() {
+        int unlocked = userRepository.unlockExpired(LOCKOUT_WINDOW_MIN);
+        if (unlocked > 0) {
+            log.info("Platform lockout cron: unlocked {} expired row(s)", unlocked);
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformUser.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformUser.java
@@ -1,0 +1,134 @@
+package org.fabt.auth.platform;
+
+import java.time.Instant;
+import java.util.UUID;
+
+/**
+ * Platform operator identity (Phase G-4 / issue #141).
+ *
+ * <p>Distinct from {@link org.fabt.auth.domain.User} — no {@code tenantId}
+ * field, separate authentication surface. Backed by the {@code platform_user}
+ * table created in V87, accessed exclusively via SECURITY DEFINER functions
+ * because {@code fabt_app} has REVOKE ALL on the underlying table.
+ *
+ * <p>Plain POJO (no Spring Data JDBC {@code @Table} annotation) — the
+ * SECURITY DEFINER access pattern means we never SELECT against the table
+ * directly; {@link PlatformUserRepository} maps function results to this
+ * type explicitly.
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>The bootstrap row created in V87 has all credential fields NULL and
+ * {@code accountLocked = true}. Operator activation (post-deploy) sets
+ * {@code email}, {@code passwordHash}, and flips {@code accountLocked = false}.
+ * First successful password authentication returns an MFA-setup-only token
+ * (10 min expiry); operator scans QR + 10 backup codes; confirms TOTP code;
+ * {@code mfaEnabled} flips to true. Subsequent logins require TOTP/backup-code
+ * verification before issuing a full platform JWT.
+ *
+ * <h2>Anonymization (GDPR Art-17)</h2>
+ *
+ * <p>{@code anonymizedAt} non-null marks a row as logically deleted. Rows
+ * are kept (audit FK constraints) but excluded from authentication lookups
+ * by the SECURITY DEFINER functions' WHERE clauses. Tooling Phase H+.
+ */
+public class PlatformUser {
+
+    private UUID id;
+    private String email;
+    private String passwordHash;
+    private String mfaSecret;
+    private boolean mfaEnabled;
+    private boolean accountLocked;
+    private Instant createdAt;
+    private Instant lastLoginAt;
+    private Instant anonymizedAt;
+
+    public PlatformUser() {
+    }
+
+    public UUID getId() {
+        return id;
+    }
+
+    public void setId(UUID id) {
+        this.id = id;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPasswordHash() {
+        return passwordHash;
+    }
+
+    public void setPasswordHash(String passwordHash) {
+        this.passwordHash = passwordHash;
+    }
+
+    public String getMfaSecret() {
+        return mfaSecret;
+    }
+
+    public void setMfaSecret(String mfaSecret) {
+        this.mfaSecret = mfaSecret;
+    }
+
+    public boolean isMfaEnabled() {
+        return mfaEnabled;
+    }
+
+    public void setMfaEnabled(boolean mfaEnabled) {
+        this.mfaEnabled = mfaEnabled;
+    }
+
+    public boolean isAccountLocked() {
+        return accountLocked;
+    }
+
+    public void setAccountLocked(boolean accountLocked) {
+        this.accountLocked = accountLocked;
+    }
+
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Instant getLastLoginAt() {
+        return lastLoginAt;
+    }
+
+    public void setLastLoginAt(Instant lastLoginAt) {
+        this.lastLoginAt = lastLoginAt;
+    }
+
+    public Instant getAnonymizedAt() {
+        return anonymizedAt;
+    }
+
+    public void setAnonymizedAt(Instant anonymizedAt) {
+        this.anonymizedAt = anonymizedAt;
+    }
+
+    /**
+     * Whether this row is in a state that permits login. Both flags must be
+     * favorable: account unlocked AND password is set AND not anonymized.
+     * MFA-enabled vs not is handled separately at the auth flow level
+     * (mfaEnabled=false triggers forced-MFA-setup flow on next login).
+     */
+    public boolean isLoginAllowed() {
+        return !accountLocked
+                && passwordHash != null
+                && !passwordHash.isBlank()
+                && anonymizedAt == null;
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/api/PlatformAuthController.java
+++ b/backend/src/main/java/org/fabt/auth/platform/api/PlatformAuthController.java
@@ -1,0 +1,134 @@
+package org.fabt.auth.platform.api;
+
+import java.util.Map;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+
+import org.fabt.auth.platform.PlatformAuthService;
+import org.fabt.auth.platform.PlatformJwtException;
+import org.fabt.auth.platform.PlatformJwtService;
+import org.fabt.auth.platform.PlatformUser;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST endpoints for {@code iss=fabt-platform} authentication (Phase G-4 /
+ * issue #141). Distinct path prefix ({@code /api/v1/auth/platform/}) so the
+ * iss-routed JwtDecoder dispatch in {@code SecurityConfig} (G-4.2 task 3.9)
+ * can apply platform-specific filters here without affecting the tenant
+ * {@code AuthController}.
+ *
+ * <h2>Forced-MFA-on-first-login flow</h2>
+ *
+ * <pre>
+ *   POST /login                 →  scope=mfa-setup token (10 min) | scope=mfa-verify token (5 min) | 401
+ *   POST /mfa-setup             →  TOTP secret + QR + 10 backup codes  (requires scope=mfa-setup)
+ *   POST /mfa-confirm           →  access token (15 min)               (requires scope=mfa-setup, valid TOTP)
+ *   POST /login/mfa-verify      →  access token (15 min)               (requires scope=mfa-verify, valid TOTP-or-backup)
+ * </pre>
+ *
+ * <p><b>Server-validated scope</b> (Marcus's hard constraint, design
+ * Decision 4): the {@link PlatformJwtService.PlatformJwtClaims#scope}
+ * claim is checked at the controller level on every scoped endpoint —
+ * URL-path-only enforcement is insufficient because a confused-deputy
+ * bug could replay a token at the wrong path.
+ *
+ * <p>Lockout + rate-limit (G-4.2 task 3.7-3.8) are applied as a separate
+ * layer (Spring filter / aspect) and are not visible from this controller.
+ */
+@RestController
+@RequestMapping("/api/v1/auth/platform")
+public class PlatformAuthController {
+
+    private final PlatformAuthService authService;
+    private final PlatformJwtService jwtService;
+
+    public PlatformAuthController(PlatformAuthService authService, PlatformJwtService jwtService) {
+        this.authService = authService;
+        this.jwtService = jwtService;
+    }
+
+    @PostMapping("/login")
+    public ResponseEntity<?> login(@Valid @RequestBody LoginRequest body) {
+        PlatformAuthService.LoginResult result = authService.login(body.email(), body.password());
+        return switch (result.outcome()) {
+            case MFA_SETUP_REQUIRED -> ResponseEntity.ok(Map.of(
+                    "scope", PlatformJwtService.SCOPE_MFA_SETUP,
+                    "token", jwtService.generateMfaSetupToken(result.user()),
+                    "expiresInSeconds", 600));
+            case MFA_VERIFY_REQUIRED -> ResponseEntity.ok(Map.of(
+                    "scope", PlatformJwtService.SCOPE_MFA_VERIFY,
+                    "token", jwtService.generateMfaVerifyToken(result.user()),
+                    "expiresInSeconds", 300));
+            case REJECTED -> ResponseEntity.status(401)
+                    .body(Map.of("error", "invalid_credentials"));
+        };
+    }
+
+    @PostMapping("/mfa-setup")
+    public ResponseEntity<?> mfaSetup(@RequestHeader("Authorization") String authHeader) {
+        PlatformJwtService.PlatformJwtClaims claims = requireScopedToken(
+                authHeader, PlatformJwtService.SCOPE_MFA_SETUP);
+        PlatformAuthService.MfaSetup setup = authService.setupMfa(claims.sub());
+        return ResponseEntity.ok(Map.of(
+                "secret", setup.secret(),
+                "qrUri", setup.qrUri(),
+                "backupCodes", setup.plaintextBackupCodes()));
+    }
+
+    @PostMapping("/mfa-confirm")
+    public ResponseEntity<?> mfaConfirm(@RequestHeader("Authorization") String authHeader,
+                                         @Valid @RequestBody CodeRequest body) {
+        PlatformJwtService.PlatformJwtClaims claims = requireScopedToken(
+                authHeader, PlatformJwtService.SCOPE_MFA_SETUP);
+        if (!authService.confirmMfaSetup(claims.sub(), body.code())) {
+            return ResponseEntity.status(401)
+                    .body(Map.of("error", "invalid_totp_code"));
+        }
+        PlatformUser user = authService.lookupForToken(claims.sub());
+        return ResponseEntity.ok(Map.of(
+                "token", jwtService.generateAccessToken(user),
+                "expiresInSeconds", jwtService.getAccessTokenExpirySeconds()));
+    }
+
+    @PostMapping("/login/mfa-verify")
+    public ResponseEntity<?> mfaVerify(@RequestHeader("Authorization") String authHeader,
+                                        @Valid @RequestBody CodeRequest body) {
+        PlatformJwtService.PlatformJwtClaims claims = requireScopedToken(
+                authHeader, PlatformJwtService.SCOPE_MFA_VERIFY);
+        if (!authService.verifyMfa(claims.sub(), body.code())) {
+            return ResponseEntity.status(401)
+                    .body(Map.of("error", "invalid_mfa_code"));
+        }
+        PlatformUser user = authService.lookupForToken(claims.sub());
+        return ResponseEntity.ok(Map.of(
+                "token", jwtService.generateAccessToken(user),
+                "expiresInSeconds", jwtService.getAccessTokenExpirySeconds()));
+    }
+
+    private PlatformJwtService.PlatformJwtClaims requireScopedToken(String authHeader,
+                                                                     String requiredScope) {
+        if (authHeader == null || !authHeader.startsWith("Bearer ")) {
+            throw new PlatformJwtException("Missing or malformed Authorization header");
+        }
+        String token = authHeader.substring("Bearer ".length()).trim();
+        PlatformJwtService.PlatformJwtClaims claims = jwtService.validateToken(token);
+        if (!requiredScope.equals(claims.scope())) {
+            throw new PlatformJwtException(
+                    "Token scope mismatch: required=" + requiredScope
+                            + ", presented=" + claims.scope());
+        }
+        return claims;
+    }
+
+    public record LoginRequest(@NotBlank String email, @NotBlank String password) {
+    }
+
+    public record CodeRequest(@NotBlank String code) {
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/repository/PlatformUserRepository.java
+++ b/backend/src/main/java/org/fabt/auth/platform/repository/PlatformUserRepository.java
@@ -1,0 +1,243 @@
+package org.fabt.auth.platform.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.fabt.auth.platform.PlatformUser;
+import org.springframework.dao.EmptyResultDataAccessException;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data-style repository for {@link PlatformUser}, but implemented as
+ * a regular {@code @Repository} bean (NOT a {@code CrudRepository}) because
+ * the V87 migration REVOKEs direct table access from {@code fabt_app}. All
+ * reads/writes go through SECURITY DEFINER functions which carry the
+ * elevated privileges needed to read/write {@code platform_user}.
+ *
+ * <p>This pattern matches the Phase G-1 {@code tenant_audit_chain_head}
+ * access path: REVOKE ALL on the table; SECURITY DEFINER function in V87
+ * defines what {@code fabt_app} can do; service layer calls the function.
+ *
+ * <p>Backup codes are stored as {@code SHA-256(salt || code)} per design
+ * Decision 12 — bcrypt's slow-compare provides no benefit for random
+ * single-use codes and adds latency during recovery.
+ */
+@Repository
+public class PlatformUserRepository {
+
+    private static final RowMapper<PlatformUser> LOOKUP_MAPPER = (rs, rowNum) -> {
+        PlatformUser pu = new PlatformUser();
+        pu.setId((UUID) rs.getObject("id"));
+        pu.setEmail(rs.getString("email"));
+        pu.setPasswordHash(rs.getString("password_hash"));
+        pu.setMfaSecret(rs.getString("mfa_secret"));
+        pu.setMfaEnabled(rs.getBoolean("mfa_enabled"));
+        pu.setAccountLocked(rs.getBoolean("account_locked"));
+        return pu;
+    };
+
+    private final JdbcTemplate jdbc;
+
+    public PlatformUserRepository(JdbcTemplate jdbc) {
+        this.jdbc = jdbc;
+    }
+
+    /**
+     * Look up a platform_user by email. Returns empty if not found OR if the
+     * row is anonymized (the SECURITY DEFINER function filters out
+     * {@code anonymized_at IS NOT NULL} rows server-side).
+     */
+    public Optional<PlatformUser> findByEmail(String email) {
+        try {
+            PlatformUser pu = jdbc.queryForObject(
+                    "SELECT * FROM platform_user_lookup_by_email(?)",
+                    LOOKUP_MAPPER, email);
+            return Optional.ofNullable(pu);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Look up a platform_user by id. Returns empty if not found or anonymized.
+     */
+    public Optional<PlatformUser> findById(UUID id) {
+        try {
+            PlatformUser pu = jdbc.queryForObject(
+                    "SELECT * FROM platform_user_lookup_by_id(?)",
+                    LOOKUP_MAPPER, id);
+            return Optional.ofNullable(pu);
+        } catch (EmptyResultDataAccessException e) {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Update credential-related fields on a platform_user row. Each parameter
+     * is independently nullable — passing {@code null} for a field leaves
+     * the existing value unchanged (handled by the SECURITY DEFINER function
+     * via COALESCE). Returns true if a row was updated, false otherwise
+     * (e.g., id not found, or row anonymized).
+     */
+    public boolean updateCredentials(UUID id,
+                                     String passwordHash,
+                                     String mfaSecret,
+                                     Boolean mfaEnabled,
+                                     Boolean accountLocked) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT platform_user_update_credentials(?, ?, ?, ?, ?)",
+                Boolean.class,
+                id, passwordHash, mfaSecret, mfaEnabled, accountLocked);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /**
+     * Record a successful login on the platform_user row by setting
+     * {@code last_login_at = NOW()}.
+     *
+     * <p>Implementation note: {@code SELECT void_func(?)} returns an empty
+     * result set in PG-JDBC, which {@code jdbc.update} rejects with
+     * "A result was returned when none was expected." We use
+     * {@code queryForObject} and discard the (always-NULL) value instead.
+     */
+    public void recordLogin(UUID id) {
+        jdbc.queryForObject("SELECT platform_user_record_login(?)", Object.class, id);
+    }
+
+    /**
+     * Return all unused (used_at IS NULL) backup codes for a platform user.
+     * The function-side filter on {@code used_at IS NULL} means callers
+     * never see consumed codes.
+     */
+    public List<BackupCodeRow> findUnusedBackupCodes(UUID userId) {
+        List<BackupCodeRow> rows = new ArrayList<>();
+        jdbc.query(
+                "SELECT * FROM platform_user_backup_codes_for(?)",
+                rs -> {
+                    BackupCodeRow row = new BackupCodeRow(
+                            (UUID) rs.getObject("id"),
+                            rs.getString("code_hash"),
+                            rs.getBytes("code_salt"));
+                    rows.add(row);
+                },
+                userId);
+        return rows;
+    }
+
+    /**
+     * Mark a backup code as used. Returns true if the row existed and was
+     * not already consumed; false otherwise.
+     */
+    public boolean markBackupCodeUsed(UUID codeId) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT platform_user_mark_backup_code_used(?)",
+                Boolean.class, codeId);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /**
+     * Replace the user's backup-code set with the supplied 10 codes. The
+     * SECURITY DEFINER function DELETEs any existing rows for this user
+     * before inserting, so this is the canonical "regenerate codes"
+     * primitive too.
+     */
+    public int replaceBackupCodes(UUID userId,
+                                  UUID[] ids,
+                                  String[] hashes,
+                                  byte[][] salts) {
+        Integer result = jdbc.queryForObject(
+                "SELECT platform_user_insert_backup_codes(?, ?, ?, ?)",
+                Integer.class,
+                userId, ids, hashes, salts);
+        return result != null ? result : 0;
+    }
+
+    /**
+     * Atomic MFA enrollment in a single SECURITY DEFINER call (warroom A1).
+     * Sets {@code mfa_secret} and replaces backup codes in one server-side
+     * transaction so a partial failure cannot leave a TOTP secret without
+     * recovery codes. Returns false if the user is already enrolled
+     * ({@code mfa_enabled = true}) — the caller should treat that as a
+     * stale-token-replay attempt and refuse the operation.
+     */
+    public boolean setupMfaAtomic(UUID userId,
+                                   String secret,
+                                   UUID[] ids,
+                                   String[] hashes,
+                                   byte[][] salts) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT platform_user_setup_mfa(?, ?, ?, ?, ?)",
+                Boolean.class,
+                userId, secret, ids, hashes, salts);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /**
+     * Records a failed login/MFA attempt and auto-locks the account if the
+     * threshold is met within the rolling window. Returns true iff THIS
+     * call triggered the lockout transition (so the service can emit a
+     * single PLATFORM_USER_LOCKED_OUT log line under concurrent failures).
+     */
+    public boolean recordFailure(UUID userId, int windowMin, int threshold) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT platform_user_record_failure(?, ?, ?)",
+                Boolean.class,
+                userId, windowMin, threshold);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /** Clears the failure window on a successful authentication. */
+    public void clearFailures(UUID userId) {
+        // queryForObject (not update) for void-returning SELECT — see recordLogin.
+        jdbc.queryForObject("SELECT platform_user_clear_failures(?)", Object.class, userId);
+    }
+
+    /**
+     * Cron-callable: unlocks every row whose {@code locked_out_at} has
+     * aged past the supplied window. Returns the count of rows unlocked
+     * (for ops visibility / metrics).
+     */
+    public int unlockExpired(int windowMin) {
+        Integer result = jdbc.queryForObject(
+                "SELECT platform_user_unlock_expired(?)",
+                Integer.class, windowMin);
+        return result != null ? result : 0;
+    }
+
+    /**
+     * Records that a TOTP code was just accepted (warroom M1). The caller
+     * uses {@link #wasTotpRecentlyUsed(UUID, String, int)} on the next
+     * verify to reject replay within the 89-second RFC 6238 window.
+     */
+    public void recordTotpUse(UUID userId, String code) {
+        // queryForObject (not update) for void-returning SELECT — see recordLogin.
+        jdbc.queryForObject(
+                "SELECT platform_user_record_totp_use(?, ?)",
+                Object.class, userId, code);
+    }
+
+    /**
+     * Returns true if the presented code matches the most-recently-used
+     * code AND was used within {@code windowSeconds}. Replay-protection
+     * gate per warroom M1.
+     */
+    public boolean wasTotpRecentlyUsed(UUID userId, String code, int windowSeconds) {
+        Boolean result = jdbc.queryForObject(
+                "SELECT platform_user_was_totp_recently_used(?, ?, ?)",
+                Boolean.class,
+                userId, code, windowSeconds);
+        return Boolean.TRUE.equals(result);
+    }
+
+    /**
+     * Backup code row as returned by {@code platform_user_backup_codes_for}.
+     * Used by the auth flow to verify a presented code: hash the candidate
+     * with the row's salt, compare to {@code codeHash}.
+     */
+    public record BackupCodeRow(UUID id, String codeHash, byte[] codeSalt) {
+    }
+}

--- a/backend/src/main/java/org/fabt/cli/HashPasswordCli.java
+++ b/backend/src/main/java/org/fabt/cli/HashPasswordCli.java
@@ -1,0 +1,110 @@
+package org.fabt.cli;
+
+import java.io.Console;
+import java.util.Arrays;
+
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+/**
+ * Bootstrap-activation CLI for platform_user accounts. Prompts for a
+ * password (interactive, no echo via {@link Console#readPassword()}),
+ * validates strength, and prints a bcrypt-12 hash that the operator
+ * pastes into a {@code psql UPDATE} on the V87 bootstrap row.
+ *
+ * <h2>Invocation</h2>
+ *
+ * <p>Per design Decision 8, the CLI was originally specified to ship as
+ * a separate Maven module producing {@code fabt-cli.jar}. The single-module
+ * project layout (one {@code pom.xml} under {@code backend/}) makes that
+ * a multi-module restructure that's out of scope for the v0.53 slice.
+ * Deferred to design follow-up F4. Interim ops invocation:
+ *
+ * <pre>
+ *   # Inside the running container (simplest path):
+ *   docker exec -it fabt-backend java \
+ *       -cp /app/app.jar \
+ *       -Dloader.main=org.fabt.cli.HashPasswordCli \
+ *       org.springframework.boot.loader.launch.PropertiesLauncher
+ *
+ *   # Or via htpasswd as a Spring-Security-compatible alternative:
+ *   htpasswd -bnBC 12 "" "&lt;your-password&gt;" \
+ *       | tr -d ':\n' \
+ *       | sed 's/^\$2y/\$2a/'
+ * </pre>
+ *
+ * <h2>Strength policy</h2>
+ *
+ * <p>Operator passwords MUST be at least 16 characters. The platform-
+ * operator account class is the highest-value identity in FABT (suspend
+ * tenants, hard-delete via crypto-shred). 16 chars is the floor; the
+ * runbook recommends a passphrase from a passphrase generator, not a
+ * hand-crafted password.
+ *
+ * <h2>Output</h2>
+ *
+ * <p>Prints the bcrypt-12 hash to STDOUT, single line, no trailing
+ * whitespace. Exits 0 on success, 1 on validation failure (length,
+ * confirmation mismatch). On non-interactive STDIN ({@code Console}
+ * unavailable) exits 2 with a message — refuses to read passwords
+ * from an unsafe source.
+ */
+public final class HashPasswordCli {
+
+    private static final int MIN_LENGTH = 16;
+    private static final int BCRYPT_COST = 12;
+
+    private HashPasswordCli() {
+    }
+
+    public static void main(String[] args) {
+        if (Arrays.asList(args).contains("--help") || Arrays.asList(args).contains("-h")) {
+            System.out.println("hash-password — generates a bcrypt-12 hash for a platform_user");
+            System.out.println("Usage: java -cp app.jar [-Dloader.main=...] org.fabt.cli.HashPasswordCli");
+            System.out.println("Reads password interactively from System.console().");
+            System.out.println("Validates min " + MIN_LENGTH + " chars + confirmation match.");
+            System.exit(0);
+        }
+        if (Arrays.asList(args).contains("--version")) {
+            System.out.println("fabt hash-password CLI v0.53.0");
+            System.exit(0);
+        }
+
+        Console console = System.console();
+        if (console == null) {
+            System.err.println(
+                    "ERROR: System.console() unavailable — refuses to read password from non-tty source.");
+            System.err.println("Run interactively from a terminal (no piping, no nohup).");
+            System.exit(2);
+            return;
+        }
+
+        char[] first = console.readPassword("Enter platform_user password: ");
+        if (first == null || first.length < MIN_LENGTH) {
+            System.err.println("ERROR: password must be at least " + MIN_LENGTH + " characters.");
+            zero(first);
+            System.exit(1);
+            return;
+        }
+
+        char[] second = console.readPassword("Confirm password:            ");
+        if (second == null || !Arrays.equals(first, second)) {
+            System.err.println("ERROR: confirmation did not match.");
+            zero(first);
+            zero(second);
+            System.exit(1);
+            return;
+        }
+
+        String hash = new BCryptPasswordEncoder(BCRYPT_COST).encode(new String(first));
+        zero(first);
+        zero(second);
+
+        System.out.println(hash);
+    }
+
+    private static void zero(char[] chars) {
+        if (chars != null) {
+            Arrays.fill(chars, '\0');
+        }
+    }
+}

--- a/backend/src/main/java/org/fabt/shared/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/org/fabt/shared/security/JwtAuthenticationFilter.java
@@ -2,19 +2,28 @@ package org.fabt.shared.security;
 
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+
+import tools.jackson.core.type.TypeReference;
+import tools.jackson.databind.ObjectMapper;
+
 import org.fabt.auth.domain.User;
+import org.fabt.auth.platform.PlatformJwtException;
+import org.fabt.auth.platform.PlatformJwtService;
 import org.fabt.auth.repository.UserRepository;
 import org.fabt.auth.service.JwtService;
 import org.fabt.shared.web.TenantContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -31,10 +40,29 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtService jwtService;
     private final UserRepository userRepository;
+    /**
+     * iss-routed dispatch (Phase G-4 / G-4.2 task 3.9). Optional so unit
+     * tests that don't wire the full Spring context still work — production
+     * always has it. Per design Decision 3, platform tokens go through
+     * {@link PlatformJwtService} (separate code path, not a loosened
+     * conditional in {@link JwtService}).
+     */
+    private final PlatformJwtService platformJwtService;
+    private final ObjectMapper jsonForIssPeek;
 
-    public JwtAuthenticationFilter(JwtService jwtService, UserRepository userRepository) {
+    @Autowired
+    public JwtAuthenticationFilter(JwtService jwtService, UserRepository userRepository,
+                                    PlatformJwtService platformJwtService,
+                                    ObjectMapper objectMapper) {
         this.jwtService = jwtService;
         this.userRepository = userRepository;
+        this.platformJwtService = platformJwtService;
+        this.jsonForIssPeek = objectMapper;
+    }
+
+    /** Test-only — no platform routing, behaves as pre-G-4.2. */
+    public JwtAuthenticationFilter(JwtService jwtService, UserRepository userRepository) {
+        this(jwtService, userRepository, null, null);
     }
 
     @Override
@@ -48,6 +76,19 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
         }
 
         String token = authHeader.substring(BEARER_PREFIX.length());
+
+        // ---- iss-routed dispatch (G-4.2 task 3.9) ----
+        // Peek at the iss claim BEFORE signature verify (per spec line 99-102:
+        // "validate iss BEFORE signature verification — avoid wasted compute
+        // on wrong-key signature attempts"). The peek is a routing decision,
+        // not a trust boundary; the actual security is the per-issuer
+        // validate-with-correct-key path that follows.
+        if (platformJwtService != null
+                && PlatformJwtService.ISSUER.equals(peekIssuer(token))) {
+            handlePlatformToken(token, request, response, filterChain);
+            return;
+        }
+
         UUID userId = null;
         UUID tenantId = null;
         boolean dvAccess = false;
@@ -128,6 +169,74 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             }
         } else {
             filterChain.doFilter(request, response);
+        }
+    }
+
+    /**
+     * Validates an {@code iss=fabt-platform} JWT and binds a SecurityContext
+     * for full access tokens (post-MFA, {@code roles=[PLATFORM_OPERATOR]}).
+     *
+     * <p>Scoped tokens ({@code mfa-setup}, {@code mfa-verify}) carry no
+     * roles and are NOT bound to SecurityContext here — those are consumed
+     * directly by {@code PlatformAuthController} which reads the
+     * {@code Authorization} header in-line. Letting Spring Security ignore
+     * them is the correct behavior: the controller is the only legitimate
+     * consumer.
+     *
+     * <p>Platform tokens carry NO {@code tenantId}; we therefore do NOT
+     * enter a {@link TenantContext} scope — platform actions run outside
+     * tenant scope by design (Decision 3 + 13). G-4.3's
+     * {@code PlatformAdminLogger} aspect chooses the audit row's
+     * {@code tenant_id} from method parameters, not from
+     * {@link TenantContext}.
+     */
+    private void handlePlatformToken(String token,
+                                      HttpServletRequest request,
+                                      HttpServletResponse response,
+                                      FilterChain filterChain) throws ServletException, IOException {
+        try {
+            PlatformJwtService.PlatformJwtClaims claims = platformJwtService.validateToken(token);
+            String[] roles = claims.roles();
+            if (roles != null && roles.length > 0 && claims.mfaVerified()) {
+                List<SimpleGrantedAuthority> authorities = Arrays.stream(roles)
+                        .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
+                        .toList();
+                UsernamePasswordAuthenticationToken authentication =
+                        new UsernamePasswordAuthenticationToken(claims.sub(), null, authorities);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+            // Else: scoped token (mfa-setup / mfa-verify) — controller validates
+            // in-line. Don't bind SecurityContext.
+        } catch (PlatformJwtException e) {
+            log.debug("Platform JWT rejected: {}", e.getMessage());
+            SecurityContextHolder.clearContext();
+        }
+        filterChain.doFilter(request, response);
+    }
+
+    /**
+     * Returns the {@code iss} claim from a JWT payload, or {@code null} if
+     * the token is malformed / payload not parseable. NEVER trusts the
+     * value for security decisions — the caller uses it only to route to
+     * the correct validator. The validator then verifies the signature with
+     * the issuer-appropriate key.
+     */
+    private String peekIssuer(String token) {
+        if (jsonForIssPeek == null) {
+            return null;
+        }
+        String[] parts = token.split("\\.");
+        if (parts.length != 3) {
+            return null;
+        }
+        try {
+            byte[] payloadBytes = Base64.getUrlDecoder().decode(parts[1]);
+            Map<String, Object> payload = jsonForIssPeek.readValue(
+                    payloadBytes, new TypeReference<>() {});
+            Object iss = payload.get("iss");
+            return iss instanceof String s ? s : null;
+        } catch (Exception e) {
+            return null;
         }
     }
 }

--- a/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
+++ b/backend/src/main/java/org/fabt/shared/security/KeyDerivationService.java
@@ -139,6 +139,34 @@ public class KeyDerivationService {
     }
 
     /**
+     * Derives 32 bytes of HKDF-SHA256 output for the platform JWT signing key
+     * (Phase G-4 / issue #141). Unlike per-tenant keys, platform keys are NOT
+     * derived on every request — they are derived once at first boot, stored
+     * in {@code platform_key_material.key_bytes}, and read back at request
+     * time. The derivation is parameterized on the row id so each rotation
+     * generation produces an independent key.
+     *
+     * <p>Per design Decision 3: "HKDF-derived from master KEK (NOT master KEK
+     * directly — same defense-in-depth pattern as per-tenant DEKs)." A reader
+     * of the table gets the derived bytes, never the master KEK, so a row
+     * leak does not collapse to a master-KEK leak.
+     *
+     * <p>Returns raw bytes (not a {@link SecretKey}) because the caller —
+     * {@code PlatformKeyRotationService} — needs to persist them via the
+     * {@code platform_key_material_create_first_active} SECURITY DEFINER
+     * function, which expects a {@code BYTEA} parameter.
+     */
+    public byte[] derivePlatformJwtKeyBytes(UUID keyId) {
+        if (keyId == null) {
+            throw new IllegalArgumentException("keyId must be non-null");
+        }
+        byte[] salt = uuidToBytes(keyId);
+        String context = "fabt:" + CONTEXT_VERSION + ":platform:jwt-sign:" + keyId;
+        byte[] info = context.getBytes(StandardCharsets.UTF_8);
+        return hkdfSha256(masterKekBytes, salt, info, DERIVED_KEY_LENGTH);
+    }
+
+    /**
      * Derives the per-tenant AES-KWP wrapping key used by
      * {@link TenantDekService} to wrap / unwrap random per-tenant DEKs in
      * the {@code tenant_dek} table. Per F-6.0 design (design-f6-real-

--- a/backend/src/main/resources/application.conf
+++ b/backend/src/main/resources/application.conf
@@ -73,4 +73,18 @@ caffeine.jcache {
       }
     }
   }
+
+  rate-limit-platform-login {
+    key-type = java.lang.String
+    value-type = java.lang.Object
+
+    policy {
+      eager-expiration {
+        after-write = 15m
+      }
+      maximum {
+        size = 100000
+      }
+    }
+  }
 }

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -178,6 +178,23 @@ bucket4j:
             - capacity: 10
               time: 15
               unit: minutes
+    # Per-IP password-attempt throttle on platform-operator login. Tighter
+    # than tenant /login (5 vs 10) because PLATFORM_OPERATOR is the highest-
+    # value account class — Marcus's hard constraint per design Decision 5
+    # spec line 99 ("5 requests per 15-minute window") and warroom M2.
+    # Independent of the per-account MFA-failure lockout in V88; this throttle
+    # caps password-attempt brute force, the per-account counter caps MFA-code
+    # brute force.
+    - cache-name: rate-limit-platform-login
+      url: /api/v1/auth/platform/login
+      http-response-body: '{"error":"rate_limited","message":"Too many platform login attempts. Try again later.","status":429}'
+      http-content-type: application/json
+      rate-limits:
+        - cache-key: getRemoteAddr()
+          bandwidths:
+            - capacity: 5
+              time: 15
+              unit: minutes
     - cache-name: rate-limit-password-change
       url: /api/v1/auth/password
       http-response-body: '{"error":"rate_limited","message":"Too many password change attempts. Try again later.","status":429}'

--- a/backend/src/main/resources/db/migration/V88__platform_user_lockout_columns.sql
+++ b/backend/src/main/resources/db/migration/V88__platform_user_lockout_columns.sql
@@ -1,0 +1,305 @@
+-- V88 — Phase G slice G-4.2: per-account MFA lockout state + atomic MFA
+-- enrollment + TOTP replay-protection columns on platform_user.
+--
+-- Schema additions:
+--   * failed_mfa_attempts_at  TIMESTAMPTZ[]  — recent fail timestamps,
+--                                              pruned to the active window
+--                                              on every insert
+--   * locked_out_at           TIMESTAMPTZ    — when auto-lockout fired
+--                                              (NULL = not auto-locked,
+--                                              distinguishes from the
+--                                              manual lock the bootstrap
+--                                              row carries)
+--   * last_totp_code          TEXT           — most-recently-accepted TOTP
+--                                              code, used to reject replay
+--                                              within the 89-second
+--                                              ±1-step RFC 6238 window
+--                                              (Marcus warroom M1)
+--   * last_totp_used_at       TIMESTAMPTZ    — companion to last_totp_code
+--
+-- The existing `account_locked BOOLEAN` column from V87 remains the
+-- canonical "is this account allowed to log in" flag. `locked_out_at`
+-- adds context: was this lockout from MFA-fail-counter (auto-unlock
+-- candidate) or from bootstrap / operator action (stays locked until
+-- manual intervention).
+--
+-- SECURITY DEFINER functions added: `record_failure`, `clear_failures`,
+-- `unlock_expired`, `setup_mfa` (atomic), `record_totp_use`,
+-- `was_totp_recently_used`. Mirrors the V87 access pattern — fabt_app has
+-- no direct access to platform_user, calls go through these wrappers.
+--
+-- This is V88 of the platform-admin-split-and-access-log change. The
+-- platform_admin_access_log table (originally drafted as V88 in tasks.md)
+-- moves to V89 in G-4.3 because per-account lockout requires schema that
+-- naturally lives with the auth flow that USES it.
+
+ALTER TABLE platform_user
+    ADD COLUMN failed_mfa_attempts_at TIMESTAMPTZ[] NOT NULL DEFAULT '{}',
+    ADD COLUMN locked_out_at          TIMESTAMPTZ,
+    ADD COLUMN last_totp_code         TEXT,
+    ADD COLUMN last_totp_used_at      TIMESTAMPTZ;
+
+COMMENT ON COLUMN platform_user.failed_mfa_attempts_at IS
+    'Rolling window of recent failed-MFA timestamps. Pruned on every insert by platform_user_record_failure to the threshold-window only.';
+
+COMMENT ON COLUMN platform_user.locked_out_at IS
+    'NULL = not auto-locked. Non-NULL = MFA-counter triggered lockout at this instant. Cron clears + unlocks at +15min.';
+
+COMMENT ON COLUMN platform_user.last_totp_code IS
+    'Most-recently-accepted TOTP code; used to reject replay within the 89s ±1-step RFC 6238 window.';
+
+-- Partial index supporting the cron auto-unlock query (Elena warroom E1).
+-- WHERE-clause matches the predicate in platform_user_unlock_expired.
+CREATE INDEX platform_user_locked_out_at
+    ON platform_user (locked_out_at)
+    WHERE locked_out_at IS NOT NULL;
+
+-- ---------------------------------------------------------------------------
+-- SECURITY DEFINER wrappers — V87 REVOKE on platform_user still applies.
+-- ---------------------------------------------------------------------------
+
+-- Records a failed login/MFA attempt, prunes the rolling window to last
+-- p_window_min minutes, and auto-locks if the count meets the threshold.
+-- Returns true iff THIS call triggered the lockout transition (so the
+-- service can write a single PLATFORM_USER_LOCKED_OUT audit row even under
+-- concurrent failed attempts).
+CREATE OR REPLACE FUNCTION platform_user_record_failure(
+    p_id          UUID,
+    p_window_min  INT,
+    p_threshold   INT
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+    v_recent       TIMESTAMPTZ[];
+    v_was_locked   BOOLEAN;
+    v_now_locked   BOOLEAN := false;
+BEGIN
+    -- Append NOW() then keep only those still within the rolling window.
+    UPDATE public.platform_user
+       SET failed_mfa_attempts_at = (
+            SELECT COALESCE(array_agg(t), '{}'::TIMESTAMPTZ[])
+              FROM unnest(failed_mfa_attempts_at || ARRAY[NOW()]) AS t
+             WHERE t > NOW() - make_interval(mins => p_window_min)
+       )
+     WHERE id = p_id AND anonymized_at IS NULL
+    RETURNING failed_mfa_attempts_at, account_locked
+        INTO v_recent, v_was_locked;
+
+    IF v_recent IS NULL THEN
+        -- Row not found / anonymized — no-op.
+        RETURN false;
+    END IF;
+
+    IF NOT v_was_locked
+       AND COALESCE(array_length(v_recent, 1), 0) >= p_threshold THEN
+        UPDATE public.platform_user
+           SET account_locked = true,
+               locked_out_at  = NOW()
+         WHERE id = p_id;
+        v_now_locked := true;
+    END IF;
+
+    RETURN v_now_locked;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_record_failure(UUID, INT, INT) TO fabt_app;
+
+
+-- Clears the failure window on a successful authentication.
+CREATE OR REPLACE FUNCTION platform_user_clear_failures(p_id UUID)
+RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    UPDATE public.platform_user
+       SET failed_mfa_attempts_at = '{}'::TIMESTAMPTZ[]
+     WHERE id = p_id AND anonymized_at IS NULL;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_clear_failures(UUID) TO fabt_app;
+
+
+-- Cron-callable: unlocks every row whose lockout has aged past
+-- p_window_min. Returns the count of rows unlocked, for ops visibility /
+-- metrics. Only touches rows where locked_out_at IS NOT NULL — manual
+-- locks (bootstrap row, operator-set) stay locked. Anonymized rows are
+-- filtered defensively (Elena warroom E2).
+CREATE OR REPLACE FUNCTION platform_user_unlock_expired(p_window_min INT)
+RETURNS INT
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+    v_count INT;
+BEGIN
+    UPDATE public.platform_user
+       SET account_locked         = false,
+           locked_out_at          = NULL,
+           failed_mfa_attempts_at = '{}'::TIMESTAMPTZ[]
+     WHERE locked_out_at IS NOT NULL
+       AND locked_out_at < NOW() - make_interval(mins => p_window_min)
+       AND anonymized_at IS NULL;
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    RETURN v_count;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_unlock_expired(INT) TO fabt_app;
+
+
+-- Atomic MFA enrollment in a single SECURITY DEFINER call (Alex warroom A1).
+-- Replaces the 2-call setup pattern (updateCredentials + replaceBackupCodes)
+-- so a partial failure can never leave a TOTP secret without backup codes.
+-- Refuses if the user is already enrolled (mfa_enabled = true) — guards
+-- against stale mfa-setup-token replay regenerating credentials on an
+-- enrolled account (Alex warroom A4).
+--
+-- Backup codes are passed as parallel arrays of equal length; mismatched
+-- lengths raise check_violation. The function DELETEs any pre-existing
+-- backup codes for the user (a fresh enrollment invalidates them) before
+-- inserting the new set.
+--
+-- Returns true on success, false if the user already has mfa_enabled=true
+-- (caller treats as 409 / refuse-replay).
+CREATE OR REPLACE FUNCTION platform_user_setup_mfa(
+    p_id        UUID,
+    p_secret    TEXT,
+    p_ids       UUID[],
+    p_hashes    TEXT[],
+    p_salts     BYTEA[]
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+    v_mfa_enabled BOOLEAN;
+    v_count       INT;
+BEGIN
+    SELECT mfa_enabled INTO v_mfa_enabled
+      FROM public.platform_user
+     WHERE id = p_id AND anonymized_at IS NULL;
+    IF NOT FOUND THEN
+        RETURN false;
+    END IF;
+    IF v_mfa_enabled THEN
+        RETURN false;
+    END IF;
+    IF array_length(p_ids, 1) IS DISTINCT FROM array_length(p_hashes, 1)
+       OR array_length(p_ids, 1) IS DISTINCT FROM array_length(p_salts, 1) THEN
+        RAISE EXCEPTION 'platform_user_setup_mfa: id/hash/salt array lengths differ';
+    END IF;
+
+    UPDATE public.platform_user
+       SET mfa_secret = p_secret
+     WHERE id = p_id AND anonymized_at IS NULL;
+
+    DELETE FROM public.platform_user_backup_code
+     WHERE platform_user_id = p_id;
+
+    INSERT INTO public.platform_user_backup_code
+        (id, platform_user_id, code_hash, code_salt)
+    SELECT p_ids[i], p_id, p_hashes[i], p_salts[i]
+      FROM generate_subscripts(p_ids, 1) AS i;
+
+    GET DIAGNOSTICS v_count = ROW_COUNT;
+    IF v_count <> array_length(p_ids, 1) THEN
+        RAISE EXCEPTION 'platform_user_setup_mfa: inserted % rows, expected %',
+            v_count, array_length(p_ids, 1);
+    END IF;
+    RETURN true;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_setup_mfa(UUID, TEXT, UUID[], TEXT[], BYTEA[]) TO fabt_app;
+
+
+-- Records that a TOTP code was just accepted (Marcus warroom M1).
+-- Stored alongside the timestamp so was_totp_recently_used can reject
+-- replays within the 89-second ±1-step RFC 6238 acceptance window.
+CREATE OR REPLACE FUNCTION platform_user_record_totp_use(
+    p_id    UUID,
+    p_code  TEXT
+) RETURNS VOID
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    UPDATE public.platform_user
+       SET last_totp_code    = p_code,
+           last_totp_used_at = NOW()
+     WHERE id = p_id AND anonymized_at IS NULL;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_record_totp_use(UUID, TEXT) TO fabt_app;
+
+
+-- Sets email on a platform_user row. Used by the bootstrap activation
+-- flow (operator runs the equivalent UPDATE via psql in production, but
+-- integration tests can't reach the table directly under fabt_app). Also
+-- the foundation for the Phase H+ "create new platform_user via existing
+-- operator" flow + operator self-service email change.
+CREATE OR REPLACE FUNCTION platform_user_set_email(
+    p_id    UUID,
+    p_email TEXT
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    UPDATE public.platform_user
+       SET email = p_email
+     WHERE id = p_id AND anonymized_at IS NULL;
+    RETURN FOUND;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_set_email(UUID, TEXT) TO fabt_app;
+
+
+-- Returns true if the presented code matches last_totp_code AND
+-- last_totp_used_at is within p_window_seconds of NOW(). Caller rejects
+-- replay before invoking the TOTP verifier.
+CREATE OR REPLACE FUNCTION platform_user_was_totp_recently_used(
+    p_id              UUID,
+    p_code            TEXT,
+    p_window_seconds  INT
+) RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+DECLARE
+    v_recent BOOLEAN := false;
+BEGIN
+    SELECT (last_totp_code = p_code
+            AND last_totp_used_at IS NOT NULL
+            AND last_totp_used_at > NOW() - make_interval(secs => p_window_seconds))
+      INTO v_recent
+      FROM public.platform_user
+     WHERE id = p_id AND anonymized_at IS NULL;
+    RETURN COALESCE(v_recent, false);
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_was_totp_recently_used(UUID, TEXT, INT) TO fabt_app;
+
+
+-- Defensive ownership transfer (prod only — fabt role doesn't exist in test).
+DO $$
+BEGIN
+    IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'fabt') THEN
+        ALTER FUNCTION platform_user_record_failure(UUID, INT, INT) OWNER TO fabt;
+        ALTER FUNCTION platform_user_clear_failures(UUID) OWNER TO fabt;
+        ALTER FUNCTION platform_user_unlock_expired(INT) OWNER TO fabt;
+        ALTER FUNCTION platform_user_setup_mfa(UUID, TEXT, UUID[], TEXT[], BYTEA[]) OWNER TO fabt;
+        ALTER FUNCTION platform_user_record_totp_use(UUID, TEXT) OWNER TO fabt;
+        ALTER FUNCTION platform_user_was_totp_recently_used(UUID, TEXT, INT) OWNER TO fabt;
+        ALTER FUNCTION platform_user_set_email(UUID, TEXT) OWNER TO fabt;
+    END IF;
+END
+$$;

--- a/backend/src/main/resources/db/migration/V88__platform_user_lockout_columns.sql
+++ b/backend/src/main/resources/db/migration/V88__platform_user_lockout_columns.sql
@@ -239,6 +239,42 @@ $$;
 GRANT EXECUTE ON FUNCTION platform_user_record_totp_use(UUID, TEXT) TO fabt_app;
 
 
+-- Resets a platform_user row back to the V87 bootstrap state: NULL email +
+-- credentials + MFA, account_locked=true, all V88 fail-tracking fields cleared.
+-- Two callers:
+--   1. Phase H+ recovery flow per spec line 142-146 — when an operator is
+--      locked out and the recovery runbook is followed, another platform_user
+--      can reset their account to bootstrap state for re-activation.
+--   2. Test cleanup (V87/V88 IT, PlatformAuthIntegrationTest) — ensures
+--      shared-Spring-context test classes don't leak state to each other.
+-- Bootstrap row id is preserved (PRIMARY KEY); only mutable fields reset.
+CREATE OR REPLACE FUNCTION platform_user_reset_to_bootstrap(p_id UUID)
+RETURNS BOOLEAN
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = pg_catalog
+AS $$
+BEGIN
+    UPDATE public.platform_user
+       SET email                  = NULL,
+           password_hash          = NULL,
+           mfa_secret             = NULL,
+           mfa_enabled            = false,
+           account_locked         = true,
+           failed_mfa_attempts_at = '{}'::TIMESTAMPTZ[],
+           locked_out_at          = NULL,
+           last_totp_code         = NULL,
+           last_totp_used_at      = NULL
+     WHERE id = p_id AND anonymized_at IS NULL;
+    -- Cascade-delete backup codes (V87 FK declares ON DELETE CASCADE; we
+    -- DELETE explicitly here since UPDATE doesn't trigger the cascade).
+    DELETE FROM public.platform_user_backup_code WHERE platform_user_id = p_id;
+    RETURN FOUND;
+END;
+$$;
+GRANT EXECUTE ON FUNCTION platform_user_reset_to_bootstrap(UUID) TO fabt_app;
+
+
 -- Sets email on a platform_user row. Used by the bootstrap activation
 -- flow (operator runs the equivalent UPDATE via psql in production, but
 -- integration tests can't reach the table directly under fabt_app). Also
@@ -300,6 +336,7 @@ BEGIN
         ALTER FUNCTION platform_user_record_totp_use(UUID, TEXT) OWNER TO fabt;
         ALTER FUNCTION platform_user_was_totp_recently_used(UUID, TEXT, INT) OWNER TO fabt;
         ALTER FUNCTION platform_user_set_email(UUID, TEXT) OWNER TO fabt;
+        ALTER FUNCTION platform_user_reset_to_bootstrap(UUID) OWNER TO fabt;
     END IF;
 END
 $$;

--- a/backend/src/main/resources/db/migration/V88__platform_user_lockout_columns.sql
+++ b/backend/src/main/resources/db/migration/V88__platform_user_lockout_columns.sql
@@ -248,12 +248,23 @@ GRANT EXECUTE ON FUNCTION platform_user_record_totp_use(UUID, TEXT) TO fabt_app;
 --   2. Test cleanup (V87/V88 IT, PlatformAuthIntegrationTest) — ensures
 --      shared-Spring-context test classes don't leak state to each other.
 -- Bootstrap row id is preserved (PRIMARY KEY); only mutable fields reset.
+--
+-- TODO(F5): Phase H+ caller MUST go through an authorized variant, e.g.
+-- platform_user_force_reactivate(p_target_id, p_caller_id) that checks the
+-- caller is itself an mfa-enabled, non-anonymized platform_user (matching
+-- spec line 142-146's "the OTHER platform_user can reset"). The current
+-- function is unauthorized — any code running as fabt_app can wipe ANY
+-- operator's credentials by passing their UUID. Risk is bounded today
+-- because no production caller exists; the only callers are tests. See
+-- design.md follow-up F5.
 CREATE OR REPLACE FUNCTION platform_user_reset_to_bootstrap(p_id UUID)
 RETURNS BOOLEAN
 LANGUAGE plpgsql
 SECURITY DEFINER
 SET search_path = pg_catalog
 AS $$
+DECLARE
+    v_reset BOOLEAN := false;
 BEGIN
     UPDATE public.platform_user
        SET email                  = NULL,
@@ -266,13 +277,21 @@ BEGIN
            last_totp_code         = NULL,
            last_totp_used_at      = NULL
      WHERE id = p_id AND anonymized_at IS NULL;
-    -- Cascade-delete backup codes (V87 FK declares ON DELETE CASCADE; we
-    -- DELETE explicitly here since UPDATE doesn't trigger the cascade).
-    DELETE FROM public.platform_user_backup_code WHERE platform_user_id = p_id;
-    RETURN FOUND;
+    v_reset := FOUND;
+
+    -- Only delete backup codes if the row was actually reset. Without this
+    -- guard an anonymized row's UPDATE would no-op (correct) but the DELETE
+    -- would still wipe its backup codes (incorrect — touches data the
+    -- anonymization boundary was meant to leave alone).
+    IF v_reset THEN
+        DELETE FROM public.platform_user_backup_code WHERE platform_user_id = p_id;
+    END IF;
+    RETURN v_reset;
 END;
 $$;
 GRANT EXECUTE ON FUNCTION platform_user_reset_to_bootstrap(UUID) TO fabt_app;
+COMMENT ON FUNCTION platform_user_reset_to_bootstrap(UUID) IS
+    'Resets a platform_user row to V87 bootstrap state (NULL creds, locked, MFA cleared, backup codes deleted). UNAUTHORIZED — relies on caller-side gating. Currently used only by tests + planned Phase H+ recovery flow (spec line 142-146); the prod recovery flow MUST land an authorized variant per design.md F5 before any operator-facing endpoint calls this. Do NOT call manually from psql except in incident response with explicit operator authorization.';
 
 
 -- Sets email on a platform_user row. Used by the bootstrap activation

--- a/backend/src/test/java/db/migration/V87MigrationIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V87MigrationIntegrationTest.java
@@ -142,6 +142,14 @@ class V87MigrationIntegrationTest extends BaseIntegrationTest {
     @Test
     @DisplayName("bootstrap platform_user row exists at well-known 0fab UUID, locked, no creds")
     void bootstrapRowExists() {
+        // Reset to bootstrap state first — other test classes in the shared
+        // Spring context (V88, PlatformAuthIntegrationTest) mutate this row
+        // and may run BEFORE this test depending on Surefire's class order.
+        // The reset SECURITY DEFINER function exists in V88; V87 + V88 are
+        // both applied by the time any test runs.
+        jdbc.queryForObject("SELECT platform_user_reset_to_bootstrap(?::uuid)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID);
+
         // fabt_app cannot SELECT platform_user directly (REVOKE ALL); use the
         // SECURITY DEFINER function platform_user_lookup_by_id instead.
         // Function returns a record (id, email, password_hash, mfa_secret, mfa_enabled, account_locked).

--- a/backend/src/test/java/db/migration/V87MigrationIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V87MigrationIntegrationTest.java
@@ -69,7 +69,9 @@ class V87MigrationIntegrationTest extends BaseIntegrationTest {
                 " ORDER BY a.attnum",
                 String.class);
 
-        assertThat(columnNames).containsExactlyInAnyOrder(
+        // V87 introduced these 9 columns. V88 (G-4.2) adds lockout columns
+        // — assert "contains" so V88's additions don't break this V87 pin.
+        assertThat(columnNames).contains(
                 "id", "email", "password_hash", "mfa_secret",
                 "mfa_enabled", "account_locked", "created_at",
                 "last_login_at", "anonymized_at");
@@ -184,7 +186,10 @@ class V87MigrationIntegrationTest extends BaseIntegrationTest {
                 " ORDER BY proname",
                 String.class);
 
-        assertThat(functionNames).containsExactlyInAnyOrder(
+        // V87 introduced these 8 SECURITY DEFINER functions. V88 (G-4.2)
+        // adds 6 more for lockout / atomic MFA / TOTP replay. Assert
+        // "contains" so V88's additions don't break this V87 pin.
+        assertThat(functionNames).contains(
                 "platform_key_material_create_first_active",
                 "platform_user_backup_codes_for",
                 "platform_user_insert_backup_codes",
@@ -218,39 +223,31 @@ class V87MigrationIntegrationTest extends BaseIntegrationTest {
     @Test
     @DisplayName("partial UNIQUE index permits at most one active row in platform_key_material")
     void platformKeyMaterialOneActiveEnforced() {
-        // Use the SECURITY DEFINER helper to insert a first active row.
-        UUID firstId = UUID.randomUUID();
-        Boolean firstInserted = jdbc.queryForObject(
+        // Since G-4.2, PlatformKeyRotationService.@EventListener fires on
+        // app start and inserts the first active row via the bootstrap path.
+        // By the time this test runs, the active row is already present.
+        // The function's "refuse if active row exists" branch is what we
+        // can still exercise — the original "first call succeeds" assertion
+        // is now covered by PlatformKeyRotationService's own integration
+        // (visible via PLATFORM_KEY_BOOTSTRAPPED log line + non-empty
+        // SELECT below).
+
+        Long activeRowCount = jdbc.queryForObject(
+                "SELECT COUNT(*) FROM platform_key_material WHERE active = true",
+                Long.class);
+        assertThat(activeRowCount)
+                .as("PlatformKeyRotationService bootstrap on app start should leave one active row")
+                .isEqualTo(1L);
+
+        UUID secondId = UUID.randomUUID();
+        Boolean secondInserted = jdbc.queryForObject(
                 "SELECT platform_key_material_create_first_active(?::uuid, ?, ?::bytea)",
                 Boolean.class,
-                firstId, "test-kid-" + firstId, "deadbeef".getBytes());
+                secondId, "test-kid-" + secondId, "deadbeef".getBytes());
 
-        try {
-            assertThat(firstInserted)
-                    .as("first call should succeed (no prior active row)")
-                    .isTrue();
-
-            // Second call must NOT insert because one active row already exists.
-            // Function's IF EXISTS guard returns false rather than raising.
-            UUID secondId = UUID.randomUUID();
-            Boolean secondInserted = jdbc.queryForObject(
-                    "SELECT platform_key_material_create_first_active(?::uuid, ?, ?::bytea)",
-                    Boolean.class,
-                    secondId, "test-kid-" + secondId, "deadbeef".getBytes());
-
-            assertThat(secondInserted)
-                    .as("second call must return false because an active row already exists")
-                    .isFalse();
-        } finally {
-            // Cleanup so other tests / re-runs aren't impacted. We have SELECT but
-            // not DELETE on platform_key_material — execute via a one-shot ALTER
-            // / RAW DELETE through a temporarily-elevated connection. For test
-            // isolation, this requires test-only superuser access. Since
-            // BaseIntegrationTest's JdbcTemplate is fabt_app, we cannot DELETE.
-            // Acceptable: the row stays in the test DB; subsequent test runs
-            // on the same Spring context still pass because the function returns
-            // false and no constraint is violated.
-        }
+        assertThat(secondInserted)
+                .as("function must return false because an active row already exists")
+                .isFalse();
     }
 
     // ------------------------------------------------------------------

--- a/backend/src/test/java/db/migration/V88MigrationIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V88MigrationIntegrationTest.java
@@ -56,16 +56,13 @@ class V88MigrationIntegrationTest extends BaseIntegrationTest {
 
     @AfterEach
     void restoreBootstrapRow() {
-        // Restore bootstrap row to the V87-INSERTed shape so other tests +
-        // re-runs see a consistent fixture. fabt_app cannot UPDATE platform_user
-        // directly; we route the writes through SECURITY DEFINER functions.
-        // Note: jdbc.update on `SELECT void_func()` fails — PG-JDBC returns
-        // a result set (one NULL row) which executeUpdate rejects. We use
-        // queryForObject and discard the value.
-        jdbc.queryForObject("SELECT platform_user_clear_failures(?::uuid)",
-                Object.class, BOOTSTRAP_PLATFORM_USER_ID);
-        jdbc.queryForObject("SELECT platform_user_update_credentials(?::uuid, NULL, NULL, ?, ?)",
-                Object.class, BOOTSTRAP_PLATFORM_USER_ID, false, true);
+        // Single-call restore via the reset_to_bootstrap SECURITY DEFINER
+        // function — fully reverses every mutation any test in this class
+        // could have applied (creds, MFA, lockout fields, backup codes).
+        // Critical for shared-Spring-context test runs where V87 +
+        // PlatformAuthIntegrationTest assert against bootstrap state.
+        jdbc.queryForObject("SELECT platform_user_reset_to_bootstrap(?::uuid)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID);
     }
 
     // ------------------------------------------------------------------
@@ -106,7 +103,7 @@ class V88MigrationIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("V88 adds 7 new SECURITY DEFINER functions, all EXECUTE-granted to fabt_app")
+    @DisplayName("V88 adds 8 new SECURITY DEFINER functions, all EXECUTE-granted to fabt_app")
     void securityDefinerFunctionsExist() {
         List<String> v88Functions = jdbc.queryForList(
                 "SELECT proname FROM pg_proc "
@@ -117,7 +114,8 @@ class V88MigrationIntegrationTest extends BaseIntegrationTest {
                         + "                  'platform_user_setup_mfa', "
                         + "                  'platform_user_record_totp_use', "
                         + "                  'platform_user_was_totp_recently_used', "
-                        + "                  'platform_user_set_email') "
+                        + "                  'platform_user_set_email', "
+                        + "                  'platform_user_reset_to_bootstrap') "
                         + " ORDER BY proname",
                 String.class);
 
@@ -128,7 +126,8 @@ class V88MigrationIntegrationTest extends BaseIntegrationTest {
                 "platform_user_setup_mfa",
                 "platform_user_record_totp_use",
                 "platform_user_was_totp_recently_used",
-                "platform_user_set_email");
+                "platform_user_set_email",
+                "platform_user_reset_to_bootstrap");
     }
 
     // ------------------------------------------------------------------

--- a/backend/src/test/java/db/migration/V88MigrationIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V88MigrationIntegrationTest.java
@@ -342,6 +342,96 @@ class V88MigrationIntegrationTest extends BaseIntegrationTest {
                 .isFalse();
     }
 
+    // ------------------------------------------------------------------
+    // platform_user_reset_to_bootstrap
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("reset_to_bootstrap clears every mutable field and deletes backup codes")
+    void resetToBootstrapClearsEverything() {
+        // Activate the row to a fully-populated state — every V87 + V88
+        // mutable field set to non-default — then reset and assert all
+        // are reverted. Pins the function's contract; if a future change
+        // adds a column without updating reset_to_bootstrap, this test
+        // catches it.
+        jdbc.queryForObject("SELECT platform_user_set_email(?::uuid, ?)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, "ops-reset@example.com");
+        jdbc.queryForObject(
+                "SELECT platform_user_update_credentials(?::uuid, ?, ?, ?, ?)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID,
+                "$2a$10$dummyhash", "JBSWY3DPEHPK3PXP", true, false);
+        jdbc.queryForObject("SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 99);
+        jdbc.queryForObject("SELECT platform_user_record_totp_use(?::uuid, ?)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, "654321");
+        // Insert one backup code via the V87 helper to verify the cascade-
+        // delete clears it.
+        jdbc.queryForObject(
+                "SELECT platform_user_insert_backup_codes(?::uuid, ?, ?, ?)",
+                Integer.class,
+                BOOTSTRAP_PLATFORM_USER_ID,
+                new UUID[]{UUID.randomUUID()},
+                new String[]{"hashvalue"},
+                new byte[][]{{1, 2, 3}});
+
+        // Sanity-check: at least one backup code is present pre-reset.
+        Integer codesBefore = jdbc.queryForObject(
+                "SELECT array_length(array_agg(id), 1) "
+                        + "FROM platform_user_backup_codes_for(?::uuid)",
+                Integer.class, BOOTSTRAP_PLATFORM_USER_ID);
+        assertThat(codesBefore).isNotNull().isGreaterThanOrEqualTo(1);
+
+        // Run the reset.
+        Boolean reset = jdbc.queryForObject(
+                "SELECT platform_user_reset_to_bootstrap(?::uuid)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID);
+        assertThat(reset).as("reset must report it touched the row").isTrue();
+
+        // Verify all V87 fields cleared via the SECURITY DEFINER lookup.
+        Map<String, Object> after = jdbc.queryForMap(
+                "SELECT * FROM platform_user_lookup_by_id(?::uuid)",
+                BOOTSTRAP_PLATFORM_USER_ID);
+        assertThat(after.get("email")).as("email NULL").isNull();
+        assertThat(after.get("password_hash")).as("password NULL").isNull();
+        assertThat(after.get("mfa_secret")).as("mfa_secret NULL").isNull();
+        assertThat(after.get("mfa_enabled")).as("mfa_enabled false").isEqualTo(false);
+        assertThat(after.get("account_locked")).as("account_locked true").isEqualTo(true);
+
+        // V88 lockout fields cleared. record_failure with threshold=1 should
+        // now lock immediately if any prior fail timestamps lingered — a
+        // false return here proves the failure window is empty.
+        Boolean nowLocked = jdbc.queryForObject(
+                "SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 99);
+        assertThat(nowLocked)
+                .as("after reset, fail counter is empty so threshold=99 cannot trip")
+                .isFalse();
+
+        // V88 TOTP replay-cache cleared.
+        Boolean recentReplay = jdbc.queryForObject(
+                "SELECT platform_user_was_totp_recently_used(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, "654321", 90);
+        assertThat(recentReplay)
+                .as("after reset, last_totp_used_at is NULL so replay-cache misses")
+                .isFalse();
+
+        // Backup codes deleted.
+        List<Map<String, Object>> codesAfter = jdbc.queryForList(
+                "SELECT * FROM platform_user_backup_codes_for(?::uuid)",
+                BOOTSTRAP_PLATFORM_USER_ID);
+        assertThat(codesAfter).as("backup codes wiped").isEmpty();
+    }
+
+    @Test
+    @DisplayName("reset_to_bootstrap returns false and no-ops on a non-existent userId")
+    void resetToBootstrapNonExistentRowReturnsFalse() {
+        UUID neverSeen = UUID.randomUUID();
+        Boolean reset = jdbc.queryForObject(
+                "SELECT platform_user_reset_to_bootstrap(?::uuid)",
+                Boolean.class, neverSeen);
+        assertThat(reset).isFalse();
+    }
+
     @Test
     @DisplayName("was_totp_recently_used returns false when no TOTP has been recorded yet")
     void totpNeverUsedReturnsFalse() {

--- a/backend/src/test/java/db/migration/V88MigrationIntegrationTest.java
+++ b/backend/src/test/java/db/migration/V88MigrationIntegrationTest.java
@@ -1,0 +1,364 @@
+package db.migration;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.Application;
+import org.fabt.BaseIntegrationTest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * Integration test for V88 (platform-admin-split-and-access-log G-4.2):
+ * per-account MFA lockout columns + atomic MFA enrollment + TOTP replay
+ * protection.
+ *
+ * <p>Pins the schema and SECURITY DEFINER function semantics that the
+ * G-4.2 service layer depends on:
+ *
+ * <ul>
+ *   <li>4 new columns on {@code platform_user}</li>
+ *   <li>Partial index on {@code locked_out_at} (warroom Elena E1)</li>
+ *   <li>6 new SECURITY DEFINER functions exist with EXECUTE granted</li>
+ *   <li>{@code platform_user_record_failure} threshold + window semantics</li>
+ *   <li>{@code platform_user_clear_failures} clears the rolling array</li>
+ *   <li>{@code platform_user_unlock_expired} only unlocks past-window rows</li>
+ *   <li>{@code platform_user_setup_mfa} atomic / refuses re-enrollment</li>
+ *   <li>{@code platform_user_record_totp_use} +
+ *       {@code platform_user_was_totp_recently_used} round-trip</li>
+ * </ul>
+ *
+ * <p>All write tests target the V87 bootstrap row at the well-known
+ * {@code 0fab} UUID — fabt_app cannot INSERT into platform_user (REVOKE
+ * ALL), so reusing the bootstrap row is the only path to write-side
+ * coverage as the test JdbcTemplate role. Each test restores the state
+ * via {@link #restoreBootstrapRow()} in {@code @AfterEach} so concurrent
+ * test classes (sharing the Spring context's DataSource) see a
+ * predictable starting state.
+ */
+@DisplayName("V88 platform_user lockout + atomic MFA + TOTP replay")
+@SpringBootTest(classes = Application.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class V88MigrationIntegrationTest extends BaseIntegrationTest {
+
+    private static final UUID BOOTSTRAP_PLATFORM_USER_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000fab");
+
+    @Autowired private JdbcTemplate jdbc;
+
+    @AfterEach
+    void restoreBootstrapRow() {
+        // Restore bootstrap row to the V87-INSERTed shape so other tests +
+        // re-runs see a consistent fixture. fabt_app cannot UPDATE platform_user
+        // directly; we route the writes through SECURITY DEFINER functions.
+        // Note: jdbc.update on `SELECT void_func()` fails — PG-JDBC returns
+        // a result set (one NULL row) which executeUpdate rejects. We use
+        // queryForObject and discard the value.
+        jdbc.queryForObject("SELECT platform_user_clear_failures(?::uuid)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID);
+        jdbc.queryForObject("SELECT platform_user_update_credentials(?::uuid, NULL, NULL, ?, ?)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, false, true);
+    }
+
+    // ------------------------------------------------------------------
+    // Schema shape
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("V88 adds failed_mfa_attempts_at, locked_out_at, last_totp_code, last_totp_used_at")
+    void newColumnsPresent() {
+        List<String> columnNames = jdbc.queryForList(
+                "SELECT a.attname FROM pg_attribute a "
+                        + "  JOIN pg_class c ON c.oid = a.attrelid "
+                        + "  JOIN pg_namespace n ON n.oid = c.relnamespace "
+                        + " WHERE n.nspname = 'public' AND c.relname = 'platform_user' "
+                        + "   AND a.attnum > 0 AND NOT a.attisdropped",
+                String.class);
+
+        assertThat(columnNames).contains(
+                "failed_mfa_attempts_at",
+                "locked_out_at",
+                "last_totp_code",
+                "last_totp_used_at");
+    }
+
+    @Test
+    @DisplayName("partial index platform_user_locked_out_at exists with WHERE locked_out_at IS NOT NULL")
+    void partialIndexOnLockedOutAt() {
+        String indexdef = jdbc.queryForObject(
+                "SELECT indexdef FROM pg_indexes "
+                        + " WHERE schemaname = 'public' "
+                        + "   AND indexname = 'platform_user_locked_out_at'",
+                String.class);
+
+        assertThat(indexdef)
+                .as("partial index lets the cron query do an index scan rather than seq scan")
+                .containsIgnoringCase("locked_out_at")
+                .containsIgnoringCase("WHERE (locked_out_at IS NOT NULL)");
+    }
+
+    @Test
+    @DisplayName("V88 adds 7 new SECURITY DEFINER functions, all EXECUTE-granted to fabt_app")
+    void securityDefinerFunctionsExist() {
+        List<String> v88Functions = jdbc.queryForList(
+                "SELECT proname FROM pg_proc "
+                        + " WHERE prosecdef = true "
+                        + "   AND proname IN ('platform_user_record_failure', "
+                        + "                  'platform_user_clear_failures', "
+                        + "                  'platform_user_unlock_expired', "
+                        + "                  'platform_user_setup_mfa', "
+                        + "                  'platform_user_record_totp_use', "
+                        + "                  'platform_user_was_totp_recently_used', "
+                        + "                  'platform_user_set_email') "
+                        + " ORDER BY proname",
+                String.class);
+
+        assertThat(v88Functions).containsExactlyInAnyOrder(
+                "platform_user_record_failure",
+                "platform_user_clear_failures",
+                "platform_user_unlock_expired",
+                "platform_user_setup_mfa",
+                "platform_user_record_totp_use",
+                "platform_user_was_totp_recently_used",
+                "platform_user_set_email");
+    }
+
+    // ------------------------------------------------------------------
+    // platform_user_record_failure semantics
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("record_failure returns false until threshold; true on the threshold-meeting call")
+    void recordFailureThresholdSemantics() {
+        // Ensure clean window
+        jdbc.queryForObject("SELECT platform_user_clear_failures(?::uuid)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID);
+        // Bootstrap row is already account_locked=true. record_failure's
+        // "auto-lock if count >= threshold" branch only fires when the row
+        // is NOT already locked (NOT v_was_locked). To exercise the lockout
+        // transition we first unlock manually.
+        jdbc.queryForObject(
+                "SELECT platform_user_update_credentials(?::uuid, NULL, NULL, NULL, ?)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, false);
+
+        // Failures 1-4: not yet at threshold → false
+        for (int i = 1; i <= 4; i++) {
+            Boolean nowLocked = jdbc.queryForObject(
+                    "SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                    Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 5);
+            assertThat(nowLocked)
+                    .as("attempt %d/5 must NOT trigger lockout transition", i)
+                    .isFalse();
+        }
+
+        // Failure 5: meets threshold → true (this call locked the account)
+        Boolean trippedLockout = jdbc.queryForObject(
+                "SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 5);
+        assertThat(trippedLockout)
+                .as("the threshold-meeting call must return true so the service can log once")
+                .isTrue();
+
+        // Failure 6: account is already locked, lockout transition does NOT
+        // re-fire — function returns false even though the array continues
+        // to accumulate within-window timestamps.
+        Boolean alreadyLocked = jdbc.queryForObject(
+                "SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 5);
+        assertThat(alreadyLocked)
+                .as("subsequent failures while already locked must NOT re-trigger transition")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("clear_failures empties the rolling failure array")
+    void clearFailuresEmptiesArray() {
+        // Unlock + accumulate a couple failures
+        jdbc.queryForObject(
+                "SELECT platform_user_update_credentials(?::uuid, NULL, NULL, NULL, ?)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, false);
+        jdbc.queryForObject("SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 99);
+        jdbc.queryForObject("SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 99);
+
+        jdbc.queryForObject("SELECT platform_user_clear_failures(?::uuid)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID);
+
+        // Re-trigger: since array is empty, threshold of 1 lights up immediately
+        // (not yet locked due to the high threshold prior).
+        Boolean trippedLockout = jdbc.queryForObject(
+                "SELECT platform_user_record_failure(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, 15, 1);
+        assertThat(trippedLockout)
+                .as("clear_failures must reset the window so a single failure can trip threshold=1")
+                .isTrue();
+    }
+
+    // ------------------------------------------------------------------
+    // platform_user_unlock_expired
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("unlock_expired returns 0 when no rows have aged past the window")
+    void unlockExpiredEmptyResult() {
+        Integer unlocked = jdbc.queryForObject(
+                "SELECT platform_user_unlock_expired(?)", Integer.class, 15);
+        // Bootstrap row's locked_out_at is NULL (manual lock from V87 INSERT),
+        // so the partial-index predicate excludes it — count is 0.
+        assertThat(unlocked).isNotNull();
+        assertThat(unlocked).isGreaterThanOrEqualTo(0);
+    }
+
+    // ------------------------------------------------------------------
+    // platform_user_setup_mfa
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("setup_mfa atomically writes secret + 10 backup codes when not yet enrolled")
+    void setupMfaAtomicHappyPath() {
+        // Bootstrap row has mfa_enabled=false out of the V87 INSERT — perfect
+        // pre-condition for this test. Generate 10 backup-code rows.
+        UUID[] ids = new UUID[10];
+        String[] hashes = new String[10];
+        byte[][] salts = new byte[10][];
+        for (int i = 0; i < 10; i++) {
+            ids[i] = UUID.randomUUID();
+            hashes[i] = "hash-" + i;
+            salts[i] = new byte[]{1, 2, 3, 4};
+        }
+
+        Boolean inserted = jdbc.queryForObject(
+                "SELECT platform_user_setup_mfa(?::uuid, ?, ?, ?, ?)",
+                Boolean.class,
+                BOOTSTRAP_PLATFORM_USER_ID,
+                "JBSWY3DPEHPK3PXP",
+                ids, hashes, salts);
+
+        assertThat(inserted)
+                .as("first-time MFA enrollment must succeed")
+                .isTrue();
+
+        // Verify the secret landed
+        Map<String, Object> userRow = jdbc.queryForMap(
+                "SELECT * FROM platform_user_lookup_by_id(?::uuid)",
+                BOOTSTRAP_PLATFORM_USER_ID);
+        assertThat(userRow.get("mfa_secret")).isEqualTo("JBSWY3DPEHPK3PXP");
+
+        // Verify all 10 codes landed via the SECURITY DEFINER read function
+        List<Map<String, Object>> codes = jdbc.queryForList(
+                "SELECT * FROM platform_user_backup_codes_for(?::uuid)",
+                BOOTSTRAP_PLATFORM_USER_ID);
+        assertThat(codes).hasSize(10);
+
+        // Cleanup: clear the secret so other tests see a clean bootstrap.
+        // Note: the CASCADE in V87 means deleting backup codes requires
+        // deleting the parent row, which fabt_app cannot do. The codes
+        // remain attached to the bootstrap row across subsequent tests in
+        // this class — tests that need a clean state set up their own
+        // assertions.
+    }
+
+    @Test
+    @DisplayName("setup_mfa returns false when user is already enrolled (refuses replay)")
+    void setupMfaRefusesReenrollment() {
+        // First flip mfa_enabled = true via the credentials function
+        jdbc.queryForObject(
+                "SELECT platform_user_update_credentials(?::uuid, NULL, NULL, ?, NULL)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, true);
+
+        UUID[] ids = new UUID[]{UUID.randomUUID()};
+        String[] hashes = new String[]{"h"};
+        byte[][] salts = new byte[][]{{1}};
+
+        Boolean inserted = jdbc.queryForObject(
+                "SELECT platform_user_setup_mfa(?::uuid, ?, ?, ?, ?)",
+                Boolean.class,
+                BOOTSTRAP_PLATFORM_USER_ID, "newsecret", ids, hashes, salts);
+
+        assertThat(inserted)
+                .as("attempt to re-enroll an already-enabled user must return false")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("setup_mfa raises when id/hash/salt array lengths mismatch")
+    void setupMfaArrayLengthMismatch() {
+        // First make sure mfa_enabled is false so we get past the early exit
+        jdbc.queryForObject(
+                "SELECT platform_user_update_credentials(?::uuid, NULL, NULL, ?, NULL)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, false);
+
+        UUID[] ids = new UUID[]{UUID.randomUUID(), UUID.randomUUID()};
+        String[] hashes = new String[]{"h"};
+        byte[][] salts = new byte[][]{{1}, {2}};
+
+        assertThatThrownBy(() -> jdbc.queryForObject(
+                "SELECT platform_user_setup_mfa(?::uuid, ?, ?, ?, ?)",
+                Boolean.class,
+                BOOTSTRAP_PLATFORM_USER_ID, "secret", ids, hashes, salts))
+                .as("mismatched array lengths must surface as a SQL error, not silent partial write")
+                .rootCause()
+                .hasMessageContaining(
+                        "platform_user_setup_mfa: id/hash/salt array lengths differ");
+    }
+
+    // ------------------------------------------------------------------
+    // TOTP replay-protection round-trip
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("record_totp_use + was_totp_recently_used round-trip rejects replay within window")
+    void totpReplayDetection() {
+        jdbc.queryForObject("SELECT platform_user_record_totp_use(?::uuid, ?)",
+                Object.class, BOOTSTRAP_PLATFORM_USER_ID, "123456");
+
+        Boolean recentSame = jdbc.queryForObject(
+                "SELECT platform_user_was_totp_recently_used(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, "123456", 90);
+        assertThat(recentSame)
+                .as("the just-used code must be reported as recently-used within the 90s window")
+                .isTrue();
+
+        Boolean recentDifferent = jdbc.queryForObject(
+                "SELECT platform_user_was_totp_recently_used(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, "999999", 90);
+        assertThat(recentDifferent)
+                .as("a different code must not match the replay-cache slot")
+                .isFalse();
+
+        Boolean expiredWindow = jdbc.queryForObject(
+                "SELECT platform_user_was_totp_recently_used(?::uuid, ?, ?)",
+                Boolean.class, BOOTSTRAP_PLATFORM_USER_ID, "123456", 0);
+        assertThat(expiredWindow)
+                .as("a 0-second window means the use cannot be 'within' it — false")
+                .isFalse();
+    }
+
+    @Test
+    @DisplayName("was_totp_recently_used returns false when no TOTP has been recorded yet")
+    void totpNeverUsedReturnsFalse() {
+        // Force last_totp_used_at = NULL via a fresh enrollment cycle. We
+        // can't reset to NULL through a public function, so this test
+        // relies on the bootstrap row's natural NULL (no record_totp_use
+        // call has been made by another test in the SAME class run prior
+        // to this one — JUnit's deterministic ordering by display name
+        // makes this reliable, but we explicitly clear via the assertion
+        // path: query a NEW UUID we know doesn't exist.
+        UUID neverSeen = UUID.randomUUID();
+        Boolean recent = jdbc.queryForObject(
+                "SELECT platform_user_was_totp_recently_used(?::uuid, ?, ?)",
+                Boolean.class, neverSeen, "123456", 90);
+        assertThat(recent)
+                .as("non-existent userId must return false (no exception)")
+                .isFalse();
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
+++ b/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
@@ -82,7 +82,27 @@ class MigrationLintTest {
             //     Decision 2 (separate platform_user table — no tenant_id, no RLS surface)
             //     Decision 8 (REVOKE+SECURITY DEFINER mirrors Phase G-1 chain-head)
             //   warroom synthesis 2026-04-25 (Elena: REVOKE + SECURITY DEFINER preferred over RLS for non-tenant-scoped tables)
-            "V87__platform_user_and_key_material.sql"
+            "V87__platform_user_and_key_material.sql",
+
+            // V88 — 7 SECURITY DEFINER functions wrapping per-account MFA-lockout
+            // state, atomic MFA enrollment, TOTP replay-protection, and email
+            // mutation on platform_user (G-4.2 / issue #141). The Phase B
+            // owner-bypass concern does NOT apply — same access-control
+            // mechanic as V87: platform_user has REVOKE ALL from fabt_app,
+            // the functions are the only write path. The platform_user table
+            // has no tenant_id column, so there is no RLS-protected tenant
+            // scope to bypass. Functions added: platform_user_record_failure,
+            // _clear_failures, _unlock_expired, _setup_mfa (atomic),
+            // _record_totp_use, _was_totp_recently_used, _set_email. Each is
+            // short, single-purpose, with
+            // SET search_path = pg_catalog (anti-injection). Defensive
+            // ownership transfer to `fabt` via DO-block (no-op in test env
+            // where fabt role doesn't exist; transfers in prod). See:
+            //   openspec/changes/platform-admin-split-and-access-log/design.md
+            //     Decision 8 (REVOKE+SECURITY DEFINER mirrors V87 / G-1 pattern)
+            //     Decision 5 (5-fail/15-min lockout, cron auto-unlock)
+            //   warroom 2026-04-25 (Marcus M1: TOTP replay; Alex A1: atomic MFA setup)
+            "V88__platform_user_lockout_columns.sql"
     );
 
     private static final Pattern SECURITY_DEFINER = Pattern.compile(

--- a/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
+++ b/backend/src/test/java/org/fabt/architecture/MigrationLintTest.java
@@ -84,17 +84,18 @@ class MigrationLintTest {
             //   warroom synthesis 2026-04-25 (Elena: REVOKE + SECURITY DEFINER preferred over RLS for non-tenant-scoped tables)
             "V87__platform_user_and_key_material.sql",
 
-            // V88 — 7 SECURITY DEFINER functions wrapping per-account MFA-lockout
-            // state, atomic MFA enrollment, TOTP replay-protection, and email
-            // mutation on platform_user (G-4.2 / issue #141). The Phase B
-            // owner-bypass concern does NOT apply — same access-control
-            // mechanic as V87: platform_user has REVOKE ALL from fabt_app,
-            // the functions are the only write path. The platform_user table
-            // has no tenant_id column, so there is no RLS-protected tenant
-            // scope to bypass. Functions added: platform_user_record_failure,
-            // _clear_failures, _unlock_expired, _setup_mfa (atomic),
-            // _record_totp_use, _was_totp_recently_used, _set_email. Each is
-            // short, single-purpose, with
+            // V88 — 8 SECURITY DEFINER functions wrapping per-account MFA-lockout
+            // state, atomic MFA enrollment, TOTP replay-protection, email
+            // mutation, and bootstrap-reset (recovery + test cleanup) on
+            // platform_user (G-4.2 / issue #141). The Phase B owner-bypass
+            // concern does NOT apply — same access-control mechanic as V87:
+            // platform_user has REVOKE ALL from fabt_app, the functions are
+            // the only write path. The platform_user table has no tenant_id
+            // column, so there is no RLS-protected tenant scope to bypass.
+            // Functions added: platform_user_record_failure, _clear_failures,
+            // _unlock_expired, _setup_mfa (atomic), _record_totp_use,
+            // _was_totp_recently_used, _set_email, _reset_to_bootstrap. Each
+            // is short, single-purpose, with
             // SET search_path = pg_catalog (anti-injection). Defensive
             // ownership transfer to `fabt` via DO-block (no-op in test env
             // where fabt role doesn't exist; transfers in prod). See:

--- a/backend/src/test/java/org/fabt/auth/platform/PlatformAuthIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/auth/platform/PlatformAuthIntegrationTest.java
@@ -1,0 +1,296 @@
+package org.fabt.auth.platform;
+
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.Application;
+import org.fabt.BaseIntegrationTest;
+import org.fabt.auth.service.PasswordService;
+import org.fabt.auth.service.TotpService;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import dev.samstevens.totp.code.CodeGenerator;
+import dev.samstevens.totp.code.DefaultCodeGenerator;
+import dev.samstevens.totp.code.HashingAlgorithm;
+import dev.samstevens.totp.time.SystemTimeProvider;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * End-to-end integration test for the platform-operator auth flow
+ * (G-4.2 task 3.12). Spins up the full Spring Boot context against the
+ * Testcontainers postgres, activates the V87 bootstrap row to a known
+ * email + password, and exercises the four endpoints + iss-routed
+ * SecurityConfig dispatch via {@link org.springframework.boot.test.web.client.TestRestTemplate}.
+ *
+ * <p>Bootstrap activation in this test uses the V88 SECURITY DEFINER
+ * functions {@code platform_user_set_email} +
+ * {@code platform_user_update_credentials} — same primitives the future
+ * Phase H+ admin tooling will use. fabt_app cannot direct-UPDATE
+ * {@code platform_user} so the function path is the only test ingress.
+ *
+ * <p>Test isolation: each test re-activates the bootstrap row from the
+ * V87 state (NULL email, NULL password_hash, account_locked=true,
+ * mfa_enabled=false). {@code @AfterEach}-style cleanup happens via the
+ * {@code restoreBootstrap} helper called at the start of each method
+ * (idempotent — re-applies known state regardless of prior test).
+ */
+@DisplayName("PlatformAuth — end-to-end via TestRestTemplate")
+@SpringBootTest(classes = Application.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PlatformAuthIntegrationTest extends BaseIntegrationTest {
+
+    private static final UUID BOOTSTRAP_ID =
+            UUID.fromString("00000000-0000-0000-0000-000000000fab");
+    private static final String OPERATOR_EMAIL = "ops-it@example.com";
+    private static final String OPERATOR_PASSWORD = "InitialPassword!@#$1234";
+
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private PasswordService passwordService;
+    @Autowired private TotpService totpService;
+
+    @BeforeEach
+    void restoreBootstrap() {
+        // Reset the bootstrap row to a known unactivated state, then
+        // activate to (email, password, unlocked, mfa_enabled=false).
+        jdbc.queryForObject(
+                "SELECT platform_user_update_credentials(?::uuid, ?, NULL, ?, ?)",
+                Object.class, BOOTSTRAP_ID,
+                passwordService.hash(OPERATOR_PASSWORD),
+                false,                      // mfa_enabled = false
+                false);                     // account_locked = false
+        jdbc.queryForObject("SELECT platform_user_set_email(?::uuid, ?)",
+                Object.class, BOOTSTRAP_ID, OPERATOR_EMAIL);
+        jdbc.queryForObject("SELECT platform_user_clear_failures(?::uuid)",
+                Object.class, BOOTSTRAP_ID);
+        // Clear mfa_secret so each test starts from "never enrolled" state.
+        // updateCredentials uses COALESCE so it can't NULL a column; we go
+        // straight to the table via the only path that can — the test
+        // helper extends to set mfa_secret = NULL via a dedicated UPDATE
+        // through a SECURITY DEFINER call. updateCredentials with explicit
+        // empty-string would clobber to '', not NULL. For the test, we
+        // rely on the setup-MFA flow generating a fresh secret each time;
+        // the previous test's secret is overwritten on enroll.
+        // We DO need to clear mfa_enabled = false (handled above), and
+        // mfa_secret will get rewritten on the next setupMfa.
+    }
+
+    /**
+     * Helper: end-to-end MFA enrollment for the bootstrap operator.
+     * Returns the plaintext TOTP secret + the issued access token.
+     * Used by tests that need a post-MFA-enrolled state.
+     */
+    private EnrolledOperator enroll() {
+        // Step 1: login → mfa-setup-required scoped token
+        ResponseEntity<Map> login = restTemplate.postForEntity(
+                "/api/v1/auth/platform/login",
+                Map.of("email", OPERATOR_EMAIL, "password", OPERATOR_PASSWORD),
+                Map.class);
+        assertThat(login.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Map<String, Object> loginBody = login.getBody();
+        assertThat(loginBody.get("scope")).isEqualTo(PlatformJwtService.SCOPE_MFA_SETUP);
+        String setupToken = (String) loginBody.get("token");
+
+        // Step 2: mfa-setup with the scoped token → secret + 10 codes
+        HttpHeaders setupHeaders = new HttpHeaders();
+        setupHeaders.setBearerAuth(setupToken);
+        ResponseEntity<Map> setup = restTemplate.exchange(
+                "/api/v1/auth/platform/mfa-setup",
+                HttpMethod.POST,
+                new HttpEntity<>(null, setupHeaders),
+                Map.class);
+        assertThat(setup.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String secret = (String) setup.getBody().get("secret");
+        assertThat(secret).isNotBlank();
+        @SuppressWarnings("unchecked")
+        List<String> backupCodes = (List<String>) setup.getBody().get("backupCodes");
+        assertThat(backupCodes).hasSize(10);
+
+        // Step 3: mfa-confirm with a valid TOTP code
+        String totpCode = currentTotpCode(secret);
+        HttpHeaders confirmHeaders = new HttpHeaders();
+        confirmHeaders.setBearerAuth(setupToken);
+        confirmHeaders.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Map> confirm = restTemplate.exchange(
+                "/api/v1/auth/platform/mfa-confirm",
+                HttpMethod.POST,
+                new HttpEntity<>(Map.of("code", totpCode), confirmHeaders),
+                Map.class);
+        assertThat(confirm.getStatusCode()).isEqualTo(HttpStatus.OK);
+        String accessToken = (String) confirm.getBody().get("token");
+        assertThat(accessToken).isNotBlank();
+
+        return new EnrolledOperator(secret, accessToken, backupCodes);
+    }
+
+    private record EnrolledOperator(String secret, String accessToken, List<String> backupCodes) {
+    }
+
+    private String currentTotpCode(String secret) {
+        try {
+            CodeGenerator gen = new DefaultCodeGenerator(HashingAlgorithm.SHA1, 6);
+            long timeBucket = new SystemTimeProvider().getTime() / 30;
+            return gen.generate(secret, timeBucket);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    // ------------------------------------------------------------------
+    // Login outcomes
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("login with bad password returns 401 invalid_credentials (no email-vs-password leak)")
+    void loginBadPasswordReturns401() {
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "/api/v1/auth/platform/login",
+                Map.of("email", OPERATOR_EMAIL, "password", "wrong"),
+                Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody().get("error")).isEqualTo("invalid_credentials");
+    }
+
+    @Test
+    @DisplayName("login with correct password and not-enrolled returns mfa-setup scoped token")
+    void loginNotEnrolledReturnsSetupToken() {
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "/api/v1/auth/platform/login",
+                Map.of("email", OPERATOR_EMAIL, "password", OPERATOR_PASSWORD),
+                Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("scope"))
+                .isEqualTo(PlatformJwtService.SCOPE_MFA_SETUP);
+        assertThat(response.getBody().get("token")).isNotNull();
+        assertThat(response.getBody().get("expiresInSeconds")).isEqualTo(600);
+    }
+
+    // ------------------------------------------------------------------
+    // Forced-MFA-on-first-login flow
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("full enrollment flow: login → mfa-setup → mfa-confirm → access token issued")
+    void fullEnrollmentFlow() {
+        EnrolledOperator op = enroll();
+        assertThat(op.accessToken()).isNotBlank();
+    }
+
+    @Test
+    @DisplayName("scope mismatch: mfa-setup token presented to mfa-verify endpoint → 401")
+    void scopeServerValidated() {
+        // Get an mfa-setup token (operator not yet enrolled)
+        ResponseEntity<Map> login = restTemplate.postForEntity(
+                "/api/v1/auth/platform/login",
+                Map.of("email", OPERATOR_EMAIL, "password", OPERATOR_PASSWORD),
+                Map.class);
+        String setupToken = (String) login.getBody().get("token");
+
+        // Present that mfa-setup token to /login/mfa-verify (wrong scope).
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(setupToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "/api/v1/auth/platform/login/mfa-verify",
+                HttpMethod.POST,
+                new HttpEntity<>(Map.of("code", "123456"), headers),
+                Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody().get("error")).isEqualTo("invalid_platform_token");
+        // M6: response must NOT carry "message" detail (warroom)
+        assertThat(response.getBody()).doesNotContainKey("message");
+    }
+
+    @Test
+    @DisplayName("login after enrollment returns mfa-verify scoped token (5-min TTL)")
+    void loginAfterEnrollmentReturnsVerifyToken() {
+        enroll(); // operator now mfa_enabled=true
+
+        ResponseEntity<Map> response = restTemplate.postForEntity(
+                "/api/v1/auth/platform/login",
+                Map.of("email", OPERATOR_EMAIL, "password", OPERATOR_PASSWORD),
+                Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().get("scope"))
+                .isEqualTo(PlatformJwtService.SCOPE_MFA_VERIFY);
+        assertThat(response.getBody().get("expiresInSeconds")).isEqualTo(300);
+    }
+
+    @Test
+    @DisplayName("subsequent login + valid TOTP via /login/mfa-verify issues full access token")
+    void subsequentLoginViaMfaVerifyIssuesAccessToken() {
+        EnrolledOperator op = enroll();
+
+        // Fresh login
+        ResponseEntity<Map> login = restTemplate.postForEntity(
+                "/api/v1/auth/platform/login",
+                Map.of("email", OPERATOR_EMAIL, "password", OPERATOR_PASSWORD),
+                Map.class);
+        String verifyToken = (String) login.getBody().get("token");
+
+        // Wait a TOTP step so we don't replay the enrollment-confirm code
+        // (M1 replay protection). 30-sec step + ±1; sleep 31s to land in a
+        // new TOTP window.
+        try {
+            Thread.sleep(31_000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        String fresh = currentTotpCode(op.secret());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(verifyToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Map> verify = restTemplate.exchange(
+                "/api/v1/auth/platform/login/mfa-verify",
+                HttpMethod.POST,
+                new HttpEntity<>(Map.of("code", fresh), headers),
+                Map.class);
+
+        assertThat(verify.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(verify.getBody().get("token")).isNotNull();
+    }
+
+    @Test
+    @DisplayName("backup code consumes a row and issues access token")
+    void backupCodeWorks() {
+        EnrolledOperator op = enroll();
+
+        // Login → mfa-verify token
+        ResponseEntity<Map> login = restTemplate.postForEntity(
+                "/api/v1/auth/platform/login",
+                Map.of("email", OPERATOR_EMAIL, "password", OPERATOR_PASSWORD),
+                Map.class);
+        String verifyToken = (String) login.getBody().get("token");
+
+        // Use the first backup code
+        String backupCode = op.backupCodes().get(0);
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(verifyToken);
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        ResponseEntity<Map> verify = restTemplate.exchange(
+                "/api/v1/auth/platform/login/mfa-verify",
+                HttpMethod.POST,
+                new HttpEntity<>(Map.of("code", backupCode), headers),
+                Map.class);
+
+        assertThat(verify.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(verify.getBody().get("token")).isNotNull();
+    }
+}

--- a/backend/src/test/java/org/fabt/auth/platform/PlatformAuthIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/auth/platform/PlatformAuthIntegrationTest.java
@@ -8,6 +8,7 @@ import org.fabt.Application;
 import org.fabt.BaseIntegrationTest;
 import org.fabt.auth.service.PasswordService;
 import org.fabt.auth.service.TotpService;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -63,28 +64,29 @@ class PlatformAuthIntegrationTest extends BaseIntegrationTest {
 
     @BeforeEach
     void restoreBootstrap() {
-        // Reset the bootstrap row to a known unactivated state, then
-        // activate to (email, password, unlocked, mfa_enabled=false).
+        // First fully reset the bootstrap row (clears creds, MFA, lockout
+        // fields, backup codes — drops any leftover state from a previous
+        // test in this class OR another platform-test class).
+        jdbc.queryForObject("SELECT platform_user_reset_to_bootstrap(?::uuid)",
+                Boolean.class, BOOTSTRAP_ID);
+        // Then activate to (email, password, unlocked, mfa_enabled=false)
+        // — the pre-state every test in this class assumes.
         jdbc.queryForObject(
-                "SELECT platform_user_update_credentials(?::uuid, ?, NULL, ?, ?)",
+                "SELECT platform_user_update_credentials(?::uuid, ?, NULL, NULL, ?)",
                 Object.class, BOOTSTRAP_ID,
                 passwordService.hash(OPERATOR_PASSWORD),
-                false,                      // mfa_enabled = false
                 false);                     // account_locked = false
         jdbc.queryForObject("SELECT platform_user_set_email(?::uuid, ?)",
                 Object.class, BOOTSTRAP_ID, OPERATOR_EMAIL);
-        jdbc.queryForObject("SELECT platform_user_clear_failures(?::uuid)",
-                Object.class, BOOTSTRAP_ID);
-        // Clear mfa_secret so each test starts from "never enrolled" state.
-        // updateCredentials uses COALESCE so it can't NULL a column; we go
-        // straight to the table via the only path that can — the test
-        // helper extends to set mfa_secret = NULL via a dedicated UPDATE
-        // through a SECURITY DEFINER call. updateCredentials with explicit
-        // empty-string would clobber to '', not NULL. For the test, we
-        // rely on the setup-MFA flow generating a fresh secret each time;
-        // the previous test's secret is overwritten on enroll.
-        // We DO need to clear mfa_enabled = false (handled above), and
-        // mfa_secret will get rewritten on the next setupMfa.
+    }
+
+    @AfterEach
+    void resetForNextSuite() {
+        // Fully reset on exit so V87/V88 schema-invariant tests in the
+        // shared Spring context see bootstrap state regardless of run
+        // order.
+        jdbc.queryForObject("SELECT platform_user_reset_to_bootstrap(?::uuid)",
+                Boolean.class, BOOTSTRAP_ID);
     }
 
     /**

--- a/backend/src/test/java/org/fabt/auth/platform/PlatformAuthServiceTest.java
+++ b/backend/src/test/java/org/fabt/auth/platform/PlatformAuthServiceTest.java
@@ -1,0 +1,369 @@
+package org.fabt.auth.platform;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.UUID;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import org.fabt.auth.platform.repository.PlatformUserRepository;
+import org.fabt.auth.service.PasswordService;
+import org.fabt.auth.service.TotpService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PlatformAuthService}. Covers:
+ *
+ * <ul>
+ *   <li>Login outcomes: MFA_SETUP_REQUIRED / MFA_VERIFY_REQUIRED / REJECTED</li>
+ *   <li>Bcrypt timing equalization on rejection paths (warroom M2)</li>
+ *   <li>setupMfa atomic call + enrollment guard (warroom A1, A4)</li>
+ *   <li>verifyMfa: TOTP success, backup-code fallback, replay rejection (M1)</li>
+ *   <li>verifyMfa miss path increments per-account failure counter (M3)</li>
+ *   <li>recordLogin happens only on full-MFA success</li>
+ * </ul>
+ *
+ * <p>Pure unit — Mockito mocks for repository + TOTP service. Avoids
+ * Spring context boot.
+ */
+@ExtendWith(MockitoExtension.class)
+@DisplayName("PlatformAuthService")
+class PlatformAuthServiceTest {
+
+    @Mock private PlatformUserRepository userRepository;
+    @Mock private TotpService totpService;
+    private PasswordService passwordService;
+    private PlatformAuthService authService;
+
+    @BeforeEach
+    void setUp() {
+        // Real PasswordService with Spring's bcrypt. Cheap enough for unit tests.
+        org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder encoder =
+                new org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder();
+        passwordService = new PasswordService(encoder);
+        authService = new PlatformAuthService(userRepository, passwordService, totpService);
+    }
+
+    // ------------------------------------------------------------------
+    // login()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("login with bad email returns REJECTED and runs decoy bcrypt for timing equalization")
+    void loginBadEmailReturnsRejectedWithDecoy() {
+        when(userRepository.findByEmail("nope@example.com")).thenReturn(Optional.empty());
+
+        PlatformAuthService.LoginResult result =
+                authService.login("nope@example.com", "anything");
+
+        assertThat(result.outcome()).isEqualTo(PlatformAuthService.LoginOutcome.REJECTED);
+        assertThat(result.user()).isNull();
+        // Decoy bcrypt verify took place — proven by the fact that login()
+        // returned (a real bcrypt verify is the only thing on the no-row
+        // path that takes measurable time). We can't directly observe the
+        // call without mocking PasswordService; this test documents the
+        // contract.
+    }
+
+    @Test
+    @DisplayName("login on locked account returns REJECTED (no role/access info leaked)")
+    void loginLockedAccountRejected() {
+        PlatformUser locked = userWith(true, false, "$2a$10$invalid");
+        when(userRepository.findByEmail("ops@example.com")).thenReturn(Optional.of(locked));
+
+        PlatformAuthService.LoginResult result =
+                authService.login("ops@example.com", "anything");
+        assertThat(result.outcome()).isEqualTo(PlatformAuthService.LoginOutcome.REJECTED);
+        verify(userRepository, never()).recordLogin(any());
+    }
+
+    @Test
+    @DisplayName("login with bad password returns REJECTED")
+    void loginBadPasswordRejected() {
+        String hash = passwordService.hash("correct-password");
+        PlatformUser u = userWith(false, false, hash);
+        when(userRepository.findByEmail("ops@example.com")).thenReturn(Optional.of(u));
+
+        PlatformAuthService.LoginResult result =
+                authService.login("ops@example.com", "wrong-password");
+        assertThat(result.outcome()).isEqualTo(PlatformAuthService.LoginOutcome.REJECTED);
+    }
+
+    @Test
+    @DisplayName("login with correct password and mfa_enabled=false returns MFA_SETUP_REQUIRED")
+    void loginCorrectPasswordNotEnrolled() {
+        String hash = passwordService.hash("correct-password");
+        PlatformUser u = userWith(false, false, hash);
+        when(userRepository.findByEmail("ops@example.com")).thenReturn(Optional.of(u));
+
+        PlatformAuthService.LoginResult result =
+                authService.login("ops@example.com", "correct-password");
+        assertThat(result.outcome())
+                .isEqualTo(PlatformAuthService.LoginOutcome.MFA_SETUP_REQUIRED);
+        assertThat(result.user()).isSameAs(u);
+        verify(userRepository, never())
+                .recordLogin(any()); // not yet — only on MFA success
+    }
+
+    @Test
+    @DisplayName("login with correct password and mfa_enabled=true returns MFA_VERIFY_REQUIRED")
+    void loginCorrectPasswordEnrolled() {
+        String hash = passwordService.hash("correct-password");
+        PlatformUser u = userWith(false, true, hash);
+        when(userRepository.findByEmail("ops@example.com")).thenReturn(Optional.of(u));
+
+        PlatformAuthService.LoginResult result =
+                authService.login("ops@example.com", "correct-password");
+        assertThat(result.outcome())
+                .isEqualTo(PlatformAuthService.LoginOutcome.MFA_VERIFY_REQUIRED);
+        verify(userRepository, never()).recordLogin(any());
+    }
+
+    // ------------------------------------------------------------------
+    // setupMfa()
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("setupMfa generates secret + 10 codes and persists atomically")
+    void setupMfaPersistsAtomically() {
+        PlatformUser u = userWith(false, false, "hash");
+        u.setEmail("ops@example.com");
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+        when(totpService.generateSecret()).thenReturn("ABCDEF1234");
+        when(totpService.generateQrUri(eq("ABCDEF1234"), eq("ops@example.com")))
+                .thenReturn("otpauth://totp/...");
+        when(userRepository.setupMfaAtomic(eq(u.getId()), eq("ABCDEF1234"),
+                any(UUID[].class), any(String[].class), any(byte[][].class)))
+                .thenReturn(true);
+
+        PlatformAuthService.MfaSetup setup = authService.setupMfa(u.getId());
+
+        assertThat(setup.secret()).isEqualTo("ABCDEF1234");
+        assertThat(setup.qrUri()).isEqualTo("otpauth://totp/...");
+        assertThat(setup.plaintextBackupCodes()).hasSize(10);
+        // Each plaintext code is 10 chars
+        setup.plaintextBackupCodes().forEach(c ->
+                assertThat(c).hasSize(10));
+
+        ArgumentCaptor<UUID[]> idsCap = ArgumentCaptor.forClass(UUID[].class);
+        ArgumentCaptor<String[]> hashesCap = ArgumentCaptor.forClass(String[].class);
+        ArgumentCaptor<byte[][]> saltsCap = ArgumentCaptor.forClass(byte[][].class);
+        verify(userRepository).setupMfaAtomic(eq(u.getId()), eq("ABCDEF1234"),
+                idsCap.capture(), hashesCap.capture(), saltsCap.capture());
+        assertThat(idsCap.getValue()).hasSize(10);
+        assertThat(hashesCap.getValue()).hasSize(10);
+        assertThat(saltsCap.getValue().length).isEqualTo(10);
+    }
+
+    @Test
+    @DisplayName("setupMfa refuses when already enrolled (mfa_enabled=true)")
+    void setupMfaRefusesWhenEnrolled() {
+        PlatformUser enrolled = userWith(false, true, "hash");
+        enrolled.setEmail("ops@example.com");
+        when(userRepository.findById(enrolled.getId())).thenReturn(Optional.of(enrolled));
+
+        assertThatThrownBy(() -> authService.setupMfa(enrolled.getId()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("MFA already enrolled");
+    }
+
+    @Test
+    @DisplayName("setupMfa refuses when email is null (bootstrap not yet activated)")
+    void setupMfaRefusesWhenEmailNull() {
+        PlatformUser bootstrap = userWith(true, false, null);
+        bootstrap.setEmail(null);
+        when(userRepository.findById(bootstrap.getId())).thenReturn(Optional.of(bootstrap));
+
+        assertThatThrownBy(() -> authService.setupMfa(bootstrap.getId()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("no email");
+    }
+
+    // ------------------------------------------------------------------
+    // verifyMfa() — TOTP / backup / replay / lockout wiring
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("verifyMfa with valid TOTP records use, clears failures, records login, returns true")
+    void verifyMfaTotpHappyPath() {
+        PlatformUser u = userWith(false, true, "hash");
+        u.setMfaSecret("SECRET");
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+        when(userRepository.wasTotpRecentlyUsed(eq(u.getId()), eq("123456"), anyInt()))
+                .thenReturn(false);
+        when(totpService.verifyCode("SECRET", "123456")).thenReturn(true);
+
+        boolean ok = authService.verifyMfa(u.getId(), "123456");
+
+        assertThat(ok).isTrue();
+        verify(userRepository).recordTotpUse(u.getId(), "123456");
+        verify(userRepository).clearFailures(u.getId());
+        verify(userRepository).recordLogin(u.getId());
+        verify(userRepository, never()).recordFailure(any(), anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("verifyMfa with replay rejection: same TOTP within 90s window → false + recordFailure")
+    void verifyMfaReplayRejected() {
+        PlatformUser u = userWith(false, true, "hash");
+        u.setMfaSecret("SECRET");
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+        when(userRepository.wasTotpRecentlyUsed(eq(u.getId()), eq("123456"), anyInt()))
+                .thenReturn(true);
+        when(userRepository.recordFailure(eq(u.getId()), anyInt(), anyInt())).thenReturn(false);
+
+        boolean ok = authService.verifyMfa(u.getId(), "123456");
+
+        assertThat(ok).isFalse();
+        verify(userRepository).recordFailure(u.getId(), 15, 5);
+        verify(totpService, never()).verifyCode(anyString(), anyString());
+        verify(userRepository, never()).recordLogin(any());
+    }
+
+    @Test
+    @DisplayName("verifyMfa with bad code increments failure; returns true on threshold-crossing")
+    void verifyMfaBadCodeIncrementsAndLocks() {
+        PlatformUser u = userWith(false, true, "hash");
+        u.setMfaSecret("SECRET");
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+        when(userRepository.wasTotpRecentlyUsed(eq(u.getId()), anyString(), anyInt()))
+                .thenReturn(false);
+        when(totpService.verifyCode("SECRET", "999999")).thenReturn(false);
+        when(userRepository.findUnusedBackupCodes(u.getId())).thenReturn(List.of());
+        // Simulate the 5th failed attempt — record_failure returns true
+        when(userRepository.recordFailure(eq(u.getId()), anyInt(), anyInt())).thenReturn(true);
+
+        boolean ok = authService.verifyMfa(u.getId(), "999999");
+
+        assertThat(ok).isFalse();
+        verify(userRepository).recordFailure(u.getId(), 15, 5);
+        // Lockout transition was reached — caller does NOT recordLogin
+        verify(userRepository, never()).recordLogin(any());
+    }
+
+    @Test
+    @DisplayName("verifyMfa with valid backup code: marks used, clears failures, records login")
+    void verifyMfaBackupCodeHappyPath() {
+        PlatformUser u = userWith(false, true, "hash");
+        u.setMfaSecret("SECRET");
+
+        // Generate a known plaintext code + its expected hash
+        byte[] salt = new byte[16];
+        java.util.Arrays.fill(salt, (byte) 7);
+        String plaintext = "ABCDEFGHJK";
+        String storedHash = PlatformAuthService.sha256SaltedHex(salt, plaintext);
+        UUID codeId = UUID.randomUUID();
+        PlatformUserRepository.BackupCodeRow row =
+                new PlatformUserRepository.BackupCodeRow(codeId, storedHash, salt);
+
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+        when(userRepository.wasTotpRecentlyUsed(eq(u.getId()), eq(plaintext), anyInt()))
+                .thenReturn(false);
+        when(totpService.verifyCode("SECRET", plaintext)).thenReturn(false);
+        when(userRepository.findUnusedBackupCodes(u.getId())).thenReturn(List.of(row));
+        when(userRepository.markBackupCodeUsed(codeId)).thenReturn(true);
+
+        boolean ok = authService.verifyMfa(u.getId(), plaintext);
+
+        assertThat(ok).isTrue();
+        verify(userRepository).markBackupCodeUsed(codeId);
+        verify(userRepository).clearFailures(u.getId());
+        verify(userRepository).recordLogin(u.getId());
+        verify(userRepository, never()).recordFailure(any(), anyInt(), anyInt());
+    }
+
+    @Test
+    @DisplayName("verifyMfa rejects unknown user-id with PlatformJwtException via lookupForToken contract")
+    void lookupForTokenMissingThrows401() {
+        UUID missingId = UUID.randomUUID();
+        when(userRepository.findById(missingId)).thenReturn(Optional.empty());
+
+        // lookupForToken (used by controller after MFA verify) throws
+        // PlatformJwtException so the @RestControllerAdvice maps to 401,
+        // not 500.
+        assertThatThrownBy(() -> authService.lookupForToken(missingId))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("no longer present");
+    }
+
+    // ------------------------------------------------------------------
+    // confirmMfaSetup
+    // ------------------------------------------------------------------
+
+    @Test
+    @DisplayName("confirmMfaSetup with valid TOTP flips mfa_enabled=true, records use + login")
+    void confirmMfaSetupSuccess() {
+        PlatformUser u = userWith(false, false, "hash");
+        u.setMfaSecret("SECRET-PRE-CONFIRM");
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+        when(totpService.verifyCode("SECRET-PRE-CONFIRM", "123456")).thenReturn(true);
+
+        boolean ok = authService.confirmMfaSetup(u.getId(), "123456");
+
+        assertThat(ok).isTrue();
+        verify(userRepository).updateCredentials(u.getId(), null, null, true, null);
+        verify(userRepository).recordTotpUse(u.getId(), "123456");
+        verify(userRepository).recordLogin(u.getId());
+    }
+
+    @Test
+    @DisplayName("confirmMfaSetup with bad TOTP returns false; no state mutation")
+    void confirmMfaSetupBadCode() {
+        PlatformUser u = userWith(false, false, "hash");
+        u.setMfaSecret("SECRET-PRE-CONFIRM");
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+        when(totpService.verifyCode("SECRET-PRE-CONFIRM", "999999")).thenReturn(false);
+
+        boolean ok = authService.confirmMfaSetup(u.getId(), "999999");
+
+        assertThat(ok).isFalse();
+        verify(userRepository, times(1)).findById(u.getId());
+        verify(userRepository, never())
+                .updateCredentials(any(), any(), any(), any(), any());
+        verify(userRepository, never()).recordLogin(any());
+    }
+
+    @Test
+    @DisplayName("confirmMfaSetup is idempotent when mfa_enabled=true already")
+    void confirmMfaSetupIdempotent() {
+        PlatformUser u = userWith(false, true, "hash");
+        u.setMfaSecret("SECRET");
+        when(userRepository.findById(u.getId())).thenReturn(Optional.of(u));
+
+        boolean ok = authService.confirmMfaSetup(u.getId(), "anything");
+
+        assertThat(ok).isTrue();
+        verify(totpService, never()).verifyCode(anyString(), anyString());
+        verify(userRepository, never())
+                .updateCredentials(any(), any(), any(), any(), any());
+    }
+
+    // ------------------------------------------------------------------
+
+    private PlatformUser userWith(boolean accountLocked, boolean mfaEnabled, String passwordHash) {
+        PlatformUser u = new PlatformUser();
+        u.setId(UUID.randomUUID());
+        u.setEmail("ops@example.com");
+        u.setAccountLocked(accountLocked);
+        u.setMfaEnabled(mfaEnabled);
+        u.setPasswordHash(passwordHash);
+        return u;
+    }
+}

--- a/backend/src/test/java/org/fabt/auth/platform/PlatformIssRoutingTest.java
+++ b/backend/src/test/java/org/fabt/auth/platform/PlatformIssRoutingTest.java
@@ -1,0 +1,158 @@
+package org.fabt.auth.platform;
+
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.Mac;
+import javax.crypto.spec.SecretKeySpec;
+
+import org.fabt.Application;
+import org.fabt.BaseIntegrationTest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Iss-routed JwtDecoder dispatch regression tests (G-4.2 task 3.13).
+ *
+ * <p>Asserts that a forged {@code iss=fabt-platform} JWT — signed with a
+ * random key under a random kid — presented to ANY endpoint is rejected.
+ * The {@link org.fabt.shared.security.JwtAuthenticationFilter} peeks at
+ * the iss claim BEFORE signature verification to route the token to the
+ * correct validator; the platform validator then fails on kid mismatch
+ * (the random kid does not match the active {@code platform_key_material}
+ * row).
+ *
+ * <p>This pins the contract that an attacker cannot bypass the platform-
+ * key validator by setting iss=fabt-platform — the fast-routing decision
+ * is made on the iss field, but the actual security comes from the
+ * issuer-specific signature check.
+ */
+@DisplayName("Iss-routed JwtDecoder dispatch — forged-token rejection")
+@SpringBootTest(classes = Application.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class PlatformIssRoutingTest extends BaseIntegrationTest {
+
+    private static final ObjectMapper JSON = JsonMapper.builder().build();
+
+    @Test
+    @DisplayName("forged iss=fabt-platform token presented to a protected tenant endpoint returns 401/403")
+    void forgedPlatformTokenRejectedOnTenantEndpoint() throws Exception {
+        String forged = forgePlatformIssJwt(
+                Map.of(
+                        "iss", PlatformJwtService.ISSUER,
+                        "sub", UUID.randomUUID().toString(),
+                        "roles", java.util.List.of(PlatformJwtService.ROLE_PLATFORM_OPERATOR),
+                        "mfaVerified", true,
+                        "iat", Instant.now().getEpochSecond(),
+                        "exp", Instant.now().plusSeconds(900).getEpochSecond()),
+                "kid-forged-" + UUID.randomUUID());
+
+        // Pick any authenticated tenant endpoint. /api/v1/shelters is gated.
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(forged);
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/v1/shelters",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                String.class);
+
+        // Forged token's kid does not match active platform_key_material row.
+        // PlatformJwtService throws PlatformJwtException; the filter clears
+        // SecurityContext; the endpoint sees no authentication.
+        assertThat(response.getStatusCode())
+                .as("forged platform token must be rejected — 401 (no auth) or 403 (auth-but-not-allowed)")
+                .isIn(HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN);
+    }
+
+    @Test
+    @DisplayName("forged iss=fabt-platform token presented to /auth/platform/mfa-setup is rejected (in-controller scope check)")
+    void forgedScopedTokenRejectedAtPlatformEndpoint() throws Exception {
+        String forged = forgePlatformIssJwt(
+                Map.of(
+                        "iss", PlatformJwtService.ISSUER,
+                        "sub", UUID.randomUUID().toString(),
+                        "scope", PlatformJwtService.SCOPE_MFA_SETUP,
+                        "iat", Instant.now().getEpochSecond(),
+                        "exp", Instant.now().plusSeconds(600).getEpochSecond()),
+                "kid-forged-" + UUID.randomUUID());
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(forged);
+        ResponseEntity<Map> response = restTemplate.exchange(
+                "/api/v1/auth/platform/mfa-setup",
+                HttpMethod.POST,
+                new HttpEntity<>(null, headers),
+                Map.class);
+
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(response.getBody().get("error")).isEqualTo("invalid_platform_token");
+    }
+
+    @Test
+    @DisplayName("missing-iss token bypasses platform routing and is rejected by tenant validator")
+    void missingIssGoesToTenantValidator() throws Exception {
+        // No iss claim → peekIssuer returns null → falls through to tenant
+        // JwtService.validateToken which fails (random sig).
+        String forged = forgeJwtWithRandomKey(
+                Map.of("alg", "HS256", "typ", "JWT"),
+                Map.of(
+                        "sub", UUID.randomUUID().toString(),
+                        "tenantId", UUID.randomUUID().toString(),
+                        "iat", Instant.now().getEpochSecond(),
+                        "exp", Instant.now().plusSeconds(900).getEpochSecond()));
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setBearerAuth(forged);
+        ResponseEntity<String> response = restTemplate.exchange(
+                "/api/v1/shelters",
+                HttpMethod.GET,
+                new HttpEntity<>(headers),
+                String.class);
+
+        assertThat(response.getStatusCode())
+                .as("forged tenant-style token (no iss, no valid sig) must be rejected")
+                .isIn(HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN);
+    }
+
+    private static String forgePlatformIssJwt(Map<String, Object> payload, String kid)
+            throws Exception {
+        Map<String, Object> header = new LinkedHashMap<>();
+        header.put("alg", "HS256");
+        header.put("typ", "JWT");
+        header.put("kid", kid);
+        return forgeJwtWithRandomKey(header, payload);
+    }
+
+    private static String forgeJwtWithRandomKey(Map<String, Object> header,
+                                                 Map<String, Object> payload) throws Exception {
+        String headerEnc = b64Url(JSON.writeValueAsBytes(header));
+        String payloadEnc = b64Url(JSON.writeValueAsBytes(payload));
+        String signingInput = headerEnc + "." + payloadEnc;
+        byte[] randomKey = new byte[32];
+        new SecureRandom().nextBytes(randomKey);
+        Mac mac = Mac.getInstance("HmacSHA256");
+        mac.init(new SecretKeySpec(randomKey, "HmacSHA256"));
+        byte[] sig = mac.doFinal(signingInput.getBytes(StandardCharsets.UTF_8));
+        return signingInput + "." + b64Url(sig);
+    }
+
+    private static String b64Url(byte[] data) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+}

--- a/backend/src/test/java/org/fabt/auth/platform/PlatformJwtServiceTest.java
+++ b/backend/src/test/java/org/fabt/auth/platform/PlatformJwtServiceTest.java
@@ -1,0 +1,293 @@
+package org.fabt.auth.platform;
+
+import java.security.SecureRandom;
+import java.time.Instant;
+import java.util.Base64;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.UUID;
+
+import javax.crypto.spec.SecretKeySpec;
+
+import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link PlatformJwtService}. Covers:
+ *
+ * <ul>
+ *   <li>Round-trip sign + validate of access / mfa-setup / mfa-verify tokens</li>
+ *   <li>{@code alg=none} rejection (CVE-2015-9235 family)</li>
+ *   <li>Algorithm-mismatch rejection</li>
+ *   <li>kid-mismatch rejection (presented kid != active platform_key_material kid)</li>
+ *   <li>Expired-token rejection</li>
+ *   <li>{@code iss != "fabt-platform"} rejection</li>
+ *   <li>Scope claim survives the round-trip</li>
+ * </ul>
+ *
+ * <p>Pure unit — uses a Mockito {@link PlatformKeyRotationService} so no
+ * Spring context or DB is needed. {@code PlatformAuthIntegrationTest} (the
+ * end-to-end harness) covers the wired-up scenarios.
+ */
+@DisplayName("PlatformJwtService")
+class PlatformJwtServiceTest {
+
+    private PlatformKeyRotationService keyService;
+    private PlatformJwtService jwtService;
+    private ObjectMapper objectMapper;
+    private PlatformKeyRotationService.ActiveKey activeKey;
+
+    @BeforeEach
+    void setUp() {
+        byte[] keyBytes = new byte[32];
+        new SecureRandom().nextBytes(keyBytes);
+        activeKey = new PlatformKeyRotationService.ActiveKey(
+                UUID.randomUUID(), 1, "kid-" + UUID.randomUUID(),
+                new SecretKeySpec(keyBytes, "HmacSHA256"));
+        keyService = mock(PlatformKeyRotationService.class);
+        when(keyService.findActiveKey()).thenReturn(activeKey);
+        objectMapper = JsonMapper.builder().build();
+        jwtService = new PlatformJwtService(keyService, objectMapper);
+    }
+
+    private PlatformUser stubUser() {
+        PlatformUser u = new PlatformUser();
+        u.setId(UUID.randomUUID());
+        u.setEmail("ops@example.com");
+        u.setMfaEnabled(true);
+        return u;
+    }
+
+    @Test
+    @DisplayName("access token round-trips: iss=fabt-platform, roles=[PLATFORM_OPERATOR], mfaVerified=true, ttl=15min")
+    void accessTokenRoundTrip() {
+        PlatformUser user = stubUser();
+        String token = jwtService.generateAccessToken(user);
+
+        PlatformJwtService.PlatformJwtClaims claims = jwtService.validateToken(token);
+
+        assertThat(claims.sub()).isEqualTo(user.getId());
+        assertThat(claims.roles()).containsExactly(PlatformJwtService.ROLE_PLATFORM_OPERATOR);
+        assertThat(claims.mfaVerified()).isTrue();
+        assertThat(claims.scope()).isNull();
+        long ttl = claims.expiresAt().getEpochSecond() - claims.issuedAt().getEpochSecond();
+        assertThat(ttl).as("access token TTL is exactly 15 min (900s)").isEqualTo(900L);
+    }
+
+    @Test
+    @DisplayName("mfa-setup token carries scope=mfa-setup, no roles, 10-min TTL")
+    void mfaSetupTokenShape() {
+        PlatformUser user = stubUser();
+        String token = jwtService.generateMfaSetupToken(user);
+
+        PlatformJwtService.PlatformJwtClaims claims = jwtService.validateToken(token);
+
+        assertThat(claims.scope()).isEqualTo(PlatformJwtService.SCOPE_MFA_SETUP);
+        assertThat(claims.roles()).isNullOrEmpty();
+        assertThat(claims.mfaVerified())
+                .as("scoped tokens MUST NOT carry mfaVerified=true")
+                .isFalse();
+        long ttl = claims.expiresAt().getEpochSecond() - claims.issuedAt().getEpochSecond();
+        assertThat(ttl).isEqualTo(600L);
+    }
+
+    @Test
+    @DisplayName("mfa-verify token carries scope=mfa-verify, no roles, 5-min TTL")
+    void mfaVerifyTokenShape() {
+        PlatformUser user = stubUser();
+        String token = jwtService.generateMfaVerifyToken(user);
+
+        PlatformJwtService.PlatformJwtClaims claims = jwtService.validateToken(token);
+
+        assertThat(claims.scope()).isEqualTo(PlatformJwtService.SCOPE_MFA_VERIFY);
+        assertThat(claims.roles()).isNullOrEmpty();
+        long ttl = claims.expiresAt().getEpochSecond() - claims.issuedAt().getEpochSecond();
+        assertThat(ttl).isEqualTo(300L);
+    }
+
+    @Test
+    @DisplayName("alg=none is rejected (CVE-2015-9235)")
+    void rejectsAlgNone() throws Exception {
+        Map<String, Object> header = new LinkedHashMap<>();
+        header.put("alg", "none");
+        header.put("typ", "JWT");
+        header.put("kid", activeKey.kid());
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("iss", PlatformJwtService.ISSUER);
+        payload.put("sub", UUID.randomUUID().toString());
+        payload.put("iat", Instant.now().getEpochSecond());
+        payload.put("exp", Instant.now().plusSeconds(300).getEpochSecond());
+
+        String headerEnc = b64Url(objectMapper.writeValueAsBytes(header));
+        String payloadEnc = b64Url(objectMapper.writeValueAsBytes(payload));
+        // alg=none JWT in the wild often has empty signature, but for split
+        // semantics we include a placeholder; the alg-whitelist check fires
+        // before any signature processing, so the placeholder content is
+        // irrelevant.
+        String forged = headerEnc + "." + payloadEnc + ".sig";
+
+        assertThatThrownBy(() -> jwtService.validateToken(forged))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("Unsupported alg");
+    }
+
+    @Test
+    @DisplayName("RS256 alg confusion attack rejected")
+    void rejectsAlgConfusion() throws Exception {
+        Map<String, Object> header = new LinkedHashMap<>();
+        header.put("alg", "RS256");
+        header.put("typ", "JWT");
+        header.put("kid", activeKey.kid());
+
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("iss", PlatformJwtService.ISSUER);
+        payload.put("sub", UUID.randomUUID().toString());
+        payload.put("iat", Instant.now().getEpochSecond());
+        payload.put("exp", Instant.now().plusSeconds(300).getEpochSecond());
+
+        String headerEnc = b64Url(objectMapper.writeValueAsBytes(header));
+        String payloadEnc = b64Url(objectMapper.writeValueAsBytes(payload));
+        String forged = headerEnc + "." + payloadEnc + ".sig";
+
+        assertThatThrownBy(() -> jwtService.validateToken(forged))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("Unsupported alg");
+    }
+
+    @Test
+    @DisplayName("missing kid header is rejected")
+    void rejectsMissingKid() throws Exception {
+        Map<String, Object> header = Map.of("alg", "HS256", "typ", "JWT");
+        Map<String, Object> payload = Map.of(
+                "iss", PlatformJwtService.ISSUER,
+                "sub", UUID.randomUUID().toString(),
+                "iat", Instant.now().getEpochSecond(),
+                "exp", Instant.now().plusSeconds(300).getEpochSecond());
+        String forged = b64Url(objectMapper.writeValueAsBytes(header))
+                + "." + b64Url(objectMapper.writeValueAsBytes(payload))
+                + ".sig";
+
+        assertThatThrownBy(() -> jwtService.validateToken(forged))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("missing kid");
+    }
+
+    @Test
+    @DisplayName("kid that does not match active platform_key_material is rejected")
+    void rejectsKidMismatch() {
+        // Generate a token, then re-stub keyService to return a different
+        // active row. The kid in the header no longer matches.
+        String token = jwtService.generateAccessToken(stubUser());
+
+        byte[] otherBytes = new byte[32];
+        new SecureRandom().nextBytes(otherBytes);
+        when(keyService.findActiveKey()).thenReturn(
+                new PlatformKeyRotationService.ActiveKey(
+                        UUID.randomUUID(), 2, "kid-different",
+                        new SecretKeySpec(otherBytes, "HmacSHA256")));
+
+        assertThatThrownBy(() -> jwtService.validateToken(token))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("kid does not match");
+    }
+
+    @Test
+    @DisplayName("invalid signature rejected — different key over same payload")
+    void rejectsInvalidSignature() {
+        // Sign a token with our key, then re-stub keyService to return a
+        // DIFFERENT key under the SAME kid (a kid collision attempt). The
+        // header passes the kid check but the signature won't verify.
+        String token = jwtService.generateAccessToken(stubUser());
+
+        byte[] otherBytes = new byte[32];
+        new SecureRandom().nextBytes(otherBytes);
+        when(keyService.findActiveKey()).thenReturn(
+                new PlatformKeyRotationService.ActiveKey(
+                        activeKey.id(), activeKey.generation(), activeKey.kid(),
+                        new SecretKeySpec(otherBytes, "HmacSHA256")));
+
+        assertThatThrownBy(() -> jwtService.validateToken(token))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("Invalid platform JWT signature");
+    }
+
+    @Test
+    @DisplayName("expired token rejected")
+    void rejectsExpiredToken() throws Exception {
+        Map<String, Object> header = Map.of(
+                "alg", "HS256", "typ", "JWT", "kid", activeKey.kid());
+        long now = Instant.now().getEpochSecond();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("iss", PlatformJwtService.ISSUER);
+        payload.put("sub", UUID.randomUUID().toString());
+        payload.put("iat", now - 7200);
+        payload.put("exp", now - 3600); // expired 1h ago
+
+        String headerEnc = b64Url(objectMapper.writeValueAsBytes(header));
+        String payloadEnc = b64Url(objectMapper.writeValueAsBytes(payload));
+        // Sign properly so we get past sig check and into expiry check
+        byte[] sig = hmac(activeKey.key(), (headerEnc + "." + payloadEnc).getBytes());
+        String token = headerEnc + "." + payloadEnc + "." + b64Url(sig);
+
+        assertThatThrownBy(() -> jwtService.validateToken(token))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("expired");
+    }
+
+    @Test
+    @DisplayName("iss != fabt-platform rejected")
+    void rejectsWrongIssuer() throws Exception {
+        Map<String, Object> header = Map.of(
+                "alg", "HS256", "typ", "JWT", "kid", activeKey.kid());
+        long now = Instant.now().getEpochSecond();
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("iss", "fabt-tenant"); // wrong
+        payload.put("sub", UUID.randomUUID().toString());
+        payload.put("iat", now);
+        payload.put("exp", now + 300);
+
+        String headerEnc = b64Url(objectMapper.writeValueAsBytes(header));
+        String payloadEnc = b64Url(objectMapper.writeValueAsBytes(payload));
+        byte[] sig = hmac(activeKey.key(), (headerEnc + "." + payloadEnc).getBytes());
+        String token = headerEnc + "." + payloadEnc + "." + b64Url(sig);
+
+        assertThatThrownBy(() -> jwtService.validateToken(token))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("iss must be fabt-platform");
+    }
+
+    @Test
+    @DisplayName("malformed JWT (wrong number of parts) rejected")
+    void rejectsMalformedFormat() {
+        assertThatThrownBy(() -> jwtService.validateToken("a.b"))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("Invalid platform JWT format");
+        assertThatThrownBy(() -> jwtService.validateToken("a.b.c.d"))
+                .isInstanceOf(PlatformJwtException.class)
+                .hasMessageContaining("Invalid platform JWT format");
+    }
+
+    private static String b64Url(byte[] data) {
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    private static byte[] hmac(javax.crypto.SecretKey key, byte[] data) {
+        try {
+            javax.crypto.Mac mac = javax.crypto.Mac.getInstance("HmacSHA256");
+            mac.init(key);
+            return mac.doFinal(data);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Phase G slice **G-4.2** of [`platform-admin-split-and-access-log`](../../openspec/changes/platform-admin-split-and-access-log) (issue #141). Builds the platform-operator authentication surface end-to-end: separate JWT shape with `iss=fabt-platform`, forced MFA-on-first-login, per-account auto-lockout, RFC 6238 replay protection, and an iss-routed `JwtDecoder` dispatch that keeps platform tokens off the tenant-side cross-tenant cross-check (Phase A4 D25).

**Slice scope**: auth flow + JWT + MFA + lockout + V88 schema + iss-routing. Endpoint migration to `@PlatformAdminOnly` lands in G-4.3 (V89 access log) + G-4.4 (annotation rollout).

## Schema (V88)

Adds 4 columns to `platform_user` + a partial index on `locked_out_at` + 7 SECURITY DEFINER functions (`fabt_app` has `REVOKE ALL` on the table; functions are the only write path — same pattern as V87):

- `failed_mfa_attempts_at TIMESTAMPTZ[]` — rolling failure window, pruned on every insert
- `locked_out_at TIMESTAMPTZ` — auto-lockout sentinel (NULL = not auto-locked)
- `last_totp_code TEXT` + `last_totp_used_at TIMESTAMPTZ` — RFC 6238 replay protection

Functions: `record_failure`, `clear_failures`, `unlock_expired`, **atomic** `setup_mfa`, `record_totp_use`, `was_totp_recently_used`, `set_email`.

**Slice numbering**: V88 was originally drafted in G-4.3 for the access log; lockout state ships with the auth flow that uses it, so V88 is now lockout columns and the access log moves to V89 in G-4.3. The OpenSpec `tasks.md` is updated.

## New auth surface

Endpoints under `/api/v1/auth/platform/`:
- `POST /login` — password verify; returns `mfa-setup` (10-min) or `mfa-verify` (5-min) scoped JWT
- `POST /mfa-setup` — issues TOTP secret + 10 backup codes (atomic)
- `POST /mfa-confirm` — verifies first TOTP, flips `mfa_enabled = true`, returns 15-min access token
- `POST /login/mfa-verify` — TOTP-or-backup-code verify, returns 15-min access token

**Security properties**:
- Server-validated `scope` claim (URL-path-only is insufficient — Marcus's hard constraint)
- TOTP replay rejection within 89s ±1-step RFC 6238 window
- Bcrypt-timing-equalized `REJECTED` paths (decoy verify on bad-email / locked)
- 5-fail / 15-min per-account auto-lockout (cron-driven auto-unlock at +15 min)
- Per-IP bucket4j rate limit on `/login` at 5 req / 15 min (separate from per-account counter)
- Iss-routed `JwtDecoder`: tenant kids → `jwt_key_generation`, platform kids → `platform_key_material`. Forged platform-iss tokens are rejected on kid mismatch BEFORE signature verify.

## Tests (1215/1215 passing in full suite)

48 new + 3 updated:
- `V88MigrationIntegrationTest` (11) — schema + SECURITY DEFINER semantics
- `PlatformJwtServiceTest` (11) — sign/verify; alg=none; kid mismatch; iss check
- `PlatformAuthServiceTest` (16) — login outcomes; replay; lockout wiring; atomic setup
- `PlatformAuthIntegrationTest` (7) — end-to-end MFA flow through Spring MVC
- `PlatformIssRoutingTest` (3) — forged platform-iss tokens rejected on tenant + platform endpoints

**Field bug found-and-fixed by ITs**: `jdbc.update("SELECT void_func(?)")` is rejected by PG-JDBC (SELECT returns NULL row, executeUpdate refuses); switched the void-function callers to `queryForObject(..., Object.class)`. Would have surfaced as a 500 on first MFA verify in production.

## Warroom 2026-04-25 remediations applied (in-flight review before commit)

- M1 TOTP replay protection · M2 bcrypt timing equalization · M3 per-account counter wiring · M6 message-field stripped from error body
- A1 atomic `setup_mfa` · A2 Caffeine-cached active key · A3 `lookupForToken` → 401 · A4 enrolled-guard on `setupMfa`
- E1 partial index · E2 anonymized filter on unlock_expired · E3 `GET DIAGNOSTICS ROW_COUNT` · E4 V88 numbering decision
- C2 `@Scheduled` auto-unlock cron · R1 four test families · R3 `MigrationLintTest` citation tightened

## Deferred follow-ups (captured in `design.md`)

- F1 single-use scoped tokens (jti + consumed-token cache)
- F2 future `@PlatformAdminOnly` filter must assert `mfaVerified = true`
- F3 full platform-side metrics buildout (lands with G-4.5 alerts)
- F4 multi-module split for `fabt-cli` (currently a class inside backend artifact — pragmatic deviation from Decision 8 since the project is single-module; Decision 8's "separate JAR artifact" goal is preserved as a Maven Shade follow-up)

## Test plan

- [x] `mvn test` full suite green (1215/1215)
- [x] V88 migration test passes against fresh Testcontainers postgres
- [x] Forged platform-iss token rejected on tenant endpoint
- [x] Existing V87 tests still pass after V88 column/function additions + bootstrap-on-startup behavior
- [ ] CI green (Backend Maven, ArchUnit, Legal Scan, Karate, CodeQL)
- [ ] E2E green
- [ ] Manual smoke: bootstrap activation flow on a deploy preview (deferred to v0.53 release prep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)