### PR TITLE
feat(auth): G-4.4 — platform admin split + per-action audit log (v0.53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,89 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased] — v0.53.0 (Phase G-4: platform admin split + access log)
+
+**Backend-code release in progress.** Backend JAR will bump `0.52.0 → 0.53.0`.
+Flyway HWM advances `V85 → V89` (V87 + V88 + V89). Operator action required:
+review `docs/oracle-update-notes-v0.53.0.md` for the customer-comms note
+about PLATFORM_ADMIN deprecation + the new platform-operator login flow.
+
+### Changed (BREAKING for fresh-token issuance, NOT for existing JWTs)
+
+- **PLATFORM_ADMIN role deprecated** (`Role.java` `@Deprecated(forRemoval=true,
+  since="0.53.0")`). V87 backfills `COC_ADMIN` onto every existing app_user
+  whose roles array contained `PLATFORM_ADMIN`, so existing operator
+  accounts continue to work for tenant-scoped admin tasks (user management,
+  shelter management, OAuth2 provider config, API keys, TOTP admin
+  endpoints). The PLATFORM_ADMIN value is preserved in the enum for the
+  deprecation window so legacy JWTs still parse; cleanup release will
+  remove the value entirely. New ArchUnit rule
+  `NoPlatformAdminPreauthorizeTest` prevents re-introduction of the role
+  in `@PreAuthorize` expressions on controller methods.
+
+- **Tenant-lifecycle endpoints + per-tenant JWT key rotation + OAuth2
+  test-connection + batch-job control require PLATFORM_OPERATOR + MFA**.
+  These actions previously accepted any PLATFORM_ADMIN-bearing JWT; they
+  now require a separate platform-operator login at
+  `POST /api/v1/auth/platform/login` (different identity table, different
+  JWT issuer, mandatory TOTP). Activation runbook in
+  `docs/oracle-update-notes-v0.53.0.md`. Existing tenant operators do NOT
+  lose tenant-scoped capability (V87 backfill grants COC_ADMIN); only the
+  cross-tenant / platform-action surface moves behind the new role.
+
+- **HMIS push (`POST /api/v1/hmis/push`) — F16 mitigation.** Endpoint
+  remains COC_ADMIN-only (tenant-scoped). NEW: requires
+  `X-Confirm-HMIS-Push: CONFIRM` header to prevent accidental triggers
+  (mirrors the X-Confirm-Policy-Change pattern). Each push writes a
+  per-tenant `HMIS_EXPORT_TRIGGERED` audit_event row capturing actor
+  identity + vendor type list + outbox entry count. Replaces the
+  G-4.3 platform_admin_access_log audit trail that was attached during
+  the brief @PlatformAdminOnly migration window. Pre-G-4.3 baseline
+  required PLATFORM_ADMIN; the V87 backfill broadened that to COC_ADMIN —
+  operators with COC_ADMIN-only roles (no historical PLATFORM_ADMIN) are
+  now authorized to push. Audit chain captures the actor for review.
+  F14 captures the future cross-tenant operator-driven endpoint at
+  `POST /api/v1/admin/tenants/{id}/hmis/push` (deferred post-v0.53).
+
+### Added
+
+- **`platform_user` schema (V87)** — separate identity table for platform
+  operators. iss=`fabt-platform` JWT distinct from tenant JWTs. Bootstrap
+  row at id `00000000-0000-0000-0000-000000000fab` is inserted locked
+  with no credentials; activate via fabt-cli + manual UPDATE.
+
+- **`platform_user_lockout_columns` (V88)** — per-account 5-fail TOTP
+  lockout with 15-minute auto-unlock cron. Failed attempts tracked as a
+  rolling timestamp array; threshold trip flips `account_locked=true`.
+  V88 SECURITY DEFINER functions enforce REVOKE on platform_user.
+
+- **`platform_admin_access_log` (V89)** — append-only audit table for
+  every `@PlatformAdminOnly` controller method invocation. Captures
+  operator id, action, justification (operator-asserted text), request
+  fingerprint, and links to a chained `audit_event` row.
+
+- **`@PlatformAdminOnly` AOP aspect** with `JustificationValidationFilter`
+  + `MFA_VERIFIED` authority check. Defense-in-depth: even if a tenant
+  JWT somehow has PLATFORM_OPERATOR in its roles array, the aspect
+  rejects without the platform-JWT-only `MFA_VERIFIED` authority.
+
+- **`HMIS_EXPORT_TRIGGERED` audit event type** (tenant-scoped) — captures
+  COC_ADMIN-driven HMIS pushes per the F16 mitigation above.
+
+- **`TestPlatformUnlockController`** (`@Profile("dev | test")`) at
+  `POST /api/v1/test/platform/unlock-expired` for E2E lockout-spec
+  cleanup. ArchUnit rule `TestControllerProfileGuardTest` enforces the
+  profile gate on every `Test*Controller`.
+
+### Deferred follow-ups (in design.md F1-F19)
+
+- **F14** — cross-tenant operator-driven HMIS push endpoint
+- **F17** — Playwright fixture caching across tests (CI runtime)
+- **F18** — Prometheus alert on per-operator tenant-update rate
+- **F19** — Platform-operator observability config persistence IT
+
+---
+
 ## [v0.52.0] — Phase G slices 0–3: tamper-evident audit chain + OCI external anchor
 
 **Backend-code release.** Backend JAR bumped `0.51.0 → 0.52.0`. Flyway HWM

--- a/backend/src/main/java/org/fabt/analytics/api/AnalyticsController.java
+++ b/backend/src/main/java/org/fabt/analytics/api/AnalyticsController.java
@@ -39,7 +39,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/utilization")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "Utilization rates over time",
             description = "Returns utilization rates from pre-aggregated daily summaries, filterable by date range and granularity.")
     public ResponseEntity<Map<String, Object>> getUtilization(
@@ -51,7 +51,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/demand")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "Demand signals",
             description = "Reservation conversion/expiry rates and zero-result search counts.")
     public ResponseEntity<Map<String, Object>> getDemand(
@@ -62,7 +62,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/capacity")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "System capacity trends",
             description = "Total beds over time, add/remove deltas.")
     public ResponseEntity<Map<String, Object>> getCapacity(
@@ -73,7 +73,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/dv-summary")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "DV shelter aggregate statistics",
             description = "Aggregated DV shelter stats with minimum cell size 5 suppression. Requires dvAccess.")
     public ResponseEntity<Map<String, Object>> getDvSummary() throws Exception {
@@ -85,7 +85,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/geographic")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "Geographic shelter view",
             description = "Shelter locations with utilization data. DV shelters excluded from map.")
     public ResponseEntity<List<Map<String, Object>>> getGeographic() {
@@ -94,7 +94,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/hic")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "HIC export (CSV)",
             description = "Housing Inventory Count export in HUD format.")
     public ResponseEntity<String> getHicExport(
@@ -109,7 +109,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/pit")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "PIT export (CSV)",
             description = "Sheltered Point-in-Time count export in HUD format.")
     public ResponseEntity<String> getPitExport(
@@ -124,7 +124,7 @@ public class AnalyticsController {
     }
 
     @GetMapping("/hmis-health")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "HMIS push health",
             description = "HMIS push success/failure rates, last push per vendor, dead letter count.")
     public ResponseEntity<Map<String, Object>> getHmisHealth() {

--- a/backend/src/main/java/org/fabt/analytics/api/AnalyticsController.java
+++ b/backend/src/main/java/org/fabt/analytics/api/AnalyticsController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * CoC Analytics API endpoints (Design D3).
- * All endpoints require COC_ADMIN or PLATFORM_ADMIN.
+ * All endpoints require COC_ADMIN.
  * Returns aggregate data — no PII.
  */
 @RestController

--- a/backend/src/main/java/org/fabt/analytics/api/BatchJobController.java
+++ b/backend/src/main/java/org/fabt/analytics/api/BatchJobController.java
@@ -34,8 +34,13 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Batch job management API (Design D14).
- * GET endpoints: COC_ADMIN, PLATFORM_ADMIN.
- * Mutating endpoints: PLATFORM_ADMIN only.
+ * GET endpoints (list, executions): COC_ADMIN — read-only telemetry of the
+ *   shared scheduler. Documented platform-scope leak (deferred follow-up F20):
+ *   a CoC admin at Tenant A can see scheduler state for jobs that affect
+ *   Tenant B. Acceptable for v0.53 because no PII / tenant-scoped data leaks
+ *   through the metadata; future hardening tightens to PLATFORM_OPERATOR.
+ * Mutating endpoints (run, restart, schedule, enable): PLATFORM_OPERATOR +
+ *   @PlatformAdminOnly + X-Platform-Justification header (G-4.4).
  */
 @RestController
 @RequestMapping("/api/v1/batch/jobs")

--- a/backend/src/main/java/org/fabt/analytics/api/BatchJobController.java
+++ b/backend/src/main/java/org/fabt/analytics/api/BatchJobController.java
@@ -57,7 +57,7 @@ public class BatchJobController {
     }
 
     @GetMapping
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "List all batch jobs",
             description = "Returns all registered batch jobs with current schedule, enabled/disabled state, and last execution status.")
     public ResponseEntity<List<Map<String, Object>>> listJobs() {
@@ -91,7 +91,7 @@ public class BatchJobController {
     }
 
     @GetMapping("/{jobName}/executions")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     @Operation(summary = "Job execution history",
             description = "Returns execution history for a specific job with step-level detail.")
     public ResponseEntity<List<Map<String, Object>>> getExecutions(@PathVariable String jobName) {
@@ -143,7 +143,7 @@ public class BatchJobController {
     // this controller (and the other 12 platform-scoped endpoints across
     // the codebase) is G-4.4. PLATFORM_ADMIN remains in the @PreAuthorize
     // expression for the deprecation window; G-4.4 swaps to PLATFORM_OPERATOR.
-    @PreAuthorize("hasAnyRole('PLATFORM_OPERATOR', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     @PlatformAdminOnly(
             reason = "Batch job trigger requires platform authority — affects scheduled work for every tenant via shared scheduler",
             emits = AuditEventType.PLATFORM_BATCH_JOB_TRIGGERED)
@@ -162,7 +162,10 @@ public class BatchJobController {
     }
 
     @PostMapping("/{jobName}/restart/{executionId}")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @PlatformAdminOnly(
+            reason = "Restart of a failed batch job execution — platform authority required because it affects shared scheduler state across tenants",
+            emits = AuditEventType.PLATFORM_BATCH_JOB_TRIGGERED)
     @Operation(summary = "Restart failed execution",
             description = "Restarts a failed job execution from the last committed chunk.")
     public ResponseEntity<Map<String, Object>> restartExecution(
@@ -181,7 +184,10 @@ public class BatchJobController {
     }
 
     @PutMapping("/{jobName}/schedule")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @PlatformAdminOnly(
+            reason = "Cron rescheduling of a batch job — platform authority required because it changes when tenant-affecting work runs",
+            emits = AuditEventType.PLATFORM_BATCH_JOB_TRIGGERED)
     @Operation(summary = "Update job schedule",
             description = "Updates the cron expression for a batch job.")
     public ResponseEntity<Map<String, Object>> updateSchedule(
@@ -201,7 +207,10 @@ public class BatchJobController {
     }
 
     @PutMapping("/{jobName}/enable")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @PlatformAdminOnly(
+            reason = "Enable/disable a batch job — platform authority required because it suppresses or resumes tenant-affecting scheduled work",
+            emits = AuditEventType.PLATFORM_BATCH_JOB_TRIGGERED)
     @Operation(summary = "Enable or disable job",
             description = "Enables or disables a batch job's scheduled execution.")
     public ResponseEntity<Map<String, Object>> setEnabled(

--- a/backend/src/main/java/org/fabt/auth/api/AccessCodeController.java
+++ b/backend/src/main/java/org/fabt/auth/api/AccessCodeController.java
@@ -38,7 +38,7 @@ public class AccessCodeController {
                     + "Code expires in 15 minutes, single-use. Returns plaintext code once. "
                     + "DV safeguard: generating a code for a dvAccess=true user requires the admin to also have dvAccess.")
     @PostMapping("/{id}/generate-access-code")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<?> generateAccessCode(@PathVariable UUID id, Authentication auth) {
         UUID adminId = UUID.fromString(auth.getName());
         UUID tenantId = TenantContext.getTenantId();

--- a/backend/src/main/java/org/fabt/auth/api/ApiKeyController.java
+++ b/backend/src/main/java/org/fabt/auth/api/ApiKeyController.java
@@ -21,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/api-keys")
-@PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+@PreAuthorize("hasRole('COC_ADMIN')")
 public class ApiKeyController {
 
     private final ApiKeyService apiKeyService;

--- a/backend/src/main/java/org/fabt/auth/api/ApiKeyController.java
+++ b/backend/src/main/java/org/fabt/auth/api/ApiKeyController.java
@@ -39,7 +39,7 @@ public class ApiKeyController {
                     "key's UUID (for management operations), the plaintext key, and a suffix (last " +
                     "4 characters) for identification in logs and UI. The optional label field is " +
                     "a human-readable name for the key. Returns 201. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping
     public ResponseEntity<ApiKeyCreateResponse> createApiKey(@Valid @RequestBody CreateApiKeyRequest request) {
@@ -57,7 +57,7 @@ public class ApiKeyController {
                     "including id, suffix, label, shelterId binding, active status, and timestamps. " +
                     "The plaintext key is never returned — only the suffix is available for " +
                     "identification. Deactivated keys are included in the response (check the " +
-                    "active field). Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "active field). Requires COC_ADMIN role."
     )
     @GetMapping
     public ResponseEntity<List<ApiKeyResponse>> listApiKeys() {
@@ -74,7 +74,7 @@ public class ApiKeyController {
                     "authenticating requests, but the record is retained for audit purposes. This " +
                     "operation is idempotent — deactivating an already-inactive key returns 204 " +
                     "without error. Returns 204 No Content on success. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deactivateApiKey(
@@ -90,7 +90,7 @@ public class ApiKeyController {
                     "once — store it immediately. The key UUID, label, and shelter binding remain " +
                     "unchanged. Use this for periodic credential rotation or after a suspected " +
                     "key compromise. Returns 200 with the new key details. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping("/{id}/rotate")
     public ResponseEntity<ApiKeyCreateResponse> rotateApiKey(

--- a/backend/src/main/java/org/fabt/auth/api/OAuth2ProviderController.java
+++ b/backend/src/main/java/org/fabt/auth/api/OAuth2ProviderController.java
@@ -39,7 +39,7 @@ public class OAuth2ProviderController {
                     "like 'google' or 'azure-ad' — must be unique within the tenant), clientId, " +
                     "clientSecret, and issuerUri (the OIDC discovery URL). The clientSecret is stored " +
                     "encrypted. Returns 201 with the provider record (clientSecret is not echoed). " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping
     public ResponseEntity<OAuth2ProviderResponse> create(
@@ -64,7 +64,7 @@ public class OAuth2ProviderController {
                     "including both enabled and disabled providers. Each record includes providerName, " +
                     "clientId, issuerUri, enabled status, and timestamps. The clientSecret is never " +
                     "returned. Use this to audit which identity providers are configured. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @GetMapping
     public ResponseEntity<List<OAuth2ProviderResponse>> list(
@@ -83,7 +83,7 @@ public class OAuth2ProviderController {
                     "a field unchanged, pass its current value. Setting enabled to false disables " +
                     "SSO login for this provider without deleting the configuration. Returns the " +
                     "updated provider record. Returns 404 if the provider ID does not exist. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PutMapping("/{providerId}")
     public ResponseEntity<OAuth2ProviderResponse> update(
@@ -110,7 +110,7 @@ public class OAuth2ProviderController {
                     "SSO and must use password login or another configured provider. This is a hard " +
                     "delete — to temporarily disable a provider without losing its configuration, " +
                     "use the update endpoint to set enabled=false instead. Returns 204 No Content. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @DeleteMapping("/{providerId}")
     public ResponseEntity<Void> delete(

--- a/backend/src/main/java/org/fabt/auth/api/OAuth2ProviderController.java
+++ b/backend/src/main/java/org/fabt/auth/api/OAuth2ProviderController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/tenants/{tenantId}/oauth2-providers")
-@PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+@PreAuthorize("hasRole('COC_ADMIN')")
 public class OAuth2ProviderController {
 
     private final TenantOAuth2ProviderService providerService;

--- a/backend/src/main/java/org/fabt/auth/api/OAuth2TestConnectionController.java
+++ b/backend/src/main/java/org/fabt/auth/api/OAuth2TestConnectionController.java
@@ -16,7 +16,6 @@ import org.springframework.web.client.RestClient;
 
 @RestController
 @RequestMapping("/api/v1/oauth2")
-@PreAuthorize("hasRole('PLATFORM_ADMIN')")
 public class OAuth2TestConnectionController {
 
     private static final Logger log = LoggerFactory.getLogger(OAuth2TestConnectionController.class);
@@ -33,6 +32,10 @@ public class OAuth2TestConnectionController {
                     "to validate that the identity provider is reachable and properly configured."
     )
     @GetMapping("/test-connection")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "OAuth2 test-connection probe — issues an outbound HTTPS request to a tenant-supplied URL; platform authority required to prevent SSRF probing by tenant admins",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_OAUTH2_TESTED)
     public ResponseEntity<Map<String, Object>> testConnection(@RequestParam String issuerUri) {
         String wellKnown = issuerUri.replaceAll("/$", "") + "/.well-known/openid-configuration";
         try {

--- a/backend/src/main/java/org/fabt/auth/api/PasswordController.java
+++ b/backend/src/main/java/org/fabt/auth/api/PasswordController.java
@@ -87,7 +87,7 @@ public class PasswordController {
 
     @Operation(
             summary = "Reset a user's password (admin action)",
-            description = "Allows a COC_ADMIN or PLATFORM_ADMIN to reset the password for any user " +
+            description = "Allows a COC_ADMIN to reset the password for any user " +
                     "within their tenant. The admin sets a temporary password (minimum 12 characters) " +
                     "which should be communicated to the user out-of-band. The user's existing JWT tokens " +
                     "are invalidated and they must sign in with the new password. Returns 404 if the user " +

--- a/backend/src/main/java/org/fabt/auth/api/TotpController.java
+++ b/backend/src/main/java/org/fabt/auth/api/TotpController.java
@@ -180,7 +180,7 @@ public class TotpController {
     @Operation(summary = "Admin disables user's 2FA",
             description = "Clears TOTP secret and disables 2FA for a user (e.g., lost device). Audit-logged.")
     @DeleteMapping("/totp/{id}")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<?> disableUserTotp(@PathVariable UUID id) {
         // D1/D3: userService.getUser(id) pulls tenantId from TenantContext
         // and throws NoSuchElementException -> 404 on cross-tenant access.
@@ -209,7 +209,7 @@ public class TotpController {
     @Operation(summary = "Admin regenerates user's backup codes",
             description = "Invalidates all previous codes and returns new ones for verbal communication to the user.")
     @PostMapping("/totp/{id}/regenerate-recovery-codes")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<?> adminRegenerateRecoveryCodes(@PathVariable UUID id) {
         // D1/D3: userService.getUser(id) pulls tenantId from TenantContext
         // and throws NoSuchElementException -> 404 on cross-tenant access.

--- a/backend/src/main/java/org/fabt/auth/api/UserController.java
+++ b/backend/src/main/java/org/fabt/auth/api/UserController.java
@@ -31,7 +31,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/users")
-@PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+@PreAuthorize("hasRole('COC_ADMIN')")
 public class UserController {
 
     private final UserService userService;

--- a/backend/src/main/java/org/fabt/auth/api/UserController.java
+++ b/backend/src/main/java/org/fabt/auth/api/UserController.java
@@ -50,7 +50,7 @@ public class UserController {
                     "records; defaults to false). The dvAccess flag is a sensitive permission: only " +
                     "set it for users who have completed DV confidentiality training. Returns 201 " +
                     "with the created user. Returns 400 if email or displayName is blank. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping
     public ResponseEntity<UserResponse> createUser(@Valid @RequestBody CreateUserRequest request) {
@@ -62,7 +62,7 @@ public class UserController {
             summary = "List all users in the authenticated tenant",
             description = "Returns all users belonging to the caller's tenant. Each user record " +
                     "includes id, email, displayName, roles, dvAccess flag, status, and timestamps. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @GetMapping
     public ResponseEntity<List<UserResponse>> listUsers() {
@@ -76,7 +76,7 @@ public class UserController {
             summary = "Get a single user by ID within the authenticated tenant",
             description = "Returns the user with the specified UUID, provided the user belongs to " +
                     "the caller's tenant. Returns 404 if the user does not exist or belongs to a " +
-                    "different tenant. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "different tenant. Requires COC_ADMIN role."
     )
     @GetMapping("/{id}")
     public ResponseEntity<UserResponse> getUser(
@@ -90,7 +90,7 @@ public class UserController {
                     "in the request body are applied. Updatable fields: displayName, email, roles " +
                     "(replaces entire list), dvAccess. Role or dvAccess changes increment " +
                     "tokenVersion, invalidating the user's existing JWTs. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PutMapping("/{id}")
     public ResponseEntity<UserResponse> updateUser(
@@ -109,7 +109,7 @@ public class UserController {
             description = "Sets the user's status to DEACTIVATED or ACTIVE. Deactivated users " +
                     "cannot log in and their existing JWTs are immediately invalidated via " +
                     "tokenVersion increment. Deactivation also disconnects any active SSE " +
-                    "notification stream. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "notification stream. Requires COC_ADMIN role."
     )
     @PatchMapping("/{id}/status")
     public ResponseEntity<UserResponse> changeStatus(

--- a/backend/src/main/java/org/fabt/auth/platform/JustificationValidationFilter.java
+++ b/backend/src/main/java/org/fabt/auth/platform/JustificationValidationFilter.java
@@ -45,12 +45,31 @@ import org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandl
  *   <li><b>Post-Security</b> (current): the same probe gets back 401
  *       (Spring Security rejects first) — no info-disclosure. An
  *       authenticated caller with the wrong role gets 403 (Spring
- *       Security). Only an authenticated, role-correct caller with a
- *       missing/short justification gets 400 — the design intent.</li>
+ *       Security URL rule). Only an authenticated caller whose role
+ *       passes the URL rule but whose request is missing/short on
+ *       justification gets 400 — the design intent.</li>
  * </ul>
  *
  * <p>The performance trade-off is microseconds per rejected request,
  * which platform-admin endpoints don't have at meaningful volume anyway.
+ *
+ * <p>Triage-pass-2 pinning probe
+ * ({@code PlatformAdminAccessAspectTest#unauthenticatedWithoutJustificationRejectedAtFilter}):
+ * an anonymous request without the justification header receives 401
+ * (Spring Security URL rule rejects), proving the post-Security
+ * ordering still holds. If this assertion ever flips to 400, the
+ * filter ordering changed and this javadoc + the warroom design
+ * decision must be re-evaluated.
+ *
+ * <p>Practical consequences for tests with legacy {@code PLATFORM_ADMIN}-
+ * bearing fixtures: those users pass the {@code /api/v1/tenants/**}
+ * URL rule (which admits {@code hasAnyRole("PLATFORM_OPERATOR",
+ * "PLATFORM_ADMIN")} during the deprecation window), so the filter is
+ * the next gate. Negative-auth assertions for those fixtures MUST
+ * include the justification header, or the filter rejects with 400
+ * before the method-level {@code @PreAuthorize} can issue the 403 the
+ * test wants to observe. Use {@code TestAuthHelper.withJustification(
+ * headers, reason)} or {@code platformOperatorHeaders(reason)}.
  *
  * <p>Decision 10 ({@code X-Platform-Justification} is operator-asserted
  * documentation, NOT server-validated authority): the filter only checks

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformActionStateCapture.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformActionStateCapture.java
@@ -1,0 +1,151 @@
+package org.fabt.auth.platform;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.context.WebApplicationContext;
+
+/**
+ * Phase G-4.4 task §5.4a — request-scoped helper letting controllers
+ * annotated {@link PlatformAdminOnly} populate {@code before_state} /
+ * {@code after_state} JSONB columns on the {@code platform_admin_access_log}
+ * row.
+ *
+ * <h2>Why request-scoped + why a separate bean</h2>
+ *
+ * <p>The {@link PlatformAdminLogger} aspect runs {@code @Around} the
+ * controller method. Audit rows commit BEFORE {@code proceed()} (Decision
+ * 11), so the aspect cannot capture state at the natural service-call
+ * boundary inside the method body. Instead, the controller method itself
+ * calls {@link #captureBefore(Map)} just before the operation and
+ * {@link #captureAfter(Map)} just after. The aspect then drains the
+ * captured state from this request-scoped bean into the audit row.
+ *
+ * <p>Request scope is the right boundary because: (a) the bean is
+ * scoped to the lifecycle of a single platform-admin call; (b) Spring's
+ * {@code TARGET_CLASS} proxy lets the singleton aspect inject this bean
+ * transparently, with the proxy resolving to the current request's
+ * instance at every call.
+ *
+ * <h2>Allowlist enforcement (warroom P2)</h2>
+ *
+ * <p>The bean's {@link #captureBefore(Map)} / {@link #captureAfter(Map)}
+ * methods filter input through a denylist regex matching common secret-
+ * related keys ({@code password}, {@code secret}, {@code key},
+ * {@code token}, {@code hash}, {@code dek}, {@code cipher}, {@code salt},
+ * {@code signature}, {@code nonce}). Matching entries are dropped with a
+ * WARN log. Caller-side discipline (controller picks only safe fields)
+ * remains the primary defense; the denylist is defense-in-depth.
+ *
+ * <h2>What controllers should capture</h2>
+ *
+ * <p>Per-action allowlist (recommended fields, NOT enforced by the bean —
+ * the controller chooses):
+ * <ul>
+ *   <li><b>Tenant lifecycle</b> ({@code suspend / unsuspend / offboard / hardDelete}) —
+ *       {@code state}, {@code slug}, {@code name}, {@code archived_at},
+ *       {@code created_at}</li>
+ *   <li><b>Tenant key rotation</b> — {@code tenantId}, {@code generation_before},
+ *       {@code generation_after}</li>
+ *   <li><b>HMIS export</b> — {@code tenantId}, {@code row_count_estimate},
+ *       {@code export_format}</li>
+ *   <li><b>OAuth2 test connection</b> — {@code tenantId}, {@code provider_name},
+ *       {@code probe_outcome}</li>
+ *   <li><b>Batch job trigger</b> — {@code job_name}, {@code parameters_keys}
+ *       (key names only, not values)</li>
+ * </ul>
+ */
+@Component
+@Scope(value = WebApplicationContext.SCOPE_REQUEST, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class PlatformActionStateCapture {
+
+    private static final Logger log = LoggerFactory.getLogger(PlatformActionStateCapture.class);
+
+    /**
+     * Defense-in-depth denylist. Any map key matching this pattern (case-
+     * insensitive) is dropped from captured state. Errs on the side of
+     * over-rejection: callers should pick controlled allowlist field
+     * names that don't trigger the regex (e.g. {@code state} instead of
+     * {@code apiKey}). Pattern is intentionally broad.
+     */
+    private static final Pattern SECRET_KEY_DENYLIST = Pattern.compile(
+            "(?i).*(password|secret|key|token|hash|dek|kek|cipher|salt|signature|nonce|credential).*");
+
+    private Map<String, Object> beforeState;
+    private Map<String, Object> afterState;
+
+    /**
+     * Captures the entity state BEFORE the platform action runs. Called
+     * by the controller method just before the destructive / mutating
+     * operation. The caller selects which fields to capture; the bean
+     * filters out denylisted key patterns as defense-in-depth.
+     *
+     * @param state field name → value. Values must be JSON-serializable
+     *              (String, Number, Boolean, UUID, nested Map). Caller
+     *              is responsible for keeping payload below the V89
+     *              {@code pg_column_size <= 65536} CHECK constraint.
+     */
+    public void captureBefore(Map<String, Object> state) {
+        this.beforeState = filtered(state);
+    }
+
+    /**
+     * Captures the entity state AFTER the platform action runs. Called
+     * by the controller method just after the operation, but before the
+     * controller returns (the aspect has already committed PAL row with
+     * NULL after_state and AE row by this point — see Decision 11).
+     *
+     * <p>NOTE: at the time this method is called, the aspect's audit
+     * rows have ALREADY been committed (Decision 11 ordering). The
+     * aspect's commit happens BEFORE proceed(); after_state captured
+     * here is therefore visible to subsequent reads of the PAL row only
+     * if the aspect runs an UPDATE post-proceed — but PAL has the
+     * append-only trigger from V89/D4 which raises on UPDATE. <b>Conclusion:
+     * after_state populated via this helper is captured for in-memory
+     * forensics during the request scope but does NOT reach the PAL
+     * row.</b> See F13 follow-up in design.md.
+     *
+     * <p>For v0.53, controllers SHOULD still call this method — it
+     * surfaces the post-action state in application logs (the aspect
+     * logs MDC platform_action=true with the captured state on commit
+     * failure) and prepares for F13 when we restructure the aspect to
+     * commit PAL after proceed().
+     */
+    public void captureAfter(Map<String, Object> state) {
+        this.afterState = filtered(state);
+    }
+
+    /** Aspect entry point — reads the captured before-state, or null. */
+    Map<String, Object> getBeforeState() {
+        return beforeState;
+    }
+
+    /** Aspect entry point — reads the captured after-state, or null. */
+    Map<String, Object> getAfterState() {
+        return afterState;
+    }
+
+    private Map<String, Object> filtered(Map<String, Object> input) {
+        if (input == null || input.isEmpty()) {
+            return null;
+        }
+        Map<String, Object> result = new LinkedHashMap<>(input.size());
+        for (Map.Entry<String, Object> entry : input.entrySet()) {
+            if (SECRET_KEY_DENYLIST.matcher(entry.getKey()).matches()) {
+                log.warn("PlatformActionStateCapture dropped denylisted key '{}' — "
+                        + "platform-admin audit state-capture must not include credentials, "
+                        + "secrets, or key material. Caller should select only safe field "
+                        + "names (e.g. state, slug, generation).", entry.getKey());
+                continue;
+            }
+            result.put(entry.getKey(), entry.getValue());
+        }
+        return result.isEmpty() ? null : result;
+    }
+}

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformAdminAccessLogger.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformAdminAccessLogger.java
@@ -89,15 +89,21 @@ public class PlatformAdminAccessLogger {
                                      String requestMethod,
                                      String requestPath,
                                      String requestBodyExcerpt,
+                                     String beforeStateJson,
                                      String ipAddress) {
         // 1. INSERT PAL — single table, raw JdbcTemplate.
+        // before_state is populated from PlatformActionStateCapture if the
+        // controller called captureBefore() before the action runs. Per F13,
+        // after_state is always NULL on v0.53 — Decision 11's pre-proceed
+        // commit timing + the V89 append-only trigger together mean post-
+        // action state can't reach this row.
         jdbc.update(
                 "INSERT INTO platform_admin_access_log ("
                         + "id, platform_user_id, action, resource, resource_id, "
                         + "justification, request_method, request_path, "
                         + "request_body_excerpt, before_state, after_state, "
                         + "audit_event_id) "
-                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, NULL, NULL, ?)",
+                        + "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?::jsonb, NULL, ?)",
                 palId,
                 platformUserId,
                 action.name(),
@@ -107,6 +113,7 @@ public class PlatformAdminAccessLogger {
                 requestMethod,
                 requestPath,
                 requestBodyExcerpt,
+                beforeStateJson,
                 auditEventId);
 
         // 2. INSERT AE via the pre-assigned-id audit subsystem path.
@@ -176,6 +183,7 @@ public class PlatformAdminAccessLogger {
                     "INTERNAL",
                     "/auth/platform/login/mfa-verify",
                     null,
+                    null,  // before_state — no meaningful pre-action state for an internal lockout
                     ipAddress);
         } catch (RuntimeException e) {
             // Per Marcus warroom synthesis: failure to audit a lockout is

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformAdminLogger.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformAdminLogger.java
@@ -82,11 +82,17 @@ public class PlatformAdminLogger {
     private static final int REQUEST_BODY_EXCERPT_LIMIT = 2000;
 
     private final PlatformAdminAccessLogger writer;
+    private final PlatformActionStateCapture stateCapture;
+    private final tools.jackson.databind.ObjectMapper objectMapper;
     private final MeterRegistry meterRegistry;
 
     public PlatformAdminLogger(PlatformAdminAccessLogger writer,
+                                PlatformActionStateCapture stateCapture,
+                                tools.jackson.databind.ObjectMapper objectMapper,
                                 ObjectProvider<MeterRegistry> meterRegistryProvider) {
         this.writer = writer;
+        this.stateCapture = stateCapture;
+        this.objectMapper = objectMapper;
         this.meterRegistry = meterRegistryProvider.getIfAvailable();
     }
 
@@ -187,6 +193,12 @@ public class PlatformAdminLogger {
         UUID resourceId = resolveResourceId(pjp);
         String resource = resolveResourceName(annotation.emits());
 
+        // Drain captured before-state from the request-scoped bean.
+        // captureBefore() must be called by the controller pre-proceed
+        // for the field to land in PAL; null is fine when there's no
+        // meaningful state delta (e.g. read-only platform actions).
+        String beforeStateJson = serializeStateOrNull(stateCapture.getBeforeState());
+
         writer.writePlatformAction(
                 palId,
                 auditEventId,
@@ -199,6 +211,7 @@ public class PlatformAdminLogger {
                 requestMethod,
                 requestPath,
                 bodyExcerpt,
+                beforeStateJson,
                 ipAddress);
 
         emitMetric(annotation.emits(), "committed");
@@ -331,6 +344,35 @@ public class PlatformAdminLogger {
             return null;
         }
         return input.length() <= max ? input : input.substring(0, max);
+    }
+
+    /**
+     * Serializes a state map to a JSON string suitable for the {@code JSONB}
+     * column. Returns {@code null} for empty/missing input so the column
+     * stays NULL (the V89 size CHECK only applies to non-NULL values).
+     *
+     * <p>If serialization fails or the result exceeds the V89 size cap
+     * (64KB), returns {@code null} with a WARN log — better to drop the
+     * captured state than to fail the audit write entirely.
+     */
+    private String serializeStateOrNull(java.util.Map<String, Object> state) {
+        if (state == null || state.isEmpty()) {
+            return null;
+        }
+        try {
+            String json = objectMapper.writeValueAsString(state);
+            if (json.length() > 65000) {
+                log.warn("PlatformActionStateCapture state serialized to {} bytes — "
+                        + "above the V89 64KB CHECK; dropping to keep the audit write "
+                        + "successful.", json.length());
+                return null;
+            }
+            return json;
+        } catch (Exception e) {
+            log.warn("PlatformActionStateCapture state failed to serialize as JSON: {}",
+                    e.toString());
+            return null;
+        }
     }
 
     private void emitMetric(AuditEventType action, String outcome) {

--- a/backend/src/main/java/org/fabt/auth/platform/PlatformAdminLogger.java
+++ b/backend/src/main/java/org/fabt/auth/platform/PlatformAdminLogger.java
@@ -100,6 +100,21 @@ public class PlatformAdminLogger {
     @Around("@annotation(annotation)")
     public Object aroundPlatformAdminOnly(ProceedingJoinPoint pjp,
                                            PlatformAdminOnly annotation) throws Throwable {
+        // Defense-in-depth gate (F2 / G-4.4 task 5.4b): the SecurityContext
+        // authentication MUST carry the MFA_VERIFIED marker authority added
+        // by JwtAuthenticationFilter when binding a post-MFA platform JWT.
+        // If absent, reject BEFORE writing any audit rows. This catches a
+        // future regression in JwtAuthenticationFilter that might bind
+        // ROLE_PLATFORM_OPERATOR without requiring mfaVerified.
+        Authentication auth = SecurityContextHolder.getContext().getAuthentication();
+        if (auth == null || auth.getAuthorities().stream()
+                .noneMatch(a -> "MFA_VERIFIED".equals(a.getAuthority()))) {
+            log.warn("Platform admin endpoint hit without MFA_VERIFIED authority — "
+                    + "rejecting before audit write. action={}", annotation.emits());
+            throw new org.springframework.security.access.AccessDeniedException(
+                    "Platform admin endpoints require MFA-verified platform JWT");
+        }
+
         String previousMdc = MDC.get(MDC_PLATFORM_ACTION);
         MDC.put(MDC_PLATFORM_ACTION, "true");
         UUID palId = UUID.randomUUID();

--- a/backend/src/main/java/org/fabt/auth/platform/api/TestPlatformUnlockController.java
+++ b/backend/src/main/java/org/fabt/auth/platform/api/TestPlatformUnlockController.java
@@ -1,0 +1,85 @@
+package org.fabt.auth.platform.api;
+
+import java.util.Map;
+
+import org.fabt.auth.platform.repository.PlatformUserRepository;
+import org.fabt.shared.security.TenantUnscopedQuery;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Test-only endpoint for unlocking platform_user rows that were locked by
+ * the per-account TOTP-failure counter. Gated on {@code @Profile("dev |
+ * test")} — never instantiated in lite, standard, full, or prod profiles.
+ *
+ * <p>Phase G-4.4 §5.13 prereq (warroom Pre-spec 2): the
+ * {@code platform-totp-lockout.spec.ts} Playwright spec exhausts the
+ * per-account 5-fail counter to prove the lockout contract. Without a
+ * deterministic unlock path, the bootstrap row stays locked for 15
+ * minutes (the {@link org.fabt.auth.platform.PlatformLockoutCronJob}
+ * window), polluting every other spec that uses
+ * {@code loginPlatformOperator()}. This endpoint exposes the cron's
+ * {@link PlatformUserRepository#unlockExpired(int)} call with a
+ * {@code windowMin=0} override so the spec's {@code afterEach} can
+ * unlock immediately.
+ *
+ * <p>Two layers of dev/test gating:
+ * <ol>
+ *   <li>{@code @Profile("dev | test")} — Spring will not instantiate the
+ *       bean in any other profile (matches {@code TestResetController}
+ *       and {@code TestDataController} patterns).</li>
+ *   <li>No authentication required: this endpoint deliberately does NOT
+ *       require a platform JWT. Reasoning: the spec calling it has
+ *       potentially LOCKED its own operator session by exhausting MFA
+ *       attempts, so requiring an auth header would be circular. The
+ *       profile gate is the security boundary; if this controller
+ *       reaches a non-dev/test profile, that is the bug to fix —
+ *       not adding redundant auth on top of a profile gate that should
+ *       have prevented instantiation.</li>
+ * </ol>
+ *
+ * <p>SecurityConfig pairing: the URL pattern {@code /api/v1/test/**}
+ * already permits PLATFORM_OPERATOR + PLATFORM_ADMIN; this endpoint
+ * lives under that umbrella but is publicly callable when the bean
+ * exists (which is only in dev/test profiles by design).
+ */
+@RestController
+@RequestMapping("/api/v1/test/platform")
+@Profile("dev | test")
+public class TestPlatformUnlockController {
+
+    private static final Logger log = LoggerFactory.getLogger(TestPlatformUnlockController.class);
+
+    private final PlatformUserRepository platformUserRepository;
+
+    public TestPlatformUnlockController(PlatformUserRepository platformUserRepository) {
+        this.platformUserRepository = platformUserRepository;
+    }
+
+    /**
+     * Unlocks every {@code platform_user} row whose {@code locked_out_at}
+     * is older than {@code windowMin} minutes. The cron job uses
+     * {@code windowMin=15} in production; tests pass {@code windowMin=0}
+     * to unlock immediately.
+     *
+     * @param windowMin minutes since {@code locked_out_at} that must have
+     *                  elapsed for a row to be unlocked. {@code 0} =
+     *                  unlock-now (test-only semantic).
+     * @return JSON {"unlocked": N} where N is the count of rows unlocked
+     */
+    @TenantUnscopedQuery("test-only platform_user unlock; class is @Profile(\"dev | test\")-gated and unreachable in lite/standard/full/prod")
+    @PostMapping("/unlock-expired")
+    public ResponseEntity<Map<String, Integer>> unlockExpired(
+            @RequestParam(defaultValue = "0") int windowMin) {
+        int unlocked = platformUserRepository.unlockExpired(windowMin);
+        log.warn("TEST UNLOCK: cleared {} locked platform_user row(s) (windowMin={})",
+                unlocked, windowMin);
+        return ResponseEntity.ok(Map.of("unlocked", unlocked));
+    }
+}

--- a/backend/src/main/java/org/fabt/availability/api/AvailabilityController.java
+++ b/backend/src/main/java/org/fabt/availability/api/AvailabilityController.java
@@ -59,7 +59,7 @@ public class AvailabilityController {
                     "Requires COORDINATOR (assigned only), COC_ADMIN, or PLATFORM_ADMIN role."
     )
     @PatchMapping("/{id}/availability")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<AvailabilitySnapshot> updateAvailability(
             @Parameter(description = "UUID of the shelter to update availability for") @PathVariable UUID id,
             @Valid @RequestBody AvailabilityUpdateRequest request,

--- a/backend/src/main/java/org/fabt/dataimport/api/ImportController.java
+++ b/backend/src/main/java/org/fabt/dataimport/api/ImportController.java
@@ -62,7 +62,7 @@ public class ImportController {
                     "any row-level errors. An import log entry is recorded for audit. Returns 400 " +
                     "if the file is empty or contains no importable organizations. Returns 500 if " +
                     "the file cannot be parsed as valid HSDS JSON. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping("/hsds")
     public ResponseEntity<ImportResultResponse> importHsds(
@@ -96,7 +96,7 @@ public class ImportController {
                     "mapping before importing. The import is upsert-based. The response includes " +
                     "counts of created, updated, and skipped records, plus row-level errors. " +
                     "Returns 400 if the file is empty or contains no data rows. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping("/211")
     public ResponseEntity<ImportResultResponse> importTwoOneOne(
@@ -128,7 +128,7 @@ public class ImportController {
                     "columns map to which shelter fields and which columns will be ignored. Use this " +
                     "before calling POST /api/v1/import/211 to verify that the CSV format is " +
                     "compatible. This is a read-only, side-effect-free operation — no data is imported. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping("/211/preview")
     public ResponseEntity<ColumnMappingResponse> previewCsvMapping(
@@ -146,7 +146,7 @@ public class ImportController {
                     "updated, WITHOUT committing any changes. Shows per-row validation errors " +
                     "and DV flag change safety notices. Use this after column mapping preview " +
                     "and before the final POST /api/v1/import/211 commit. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping("/211/preview-import")
     public ResponseEntity<ImportResultResponse> previewImport(
@@ -176,7 +176,7 @@ public class ImportController {
                     "211_CSV), original filename, row counts (created, updated, skipped, errored), " +
                     "and the timestamp of the import. Use this to audit past imports and track " +
                     "data provenance. The list is unpaginated. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @GetMapping("/history")
     public ResponseEntity<List<ImportLogResponse>> history() {

--- a/backend/src/main/java/org/fabt/dataimport/api/ImportController.java
+++ b/backend/src/main/java/org/fabt/dataimport/api/ImportController.java
@@ -34,7 +34,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequestMapping("/api/v1/import")
-@PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+@PreAuthorize("hasRole('COC_ADMIN')")
 public class ImportController {
 
     private final ShelterImportService shelterImportService;

--- a/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
+++ b/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
@@ -54,7 +54,7 @@ public class HmisExportController {
     @Operation(summary = "Get HMIS export status",
             description = "Returns current export status per vendor: last push, status, next scheduled push.")
     @GetMapping("/status")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<Map<String, Object>> getStatus() {
         UUID tenantId = TenantContext.getTenantId();
         List<HmisVendorConfig> vendors = configService.getVendors(tenantId);
@@ -80,7 +80,7 @@ public class HmisExportController {
             description = "Returns the bed inventory data that would be pushed. DV shelters shown as " +
                     "aggregated row. Filterable by population type and DV/non-DV.")
     @GetMapping("/preview")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<List<HmisInventoryRecord>> getPreview(
             @Parameter(description = "Filter by population type") @RequestParam(required = false) String populationType,
             @Parameter(description = "Filter DV only") @RequestParam(required = false) Boolean dvOnly) throws Exception {
@@ -104,7 +104,7 @@ public class HmisExportController {
     @Operation(summary = "Get HMIS export history",
             description = "Returns audit log of past pushes. Filterable by vendor type.")
     @GetMapping("/history")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<List<HmisAuditEntry>> getHistory(
             @Parameter(description = "Filter by vendor type") @RequestParam(required = false) String vendorType,
             @Parameter(description = "Max results") @RequestParam(defaultValue = "50") int limit) {
@@ -119,9 +119,12 @@ public class HmisExportController {
     }
 
     @Operation(summary = "Trigger manual HMIS push",
-            description = "Initiates an immediate push to all enabled vendors. PLATFORM_ADMIN only.")
+            description = "Initiates an immediate push to all enabled vendors. PLATFORM_OPERATOR only.")
     @PostMapping("/push")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Manual HMIS push exports tenant data to external vendor systems — platform authority required",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
     public ResponseEntity<Map<String, Object>> manualPush() throws Exception {
         // D11: service pulls tenantId from TenantContext via
         // createOutboxEntriesForCurrentTenant; no pass-through.
@@ -133,7 +136,7 @@ public class HmisExportController {
     @Operation(summary = "List configured HMIS vendors",
             description = "Returns all HMIS vendor configurations for the tenant. API keys shown masked.")
     @GetMapping("/vendors")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     public ResponseEntity<List<Map<String, Object>>> listVendors() {
         UUID tenantId = TenantContext.getTenantId();
         List<HmisVendorConfig> vendors = configService.getVendors(tenantId);
@@ -151,7 +154,10 @@ public class HmisExportController {
     @Operation(summary = "[STUB] Add HMIS vendor — not yet implemented",
             description = "Placeholder endpoint. Returns hardcoded response. Will be implemented in platform-hardening change.")
     @PostMapping("/vendors")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Add HMIS vendor — platform authority required to configure external data export targets (stub; full impl in platform-hardening)",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
     public ResponseEntity<Map<String, Object>> addVendor(@RequestBody Map<String, Object> body) {
         return ResponseEntity.status(501).body(Map.of("error", "not_implemented",
                 "message", "HMIS vendor management is not yet implemented"));
@@ -161,7 +167,10 @@ public class HmisExportController {
     @Operation(summary = "[STUB] Update HMIS vendor — not yet implemented",
             description = "Placeholder endpoint. Returns 501. Will be implemented in platform-hardening change.")
     @PutMapping("/vendors/{vendorId}")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Update HMIS vendor — platform authority required to mutate external data export configuration (stub; full impl in platform-hardening)",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
     public ResponseEntity<Map<String, Object>> updateVendor(
             @PathVariable String vendorId, @RequestBody Map<String, Object> body) {
         return ResponseEntity.status(501).body(Map.of("error", "not_implemented",
@@ -172,16 +181,22 @@ public class HmisExportController {
     @Operation(summary = "[STUB] Remove HMIS vendor — not yet implemented",
             description = "Placeholder endpoint. Returns 501. Will be implemented in platform-hardening change.")
     @DeleteMapping("/vendors/{vendorId}")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Remove HMIS vendor — platform authority required to drop an external data export target (stub; full impl in platform-hardening)",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
     public ResponseEntity<Map<String, Object>> removeVendor(@PathVariable String vendorId) {
         return ResponseEntity.status(501).body(Map.of("error", "not_implemented",
                 "message", "HMIS vendor management is not yet implemented"));
     }
 
     @Operation(summary = "Retry dead-letter HMIS entry",
-            description = "Move a dead-letter outbox entry back to PENDING for reprocessing. PLATFORM_ADMIN only.")
+            description = "Move a dead-letter outbox entry back to PENDING for reprocessing. PLATFORM_OPERATOR only.")
     @PostMapping("/retry/{outboxId}")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Retry of a dead-letter HMIS export entry — platform authority required because it re-engages an outbound integration that previously failed",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
     public ResponseEntity<Map<String, Object>> retryDeadLetter(@PathVariable UUID outboxId) {
         pushService.retryDeadLetter(outboxId);
         return ResponseEntity.ok(Map.of("status", "entry reset to PENDING", "outboxId", outboxId.toString()));

--- a/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
+++ b/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
@@ -37,7 +37,10 @@ import org.springframework.web.bind.annotation.RestController;
 
 /**
  * Admin API for HMIS bridge management — export status, data preview, history, vendor config.
- * All endpoints require COC_ADMIN or PLATFORM_ADMIN. Write operations require PLATFORM_ADMIN.
+ * Most endpoints (status / preview / history / push / vendors / vendor CRUD stubs) require
+ * {@code COC_ADMIN} (tenant-scoped per the G-4.4 F16 revert). The cross-tenant
+ * {@code retry/{outboxId}} endpoint requires {@code PLATFORM_OPERATOR + @PlatformAdminOnly}.
+ * See CHANGELOG v0.53.0 + design.md F16 for the revert rationale.
  */
 @RestController
 @RequestMapping("/api/v1/hmis")

--- a/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
+++ b/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
@@ -119,15 +119,17 @@ public class HmisExportController {
     }
 
     @Operation(summary = "Trigger manual HMIS push",
-            description = "Initiates an immediate push to all enabled vendors. PLATFORM_OPERATOR only.")
+            description = "Initiates an immediate push to all enabled vendors. COC_ADMIN only — "
+                    + "tenant-scoped operation that exports the caller's tenant data.")
     @PostMapping("/push")
-    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
-    @org.fabt.auth.platform.PlatformAdminOnly(
-            reason = "Manual HMIS push exports tenant data to external vendor systems — platform authority required",
-            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<Map<String, Object>> manualPush() throws Exception {
-        // D11: service pulls tenantId from TenantContext via
-        // createOutboxEntriesForCurrentTenant; no pass-through.
+        // G-4.4 follow-up: HMIS push is conceptually tenant-scoped — the
+        // service pulls tenantId from TenantContext, so a platform-operator
+        // JWT (no tenant context) cannot meaningfully invoke it. Revert to
+        // COC_ADMIN. A future change can introduce a separate
+        // /api/v1/admin/tenants/{id}/hmis/push for cross-tenant platform-
+        // operator use that takes tenantId in the path.
         int created = pushService.createOutboxEntriesForCurrentTenant();
         pushService.processOutbox();
         return ResponseEntity.ok(Map.of("outboxEntriesCreated", created, "status", "push initiated"));
@@ -136,7 +138,7 @@ public class HmisExportController {
     @Operation(summary = "List configured HMIS vendors",
             description = "Returns all HMIS vendor configurations for the tenant. API keys shown masked.")
     @GetMapping("/vendors")
-    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<List<Map<String, Object>>> listVendors() {
         UUID tenantId = TenantContext.getTenantId();
         List<HmisVendorConfig> vendors = configService.getVendors(tenantId);
@@ -154,10 +156,7 @@ public class HmisExportController {
     @Operation(summary = "[STUB] Add HMIS vendor — not yet implemented",
             description = "Placeholder endpoint. Returns hardcoded response. Will be implemented in platform-hardening change.")
     @PostMapping("/vendors")
-    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
-    @org.fabt.auth.platform.PlatformAdminOnly(
-            reason = "Add HMIS vendor — platform authority required to configure external data export targets (stub; full impl in platform-hardening)",
-            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<Map<String, Object>> addVendor(@RequestBody Map<String, Object> body) {
         return ResponseEntity.status(501).body(Map.of("error", "not_implemented",
                 "message", "HMIS vendor management is not yet implemented"));
@@ -167,10 +166,7 @@ public class HmisExportController {
     @Operation(summary = "[STUB] Update HMIS vendor — not yet implemented",
             description = "Placeholder endpoint. Returns 501. Will be implemented in platform-hardening change.")
     @PutMapping("/vendors/{vendorId}")
-    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
-    @org.fabt.auth.platform.PlatformAdminOnly(
-            reason = "Update HMIS vendor — platform authority required to mutate external data export configuration (stub; full impl in platform-hardening)",
-            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<Map<String, Object>> updateVendor(
             @PathVariable String vendorId, @RequestBody Map<String, Object> body) {
         return ResponseEntity.status(501).body(Map.of("error", "not_implemented",
@@ -181,10 +177,7 @@ public class HmisExportController {
     @Operation(summary = "[STUB] Remove HMIS vendor — not yet implemented",
             description = "Placeholder endpoint. Returns 501. Will be implemented in platform-hardening change.")
     @DeleteMapping("/vendors/{vendorId}")
-    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
-    @org.fabt.auth.platform.PlatformAdminOnly(
-            reason = "Remove HMIS vendor — platform authority required to drop an external data export target (stub; full impl in platform-hardening)",
-            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_HMIS_EXPORTED)
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<Map<String, Object>> removeVendor(@PathVariable String vendorId) {
         return ResponseEntity.status(501).body(Map.of("error", "not_implemented",
                 "message", "HMIS vendor management is not yet implemented"));

--- a/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
+++ b/backend/src/main/java/org/fabt/hmis/api/HmisExportController.java
@@ -15,7 +15,13 @@ import org.fabt.hmis.repository.HmisAuditRepository;
 import org.fabt.hmis.repository.HmisOutboxRepository;
 import org.fabt.hmis.service.HmisConfigService;
 import org.fabt.hmis.service.HmisPushService;
+import org.fabt.shared.audit.AuditEventRecord;
+import org.fabt.shared.audit.AuditEventType;
 import org.fabt.shared.web.TenantContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -24,6 +30,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -36,19 +43,24 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/v1/hmis")
 public class HmisExportController {
 
+    private static final Logger log = LoggerFactory.getLogger(HmisExportController.class);
+
     private final HmisPushService pushService;
     private final HmisConfigService configService;
     private final HmisOutboxRepository outboxRepository;
     private final HmisAuditRepository auditRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     public HmisExportController(HmisPushService pushService,
                                 HmisConfigService configService,
                                 HmisOutboxRepository outboxRepository,
-                                HmisAuditRepository auditRepository) {
+                                HmisAuditRepository auditRepository,
+                                ApplicationEventPublisher eventPublisher) {
         this.pushService = pushService;
         this.configService = configService;
         this.outboxRepository = outboxRepository;
         this.auditRepository = auditRepository;
+        this.eventPublisher = eventPublisher;
     }
 
     @Operation(summary = "Get HMIS export status",
@@ -120,18 +132,84 @@ public class HmisExportController {
 
     @Operation(summary = "Trigger manual HMIS push",
             description = "Initiates an immediate push to all enabled vendors. COC_ADMIN only — "
-                    + "tenant-scoped operation that exports the caller's tenant data.")
+                    + "tenant-scoped operation that exports the caller's tenant data. "
+                    + "Requires X-Confirm-HMIS-Push: CONFIRM header to prevent accidental triggers. "
+                    + "Writes a tenant-scoped HMIS_EXPORT_TRIGGERED audit_event row with the "
+                    + "caller's userId, the vendor list, and the outbox entry count.")
     @PostMapping("/push")
     @PreAuthorize("hasRole('COC_ADMIN')")
-    public ResponseEntity<Map<String, Object>> manualPush() throws Exception {
-        // G-4.4 follow-up: HMIS push is conceptually tenant-scoped — the
-        // service pulls tenantId from TenantContext, so a platform-operator
-        // JWT (no tenant context) cannot meaningfully invoke it. Revert to
-        // COC_ADMIN. A future change can introduce a separate
-        // /api/v1/admin/tenants/{id}/hmis/push for cross-tenant platform-
-        // operator use that takes tenantId in the path.
+    public ResponseEntity<Map<String, Object>> manualPush(
+            @RequestHeader(value = "X-Confirm-HMIS-Push", required = false) String confirmHeader)
+            throws Exception {
+        // G-4.4 §F16 mitigation (Marcus/Jordan HIGH):
+        //
+        // (1) The HMIS push endpoint reverted from @PlatformAdminOnly to
+        //     COC_ADMIN — its service contract reads TenantContext, which
+        //     a platform-operator JWT does not populate. The revert
+        //     broadened authority (CoC admins who never had PLATFORM_ADMIN
+        //     are now authorized to trigger an outbound bed-inventory
+        //     export to a 3rd-party HMIS vendor) and dropped the
+        //     platform_admin_access_log audit trail G-4.3 attached.
+        //
+        // (2) Confirm-header gate: requiring X-Confirm-HMIS-Push: CONFIRM
+        //     prevents accidental triggers (e.g., a misclick on a future
+        //     admin UI button or a copy-paste curl). Mirrors the
+        //     X-Confirm-Policy-Change pattern on TenantController and the
+        //     X-Confirm-Reset pattern on TestResetController.
+        //
+        // (3) Audit event: per-tenant HMIS_EXPORT_TRIGGERED audit_event
+        //     row replaces the lost PAL row. Captures actor identity,
+        //     vendor list, and outbox count. Goes through the standard
+        //     ApplicationEventPublisher → AuditEventService onAuditEvent
+        //     pipeline so it lands on the tenant's audit chain like every
+        //     other tenant-scoped action.
+        //
+        // (4) F14 (separate /api/v1/admin/tenants/{id}/hmis/push for
+        //     cross-tenant platform-operator use) remains deferred to
+        //     G-4.5 / a dedicated micro-change post-v0.53.
+
+        if (!"CONFIRM".equals(confirmHeader)) {
+            return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(Map.of(
+                    "error", "missing_confirmation",
+                    "message", "Missing or invalid X-Confirm-HMIS-Push header. Send "
+                            + "'CONFIRM' to proceed. HMIS push is irreversible — every "
+                            + "vendor configured for this tenant will receive the current "
+                            + "bed inventory snapshot."));
+        }
+
+        UUID tenantId = TenantContext.getTenantId();
+        UUID actorUserId = TenantContext.getUserId();
         int created = pushService.createOutboxEntriesForCurrentTenant();
         pushService.processOutbox();
+
+        // Audit row: tenant-scoped, action=HMIS_EXPORT_TRIGGERED. Detail blob
+        // captures vendor type list + outbox count for compliance review.
+        // No vendor secrets / API keys land in the row (configService.getVendors
+        // returns the type enum + flags only when projected this way).
+        List<String> vendorTypes = configService.getVendors(tenantId).stream()
+                .filter(HmisVendorConfig::enabled)
+                .map(v -> v.type().name())
+                .toList();
+        try {
+            eventPublisher.publishEvent(new AuditEventRecord(
+                    actorUserId,
+                    null,
+                    AuditEventType.HMIS_EXPORT_TRIGGERED,
+                    Map.of(
+                            "vendorTypes", vendorTypes,
+                            "outboxEntriesCreated", created
+                    ),
+                    null
+            ));
+        } catch (RuntimeException e) {
+            // Don't fail the push because the audit row failed — log loud
+            // and continue. Operators MUST notice missing audit rows via
+            // the fabt.audit.system_insert.count alert (already wired in
+            // G-1) so a silent regression is impossible.
+            log.error("HMIS push audit event publish failed — push completed but "
+                    + "audit row may be missing. tenant={} actor={}", tenantId, actorUserId, e);
+        }
+
         return ResponseEntity.ok(Map.of("outboxEntriesCreated", created, "status", "push initiated"));
     }
 

--- a/backend/src/main/java/org/fabt/notification/api/EscalationPolicyController.java
+++ b/backend/src/main/java/org/fabt/notification/api/EscalationPolicyController.java
@@ -72,7 +72,7 @@ public class EscalationPolicyController {
                     + "for CoC admins and platform admins."
     )
     @GetMapping("/{eventType}")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<EscalationPolicyDto> getCurrentPolicy(
             @Parameter(description = "Event type identifier (e.g. 'dv-referral')") @PathVariable String eventType) {
         UUID tenantId = TenantContext.getTenantId();
@@ -95,7 +95,7 @@ public class EscalationPolicyController {
                     + "Writes ESCALATION_POLICY_UPDATED audit event. Authorized for CoC admins."
     )
     @PatchMapping("/{eventType}")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<EscalationPolicyDto> updatePolicy(
             @PathVariable String eventType,
             @Valid @RequestBody UpdateEscalationPolicyRequest request,

--- a/backend/src/main/java/org/fabt/referral/api/ReferralTokenController.java
+++ b/backend/src/main/java/org/fabt/referral/api/ReferralTokenController.java
@@ -76,7 +76,7 @@ public class ReferralTokenController {
                     "Authorized for CoC admins and platform admins. Contains zero PII."
     )
     @GetMapping("/escalated")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COC_ADMIN')")
     public ResponseEntity<List<EscalatedReferralDto>> getEscalatedQueue() {
         List<ReferralToken> tokens = referralTokenService.getEscalatedQueue();
 
@@ -112,7 +112,7 @@ public class ReferralTokenController {
                     "requires the Override-Claim header (or override=true query param) to steal."
     )
     @PostMapping("/{id}/claim")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COC_ADMIN')")
     public ResponseEntity<EscalatedReferralDto> claim(
             @PathVariable UUID id,
             @RequestParam(required = false, defaultValue = "false") boolean override,
@@ -135,7 +135,7 @@ public class ReferralTokenController {
 
     @Operation(summary = "Release a referral claim manually")
     @PostMapping("/{id}/release")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COC_ADMIN')")
     public ResponseEntity<Void> release(
             @PathVariable UUID id,
             @RequestParam(required = false, defaultValue = "false") boolean override,
@@ -157,7 +157,7 @@ public class ReferralTokenController {
                     + "took manual ownership). Writes DV_REFERRAL_REASSIGNED audit event."
     )
     @PostMapping("/{id}/reassign")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COC_ADMIN')")
     public ResponseEntity<Void> reassign(
             @PathVariable UUID id,
             @Valid @RequestBody ReassignReferralRequest request,
@@ -202,7 +202,7 @@ public class ReferralTokenController {
                     "allowed. Returns 409 if a duplicate exists. Requires dvAccess=true."
     )
     @PostMapping
-    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReferralTokenResponse> create(
             @Valid @RequestBody CreateReferralRequest request,
             Authentication authentication) {
@@ -232,7 +232,7 @@ public class ReferralTokenController {
                     "destination shelter is deactivated or no longer a DV shelter, status is returned as SHELTER_CLOSED."
     )
     @GetMapping("/mine")
-    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN')")
 
     public ResponseEntity<List<ReferralTokenResponse>> listMine(Authentication authentication) {
         UUID userId = UUID.fromString(authentication.getName());
@@ -302,7 +302,7 @@ public class ReferralTokenController {
                     "number. Contains zero client PII."
     )
     @GetMapping("/pending")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
 
     public ResponseEntity<List<ReferralTokenResponse>> listPending(
             @Parameter(description = "UUID of the DV shelter") @RequestParam UUID shelterId) {
@@ -325,7 +325,7 @@ public class ReferralTokenController {
                     + "and shelter."
     )
     @GetMapping("/pending/count")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<PendingReferralCountResponse> countPending(Authentication authentication) {
         UUID userId = UUID.fromString(authentication.getName());
         List<UUID> assignedShelterIds = coordinatorAssignmentRepository.findShelterIdsByUserId(userId);
@@ -350,7 +350,7 @@ public class ReferralTokenController {
                     + "Contains zero client PII (same shape as /pending list rows)."
     )
     @GetMapping("/{id}")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReferralTokenResponse> getById(
             @Parameter(description = "UUID of the referral token") @PathVariable UUID id) {
         ReferralToken token = referralTokenService.findById(id);
@@ -365,7 +365,7 @@ public class ReferralTokenController {
                     "NEVER through this system. Returns 409 if token is expired or not pending."
     )
     @PatchMapping("/{id}/accept")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReferralTokenResponse> accept(
             @Parameter(description = "UUID of the referral token") @PathVariable UUID id,
             Authentication authentication) {
@@ -382,7 +382,7 @@ public class ReferralTokenController {
                     "label is shown to shelter staff. Returns 409 if token is expired or not pending."
     )
     @PatchMapping("/{id}/reject")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReferralTokenResponse> reject(
             @Parameter(description = "UUID of the referral token") @PathVariable UUID id,
             @Valid @RequestBody RejectReferralRequest request,
@@ -401,7 +401,7 @@ public class ReferralTokenController {
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @GetMapping("/analytics")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COC_ADMIN')")
     public ResponseEntity<Map<String, Object>> analytics() {
         Map<String, Object> result = new LinkedHashMap<>();
         result.put("requested", getCounterValue("requested"));

--- a/backend/src/main/java/org/fabt/referral/api/ReferralTokenController.java
+++ b/backend/src/main/java/org/fabt/referral/api/ReferralTokenController.java
@@ -398,7 +398,7 @@ public class ReferralTokenController {
                     "rejected, expired) and average response time. Backed by Micrometer counters — " +
                     "no PII, no individual referral data. Counters persist in Prometheus when the " +
                     "observability stack is active; otherwise reset on backend restart. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @GetMapping("/analytics")
     @PreAuthorize("hasAnyRole('COC_ADMIN')")

--- a/backend/src/main/java/org/fabt/reservation/api/ManualHoldController.java
+++ b/backend/src/main/java/org/fabt/reservation/api/ManualHoldController.java
@@ -81,7 +81,7 @@ public class ManualHoldController {
                     "PATCH path that bypasses the recompute discipline."
     )
     @PostMapping("/{shelterId}/manual-hold")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReservationResponse> create(
             @Parameter(description = "UUID of the shelter to hold a bed at") @PathVariable UUID shelterId,
             @Valid @RequestBody ManualHoldRequest request,

--- a/backend/src/main/java/org/fabt/reservation/api/ReservationController.java
+++ b/backend/src/main/java/org/fabt/reservation/api/ReservationController.java
@@ -53,7 +53,7 @@ public class ReservationController {
                     "Requires OUTREACH_WORKER, COORDINATOR, COC_ADMIN, or PLATFORM_ADMIN role."
     )
     @PostMapping
-    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReservationResponse> create(
             @Valid @RequestBody CreateReservationRequest request,
             @RequestHeader(value = "X-Idempotency-Key", required = false) String idempotencyKey,
@@ -79,7 +79,7 @@ public class ReservationController {
                     + "status. Requires any authenticated role with reservation capability."
     )
     @GetMapping
-    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<List<ReservationResponse>> listForUser(
             @Parameter(description = "Comma-separated reservation statuses to include. "
                     + "Omit for HELD-only (legacy behavior).")
@@ -129,7 +129,7 @@ public class ReservationController {
                     "the reservation has already expired, been cancelled, or been confirmed."
     )
     @PatchMapping("/{id}/confirm")
-    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReservationResponse> confirm(
             @Parameter(description = "UUID of the reservation to confirm") @PathVariable UUID id,
             Authentication authentication) {
@@ -146,7 +146,7 @@ public class ReservationController {
                     "the reservation has already expired, been cancelled, or been confirmed."
     )
     @PatchMapping("/{id}/cancel")
-    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('OUTREACH_WORKER', 'COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ReservationResponse> cancel(
             @Parameter(description = "UUID of the reservation to cancel") @PathVariable UUID id,
             Authentication authentication) {

--- a/backend/src/main/java/org/fabt/shared/api/TestResetController.java
+++ b/backend/src/main/java/org/fabt/shared/api/TestResetController.java
@@ -57,9 +57,12 @@ public class TestResetController {
                     "IN PRODUCTION — it is profile-gated with @Profile(\"dev | test\"). Requires PLATFORM_ADMIN " +
                     "role and X-Confirm-Reset: DESTROY header."
     )
-    @TenantUnscopedQuery("test/dev-only DESTROY endpoint; class is @Profile(\"dev | test\")-gated and unreachable in lite/standard/full. PLATFORM_ADMIN + X-Confirm-Reset header required.")
+    @TenantUnscopedQuery("test/dev-only DESTROY endpoint; class is @Profile(\"dev | test\")-gated and unreachable in lite/standard/full. PLATFORM_OPERATOR + X-Confirm-Reset header required.")
     @DeleteMapping("/reset")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Test-data DESTROY — dev/test profile only; platform authority required because it wipes every tenant's data wholesale",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TEST_RESET_INVOKED)
     public ResponseEntity<?> resetTestData(
             @RequestHeader(value = "X-Confirm-Reset", required = false) String confirmHeader) throws Exception {
 

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventType.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventType.java
@@ -234,6 +234,27 @@ public enum AuditEventType {
      */
     BACKUP_CODES_REGENERATED,
 
+    // ─── HMIS export (tenant-scoped) ───
+
+    /**
+     * A COC_ADMIN triggered an HMIS export of their tenant's bed inventory
+     * via {@code POST /api/v1/hmis/push}. Tenant-scoped action — distinct
+     * from {@link #PLATFORM_HMIS_EXPORTED} (the platform-operator-driven
+     * cross-tenant flavour, deferred to F14). Detail blob:
+     * {@code {"vendorTypes": [...], "outboxEntriesCreated": N}}.
+     *
+     * <p>Phase G-4.4 §F16 mitigation: the HMIS push endpoint reverted from
+     * {@code @PlatformAdminOnly} to {@code COC_ADMIN}-only because its
+     * service contract reads {@code TenantContext}. The revert broadened
+     * authority (CoC admins who never had PLATFORM_ADMIN are now
+     * authorized) and dropped the platform_admin_access_log audit trail
+     * G-4.3 had attached. This audit_event row is the per-tenant
+     * replacement: every CoC admin's HMIS export attempt produces a row
+     * in {@code audit_events} with actor identity + vendor list, scoped
+     * to the calling tenant.
+     */
+    HMIS_EXPORT_TRIGGERED,
+
     /**
      * A platform admin forcibly disabled TOTP on another user's account via
      * {@code POST /api/v1/users/{id}/totp/disable}. Detail blob: {@code null}.

--- a/backend/src/main/java/org/fabt/shared/audit/AuditEventType.java
+++ b/backend/src/main/java/org/fabt/shared/audit/AuditEventType.java
@@ -476,6 +476,33 @@ public enum AuditEventType {
     PLATFORM_TENANT_CREATED,
 
     /**
+     * A PLATFORM_OPERATOR updated tenant display-name metadata via
+     * {@code PUT /api/v1/tenants/{id}}. Aspect-emitted; AE.tenant_id =
+     * target tenant. Distinct from {@link #PLATFORM_TENANT_CREATED} so
+     * oncall + SIEM rules can distinguish create-vs-update activity in
+     * audit timelines.
+     */
+    PLATFORM_TENANT_UPDATED,
+
+    /**
+     * A PLATFORM_OPERATOR updated a tenant's observability config via
+     * {@code PUT /api/v1/tenants/{id}/observability}. Aspect-emitted;
+     * AE.tenant_id = target tenant. Distinct event type so changes to
+     * monitoring/tracing posture can be queried independently of other
+     * tenant mutations.
+     */
+    PLATFORM_TENANT_OBSERVABILITY_UPDATED,
+
+    /**
+     * A PLATFORM_OPERATOR changed a tenant's DV-address visibility policy
+     * via {@code PUT /api/v1/tenants/{id}/dv-address-policy}. Aspect-
+     * emitted; AE.tenant_id = target tenant. Distinct event type because
+     * DV-address policy is the single highest-sensitivity tenant config —
+     * compliance reviews query this action class specifically.
+     */
+    PLATFORM_DV_ADDRESS_POLICY_CHANGED,
+
+    /**
      * A PLATFORM_OPERATOR triggered tenant suspension via
      * {@code POST /api/v1/tenants/{id}/suspend}. AE.tenant_id = target tenant.
      * Chained in target tenant's chain. See {@link #PLATFORM_TENANT_CREATED}

--- a/backend/src/main/java/org/fabt/shared/audit/api/AuditEventController.java
+++ b/backend/src/main/java/org/fabt/shared/audit/api/AuditEventController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/audit-events")
-@PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+@PreAuthorize("hasRole('COC_ADMIN')")
 public class AuditEventController {
 
     private final AuditEventService auditEventService;

--- a/backend/src/main/java/org/fabt/shared/security/JwtAuthenticationFilter.java
+++ b/backend/src/main/java/org/fabt/shared/security/JwtAuthenticationFilter.java
@@ -198,9 +198,20 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             PlatformJwtService.PlatformJwtClaims claims = platformJwtService.validateToken(token);
             String[] roles = claims.roles();
             if (roles != null && roles.length > 0 && claims.mfaVerified()) {
-                List<SimpleGrantedAuthority> authorities = Arrays.stream(roles)
+                // Build the authority list with TWO classes of authority:
+                // 1. ROLE_<role> per claim role (drives @PreAuthorize hasRole)
+                // 2. MFA_VERIFIED — marker authority added ONLY when the JWT
+                //    carries mfaVerified=true. Per design follow-up F2 / G-4.4
+                //    task 5.4b, this provides defense-in-depth: the
+                //    @PlatformAdminOnly aspect asserts the marker's presence
+                //    before writing audit rows. If a future change to this
+                //    filter accidentally grants ROLE_PLATFORM_OPERATOR without
+                //    requiring mfaVerified, the aspect still rejects.
+                List<SimpleGrantedAuthority> authorities = new java.util.ArrayList<>();
+                Arrays.stream(roles)
                         .map(role -> new SimpleGrantedAuthority("ROLE_" + role))
-                        .toList();
+                        .forEach(authorities::add);
+                authorities.add(new SimpleGrantedAuthority("MFA_VERIFIED"));
                 UsernamePasswordAuthenticationToken authentication =
                         new UsernamePasswordAuthenticationToken(claims.sub(), null, authorities);
                 SecurityContextHolder.getContext().setAuthentication(authentication);

--- a/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
@@ -153,8 +153,8 @@ public class SecurityConfig {
                         // POST /auth/login, /auth/refresh, /auth/access-code, /auth/verify-totp,
                         // POST /auth/forgot-password, /auth/reset-password, GET /auth/capabilities
                         // TOTP admin operations require COC_ADMIN+
-                        .requestMatchers(HttpMethod.DELETE, "/api/v1/auth/totp/*").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
-                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/totp/*/regenerate-recovery-codes").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        .requestMatchers(HttpMethod.DELETE, "/api/v1/auth/totp/*").hasRole("COC_ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/auth/totp/*/regenerate-recovery-codes").hasRole("COC_ADMIN")
                         .requestMatchers("/api/v1/auth/**").permitAll()
                         .requestMatchers("/oauth2/**", "/login/oauth2/**").permitAll()
                         .requestMatchers("/actuator/health/**").permitAll()
@@ -164,23 +164,30 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/tenants/*/oauth2-providers/public").permitAll()
                         .requestMatchers(HttpMethod.GET, "/api/v1/version").permitAll()
 
-                        // OAuth2 provider management — COC_ADMIN or PLATFORM_ADMIN
+                        // OAuth2 provider management — COC_ADMIN (G-4.4 stripped PLATFORM_ADMIN per V87 backfill posture)
                         // Must be BEFORE the general /api/v1/tenants/** matcher
-                        .requestMatchers("/api/v1/tenants/*/oauth2-providers/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        .requestMatchers("/api/v1/tenants/*/oauth2-providers/**").hasRole("COC_ADMIN")
 
-                        // Tenant management — PLATFORM_ADMIN only
-                        .requestMatchers("/api/v1/tenants/**").hasRole("PLATFORM_ADMIN")
+                        // OAuth2 test-connection — PLATFORM_OPERATOR (G-4.4: SSRF-mitigation; method also has @PlatformAdminOnly)
+                        .requestMatchers("/api/v1/oauth2/**").hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")
 
-                        // User management — COC_ADMIN or PLATFORM_ADMIN
-                        .requestMatchers("/api/v1/users/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        // Tenant management — PLATFORM_OPERATOR (G-4.4 / G-4.6); kept PLATFORM_ADMIN
+                        // in hasAnyRole for the deprecation window so existing tooling that still issues
+                        // PLATFORM_ADMIN-only JWTs receives 403 from method @PreAuthorize, not 401 from
+                        // URL-rule short-circuit. Method-level @PreAuthorize + @PlatformAdminOnly are
+                        // the real gates.
+                        .requestMatchers("/api/v1/tenants/**").hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")
 
-                        // API key management — COC_ADMIN or PLATFORM_ADMIN
-                        .requestMatchers("/api/v1/api-keys/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        // User management — COC_ADMIN (G-4.4 stripped PLATFORM_ADMIN per V87 backfill posture)
+                        .requestMatchers("/api/v1/users/**").hasRole("COC_ADMIN")
+
+                        // API key management — COC_ADMIN (G-4.4 stripped PLATFORM_ADMIN per V87 backfill posture)
+                        .requestMatchers("/api/v1/api-keys/**").hasRole("COC_ADMIN")
 
                         // Surge events — GET any authenticated, POST/PATCH COC_ADMIN+
                         .requestMatchers(HttpMethod.GET, "/api/v1/surge-events/**").authenticated()
-                        .requestMatchers(HttpMethod.POST, "/api/v1/surge-events/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
-                        .requestMatchers(HttpMethod.PATCH, "/api/v1/surge-events/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/surge-events/**").hasRole("COC_ADMIN")
+                        .requestMatchers(HttpMethod.PATCH, "/api/v1/surge-events/**").hasRole("COC_ADMIN")
 
                         // Reservations — outreach workers, coordinators, and admins
                         .requestMatchers("/api/v1/reservations/**").hasAnyRole("OUTREACH_WORKER", "COORDINATOR", "COC_ADMIN", "PLATFORM_ADMIN")
@@ -192,7 +199,7 @@ public class SecurityConfig {
                         .requestMatchers("/api/v1/hmis/**").authenticated()
 
                         // Analytics — COC_ADMIN or PLATFORM_ADMIN (fine-grained via @PreAuthorize)
-                        .requestMatchers("/api/v1/analytics/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        .requestMatchers("/api/v1/analytics/**").hasRole("COC_ADMIN")
 
                         // Batch job management — view: COC_ADMIN+, mutate: PLATFORM_OPERATOR / PLATFORM_ADMIN
                         // (G-4.3 canary + G-4.4 endpoint migration). Method-level
@@ -218,14 +225,14 @@ public class SecurityConfig {
                         // never be more restrictive than the controller body. Must precede the broader
                         // POST /shelters/** rule below since matchers are first-match-wins.
                         .requestMatchers(HttpMethod.POST, "/api/v1/shelters/*/manual-hold").hasAnyRole("COORDINATOR", "COC_ADMIN", "PLATFORM_ADMIN")
-                        .requestMatchers(HttpMethod.POST, "/api/v1/shelters/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        .requestMatchers(HttpMethod.POST, "/api/v1/shelters/**").hasRole("COC_ADMIN")
                         .requestMatchers(HttpMethod.PUT, "/api/v1/shelters/**").hasAnyRole("COORDINATOR", "COC_ADMIN", "PLATFORM_ADMIN")
 
                         // Import — COC_ADMIN or PLATFORM_ADMIN
-                        .requestMatchers("/api/v1/import/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        .requestMatchers("/api/v1/import/**").hasRole("COC_ADMIN")
 
                         // Audit events — COC_ADMIN or PLATFORM_ADMIN
-                        .requestMatchers("/api/v1/audit-events/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN")
+                        .requestMatchers("/api/v1/audit-events/**").hasRole("COC_ADMIN")
 
                         // SSE notifications — any authenticated role (token via query param)
                         .requestMatchers("/api/v1/notifications/stream").authenticated()

--- a/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
@@ -208,6 +208,17 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/batch/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN", "PLATFORM_OPERATOR")
                         .requestMatchers("/api/v1/batch/**").hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")
 
+                        // Test platform unlock-expired — profile-gated (dev/test only) per
+                        // TestPlatformUnlockController. The spec calling this endpoint may
+                        // have just LOCKED its operator session by exhausting MFA attempts,
+                        // so requiring an Authorization header would create a circular
+                        // dependency. The @Profile("dev | test") gate on the controller is
+                        // the security boundary — the bean does not exist outside dev/test
+                        // so this URL is unreachable in prod. Must be ordered BEFORE the
+                        // /api/v1/test/** catch-all below (Spring matchers are first-match-
+                        // wins).
+                        .requestMatchers(HttpMethod.POST, "/api/v1/test/platform/unlock-expired").permitAll()
+
                         // Test reset — profile-gated (dev/test only). G-4.4: migrated to
                         // PLATFORM_OPERATOR + @PlatformAdminOnly; URL rule kept inclusive of
                         // PLATFORM_ADMIN for the deprecation window so legacy JWTs receive 403

--- a/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
+++ b/backend/src/main/java/org/fabt/shared/security/SecurityConfig.java
@@ -208,8 +208,12 @@ public class SecurityConfig {
                         .requestMatchers(HttpMethod.GET, "/api/v1/batch/**").hasAnyRole("COC_ADMIN", "PLATFORM_ADMIN", "PLATFORM_OPERATOR")
                         .requestMatchers("/api/v1/batch/**").hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")
 
-                        // Test reset — profile-gated (dev/test only), requires PLATFORM_ADMIN + confirmation header
-                        .requestMatchers("/api/v1/test/**").hasRole("PLATFORM_ADMIN")
+                        // Test reset — profile-gated (dev/test only). G-4.4: migrated to
+                        // PLATFORM_OPERATOR + @PlatformAdminOnly; URL rule kept inclusive of
+                        // PLATFORM_ADMIN for the deprecation window so legacy JWTs receive 403
+                        // from method @PreAuthorize, not 401 short-circuit. Method-level
+                        // @PreAuthorize + @PlatformAdminOnly are the real gates.
+                        .requestMatchers("/api/v1/test/**").hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")
 
                         // Bed search queries — any authenticated role
                         .requestMatchers("/api/v1/queries/**").authenticated()

--- a/backend/src/main/java/org/fabt/shelter/api/ShelterController.java
+++ b/backend/src/main/java/org/fabt/shelter/api/ShelterController.java
@@ -66,7 +66,7 @@ public class ShelterController {
                     "domestic violence shelters — their records are hidden from users who do not " +
                     "have dvAccess=true on their user profile. Returns 201 with the created shelter " +
                     "including its generated UUID. Returns 400 if validation fails. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping
     @PreAuthorize("hasRole('COC_ADMIN')")
@@ -286,7 +286,7 @@ public class ShelterController {
     @Operation(
             summary = "List coordinators assigned to a shelter",
             description = "Returns the user IDs of coordinators assigned to the specified shelter. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @GetMapping("/{id}/coordinators")
     @PreAuthorize("hasRole('COC_ADMIN')")
@@ -304,7 +304,7 @@ public class ShelterController {
                     "profile via PUT /api/v1/shelters/{id}. The shelter must exist within the caller's " +
                     "tenant — returns 404 if not found. The request body must include the userId of the " +
                     "user to assign. Assigning an already-assigned coordinator is idempotent. " +
-                    "Returns 200 on success. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Returns 200 on success. Requires COC_ADMIN role."
     )
     @PostMapping("/{id}/coordinators")
     @PreAuthorize("hasRole('COC_ADMIN')")
@@ -323,9 +323,9 @@ public class ShelterController {
             summary = "Remove a coordinator assignment from a shelter",
             description = "Removes the assignment linking the specified user to the specified shelter. " +
                     "After removal, the user can no longer update this shelter (unless they also hold " +
-                    "COC_ADMIN or PLATFORM_ADMIN role). The shelter must exist within the caller's " +
+                    "COC_ADMIN role). The shelter must exist within the caller's " +
                     "tenant — returns 404 if not found. Removing a non-existent assignment is " +
-                    "idempotent and returns 204. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "idempotent and returns 204. Requires COC_ADMIN role."
     )
     @DeleteMapping("/{id}/coordinators/{userId}")
     @PreAuthorize("hasRole('COC_ADMIN')")
@@ -344,7 +344,7 @@ public class ShelterController {
             summary = "Deactivate a shelter",
             description = "Deactivates a shelter, making it invisible in bed search. Active holds are " +
                     "cancelled and outreach workers are notified. For DV shelters with pending referrals, " +
-                    "a confirmation is required. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "a confirmation is required. Requires COC_ADMIN role."
     )
     @PatchMapping("/{id}/deactivate")
     @PreAuthorize("hasRole('COC_ADMIN')")
@@ -381,7 +381,7 @@ public class ShelterController {
     @Operation(
             summary = "Reactivate a shelter",
             description = "Reactivates a previously deactivated shelter, making it visible in bed search " +
-                    "again. Clears all deactivation metadata. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "again. Clears all deactivation metadata. Requires COC_ADMIN role."
     )
     @PatchMapping("/{id}/reactivate")
     @PreAuthorize("hasRole('COC_ADMIN')")

--- a/backend/src/main/java/org/fabt/shelter/api/ShelterController.java
+++ b/backend/src/main/java/org/fabt/shelter/api/ShelterController.java
@@ -69,7 +69,7 @@ public class ShelterController {
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PostMapping
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<ShelterResponse> create(@Valid @RequestBody CreateShelterRequest request) {
         Shelter shelter = shelterService.create(request);
         return ResponseEntity.status(HttpStatus.CREATED).body(ShelterResponse.from(shelter));
@@ -251,7 +251,7 @@ public class ShelterController {
                     "Requires COORDINATOR (assigned only), COC_ADMIN, or PLATFORM_ADMIN role."
     )
     @PutMapping("/{id}")
-    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COORDINATOR', 'COC_ADMIN')")
     public ResponseEntity<ShelterResponse> update(
             @Parameter(description = "UUID of the shelter to update") @PathVariable UUID id,
             @Valid @RequestBody UpdateShelterRequest request,
@@ -289,7 +289,7 @@ public class ShelterController {
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @GetMapping("/{id}/coordinators")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<List<java.util.UUID>> listCoordinators(
             @Parameter(description = "UUID of the shelter") @PathVariable java.util.UUID id) {
         shelterService.findById(id)
@@ -307,7 +307,7 @@ public class ShelterController {
                     "Returns 200 on success. Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PostMapping("/{id}/coordinators")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<Void> assignCoordinator(
             @Parameter(description = "UUID of the shelter to assign the coordinator to") @PathVariable UUID id,
             @Valid @RequestBody AssignCoordinatorRequest request) {
@@ -328,7 +328,7 @@ public class ShelterController {
                     "idempotent and returns 204. Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @DeleteMapping("/{id}/coordinators/{userId}")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<Void> unassignCoordinator(
             @Parameter(description = "UUID of the shelter") @PathVariable UUID id,
             @Parameter(description = "UUID of the coordinator user to unassign") @PathVariable UUID userId) {
@@ -347,7 +347,7 @@ public class ShelterController {
                     "a confirmation is required. Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PatchMapping("/{id}/deactivate")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<?> deactivate(
             @Parameter(description = "UUID of the shelter to deactivate") @PathVariable UUID id,
             @Valid @RequestBody DeactivateShelterRequest request,
@@ -384,7 +384,7 @@ public class ShelterController {
                     "again. Clears all deactivation metadata. Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PatchMapping("/{id}/reactivate")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('COC_ADMIN')")
     public ResponseEntity<ShelterResponse> reactivate(
             @Parameter(description = "UUID of the shelter to reactivate") @PathVariable UUID id,
             Authentication authentication) {

--- a/backend/src/main/java/org/fabt/shelter/api/UserShelterController.java
+++ b/backend/src/main/java/org/fabt/shelter/api/UserShelterController.java
@@ -23,7 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
  */
 @RestController
 @RequestMapping("/api/v1/users")
-@PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+@PreAuthorize("hasRole('COC_ADMIN')")
 public class UserShelterController {
 
     private final CoordinatorAssignmentRepository coordinatorAssignmentRepository;

--- a/backend/src/main/java/org/fabt/shelter/api/UserShelterController.java
+++ b/backend/src/main/java/org/fabt/shelter/api/UserShelterController.java
@@ -38,7 +38,7 @@ public class UserShelterController {
                     "scoped to the caller's tenant. Each entry contains the shelter's UUID and name. " +
                     "Returns an empty array if the user has no assignments or belongs to a different tenant. " +
                     "DV shelters are only visible if the caller has dvAccess=true (RLS enforced). " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @GetMapping("/{id}/shelters")
     public ResponseEntity<List<ShelterSummary>> getUserShelters(

--- a/backend/src/main/java/org/fabt/surge/api/SurgeEventController.java
+++ b/backend/src/main/java/org/fabt/surge/api/SurgeEventController.java
@@ -36,7 +36,7 @@ public class SurgeEventController {
                     "shelter capacity is being opened. Only one surge can be active per tenant. " +
                     "The response includes affected_shelter_count and estimated_overflow_beds. " +
                     "A surge.activated event is published to the EventBus for webhook delivery. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PostMapping
     @PreAuthorize("hasAnyRole('COC_ADMIN')")
@@ -78,7 +78,7 @@ public class SurgeEventController {
             summary = "Deactivate a surge event",
             description = "Ends an active surge event. Transitions status to DEACTIVATED and " +
                     "publishes a surge.deactivated event to the EventBus. " +
-                    "Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "Requires COC_ADMIN role."
     )
     @PatchMapping("/{id}/deactivate")
     @PreAuthorize("hasAnyRole('COC_ADMIN')")

--- a/backend/src/main/java/org/fabt/surge/api/SurgeEventController.java
+++ b/backend/src/main/java/org/fabt/surge/api/SurgeEventController.java
@@ -39,7 +39,7 @@ public class SurgeEventController {
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PostMapping
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COC_ADMIN')")
     public ResponseEntity<SurgeEventResponse> activate(
             @Valid @RequestBody ActivateSurgeRequest request,
             Authentication authentication) {
@@ -81,7 +81,7 @@ public class SurgeEventController {
                     "Requires COC_ADMIN or PLATFORM_ADMIN role."
     )
     @PatchMapping("/{id}/deactivate")
-    @PreAuthorize("hasAnyRole('COC_ADMIN', 'PLATFORM_ADMIN')")
+    @PreAuthorize("hasAnyRole('COC_ADMIN')")
     public ResponseEntity<SurgeEventResponse> deactivate(
             @Parameter(description = "UUID of the surge event to deactivate") @PathVariable UUID id,
             Authentication authentication) {

--- a/backend/src/main/java/org/fabt/tenant/api/TenantConfigController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantConfigController.java
@@ -33,7 +33,7 @@ public class TenantConfigController {
                     "is stored as an arbitrary JSON object (Map<String, Object>) and may include keys " +
                     "such as feature flags, display preferences, or integration settings. Returns an " +
                     "empty map if no configuration has been set. Returns 404 if the tenant does not " +
-                    "exist. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "exist. Requires COC_ADMIN role."
     )
     @GetMapping
     public ResponseEntity<Map<String, Object>> getConfig(
@@ -50,7 +50,7 @@ public class TenantConfigController {
                     "from the request body will be removed. Returns the saved configuration after the " +
                     "update. To add a single key without losing others, first GET the current config, " +
                     "merge your changes client-side, then PUT the full map. Returns 404 if the tenant " +
-                    "does not exist. Requires COC_ADMIN or PLATFORM_ADMIN role."
+                    "does not exist. Requires COC_ADMIN role."
     )
     @PutMapping
     public ResponseEntity<Map<String, Object>> updateConfig(

--- a/backend/src/main/java/org/fabt/tenant/api/TenantConfigController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantConfigController.java
@@ -18,7 +18,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/tenants/{tenantId}/config")
-@PreAuthorize("hasAnyRole('PLATFORM_ADMIN', 'COC_ADMIN')")
+@PreAuthorize("hasRole('COC_ADMIN')")
 public class TenantConfigController {
 
     private final TenantService tenantService;

--- a/backend/src/main/java/org/fabt/tenant/api/TenantController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantController.java
@@ -33,7 +33,6 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequestMapping("/api/v1/tenants")
-@PreAuthorize("hasRole('PLATFORM_ADMIN')")
 public class TenantController {
 
     private static final Logger log = LoggerFactory.getLogger(TenantController.class);
@@ -68,6 +67,10 @@ public class TenantController {
                     "required fields (name, slug) are missing. Requires PLATFORM_ADMIN role."
     )
     @PostMapping
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Tenant creation — provisions a new isolation boundary; platform authority required",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
     public ResponseEntity<TenantResponse> create(@Valid @RequestBody CreateTenantRequest request) {
         // F-4: prefer the lifecycle service's atomic bootstrap when the feature
         // flag is on (TenantLifecycleService bean exists). Falls back to the
@@ -93,6 +96,7 @@ public class TenantController {
                     "admin dashboards. Requires PLATFORM_ADMIN role."
     )
     @GetMapping
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     public ResponseEntity<List<TenantResponse>> listAll() {
         List<TenantResponse> tenants = StreamSupport.stream(tenantService.findAll().spliterator(), false)
                 .map(TenantResponse::from)
@@ -107,6 +111,7 @@ public class TenantController {
                     "if no tenant exists with the given ID. Requires PLATFORM_ADMIN role."
     )
     @GetMapping("/{id}")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     public ResponseEntity<TenantResponse> getById(
             @Parameter(description = "UUID of the tenant to retrieve") @PathVariable UUID id) {
         return tenantService.findById(id)
@@ -123,6 +128,10 @@ public class TenantController {
                     "exist. Requires PLATFORM_ADMIN role."
     )
     @PutMapping("/{id}")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Tenant attribute update (display name) — platform authority required for any tenant-level metadata change",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
     public ResponseEntity<TenantResponse> update(
             @Parameter(description = "UUID of the tenant to update") @PathVariable UUID id,
             @Valid @RequestBody UpdateTenantRequest request) {
@@ -138,6 +147,7 @@ public class TenantController {
                     "tenant config JSONB and cached with a 60-second refresh interval."
     )
     @GetMapping("/{id}/observability")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     public ResponseEntity<ObservabilityConfig> getObservabilityConfig(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id) {
         TenantPathGuard.requireMatchingTenant(id);
@@ -151,6 +161,10 @@ public class TenantController {
                     "monitor intervals). Changes take effect within 60 seconds without restart."
     )
     @PutMapping("/{id}/observability")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Tenant observability config update — affects what monitoring + tracing flows out of the tenant; platform authority required",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
     public ResponseEntity<ObservabilityConfig> updateObservabilityConfig(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id,
             @RequestBody Map<String, Object> observabilitySettings) {
@@ -170,7 +184,10 @@ public class TenantController {
                     "INTERNAL/ADMIN-ONLY — this endpoint should not be exposed outside the corporate firewall."
     )
     @PutMapping("/{id}/dv-address-policy")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "DV-address visibility policy change — affects who can see DV shelter physical addresses; high compliance impact (VAWA-comparable posture); platform authority required",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
     public ResponseEntity<?> updateDvAddressPolicy(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id,
             @RequestBody Map<String, String> body,

--- a/backend/src/main/java/org/fabt/tenant/api/TenantController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantController.java
@@ -63,7 +63,7 @@ public class TenantController {
                     "are scoped to a tenant. The slug must be globally unique and is used in URLs and " +
                     "OAuth2 redirect URIs (e.g., 'atlanta-coc'). Returns 201 with the created tenant " +
                     "including its generated UUID. Returns 400 if the slug is already taken or if " +
-                    "required fields (name, slug) are missing. Requires PLATFORM_ADMIN role."
+                    "required fields (name, slug) are missing. Requires PLATFORM_OPERATOR role + X-Platform-Justification header."
     )
     @PostMapping
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
@@ -92,7 +92,7 @@ public class TenantController {
             description = "Returns every tenant registered on the platform. Each tenant represents " +
                     "a Continuum of Care organization. The response includes tenant id, name, slug, " +
                     "and timestamps. This is an unfiltered, unpaginated list — suitable for platform " +
-                    "admin dashboards. Requires PLATFORM_ADMIN role."
+                    "admin dashboards. Requires PLATFORM_OPERATOR role + X-Platform-Justification header."
     )
     @GetMapping
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
@@ -107,7 +107,7 @@ public class TenantController {
             summary = "Get a single tenant by ID",
             description = "Returns the tenant with the specified UUID. Use this to retrieve tenant " +
                     "details including name, slug, and timestamps. Returns 404 (via NoSuchElementException) " +
-                    "if no tenant exists with the given ID. Requires PLATFORM_ADMIN role."
+                    "if no tenant exists with the given ID. Requires PLATFORM_OPERATOR role + X-Platform-Justification header."
     )
     @GetMapping("/{id}")
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
@@ -124,13 +124,13 @@ public class TenantController {
             description = "Updates the name of an existing tenant. The slug cannot be changed after " +
                     "creation because it is embedded in OAuth2 redirect URIs and API key scoping. " +
                     "Returns the full updated tenant object. Returns 404 if the tenant ID does not " +
-                    "exist. Requires PLATFORM_ADMIN role."
+                    "exist. Requires PLATFORM_OPERATOR role + X-Platform-Justification header."
     )
     @PutMapping("/{id}")
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     @org.fabt.auth.platform.PlatformAdminOnly(
             reason = "Tenant attribute update (display name) — platform authority required for any tenant-level metadata change",
-            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_UPDATED)
     public ResponseEntity<TenantResponse> update(
             @Parameter(description = "UUID of the tenant to update") @PathVariable UUID id,
             @Valid @RequestBody UpdateTenantRequest request) {
@@ -172,7 +172,7 @@ public class TenantController {
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     @org.fabt.auth.platform.PlatformAdminOnly(
             reason = "Tenant observability config update — affects what monitoring + tracing flows out of the tenant; platform authority required",
-            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_OBSERVABILITY_UPDATED)
     public ResponseEntity<ObservabilityConfig> updateObservabilityConfig(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id,
             @RequestBody Map<String, Object> observabilitySettings) {
@@ -188,14 +188,14 @@ public class TenantController {
             summary = "Change DV address visibility policy",
             description = "Updates the DV shelter address visibility policy for a tenant. " +
                     "Valid policies: ADMIN_AND_ASSIGNED (default), ADMIN_ONLY, ALL_DV_ACCESS, NONE. " +
-                    "Requires PLATFORM_ADMIN role and X-Confirm-Policy-Change: CONFIRM header. " +
+                    "Requires PLATFORM_OPERATOR role + X-Platform-Justification header + X-Confirm-Policy-Change: CONFIRM header. " +
                     "INTERNAL/ADMIN-ONLY — this endpoint should not be exposed outside the corporate firewall."
     )
     @PutMapping("/{id}/dv-address-policy")
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     @org.fabt.auth.platform.PlatformAdminOnly(
             reason = "DV-address visibility policy change — affects who can see DV shelter physical addresses; high-sensitivity tenant config; platform authority required",
-            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_DV_ADDRESS_POLICY_CHANGED)
     public ResponseEntity<?> updateDvAddressPolicy(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id,
             @RequestBody Map<String, String> body,

--- a/backend/src/main/java/org/fabt/tenant/api/TenantController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantController.java
@@ -194,7 +194,7 @@ public class TenantController {
     @PutMapping("/{id}/dv-address-policy")
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     @org.fabt.auth.platform.PlatformAdminOnly(
-            reason = "DV-address visibility policy change — affects who can see DV shelter physical addresses; high compliance impact (VAWA-comparable posture); platform authority required",
+            reason = "DV-address visibility policy change — affects who can see DV shelter physical addresses; high-sensitivity tenant config; platform authority required",
             emits = org.fabt.shared.audit.AuditEventType.PLATFORM_TENANT_CREATED)
     public ResponseEntity<?> updateDvAddressPolicy(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id,

--- a/backend/src/main/java/org/fabt/tenant/api/TenantController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantController.java
@@ -13,7 +13,6 @@ import org.slf4j.LoggerFactory;
 import org.fabt.observability.ObservabilityConfigService;
 import org.fabt.observability.ObservabilityConfigService.ObservabilityConfig;
 import org.fabt.shared.web.TenantContext;
-import org.fabt.shared.web.TenantPathGuard;
 import org.fabt.tenant.domain.Tenant;
 import org.fabt.tenant.service.TenantLifecycleService;
 import org.fabt.tenant.service.TenantService;
@@ -135,7 +134,16 @@ public class TenantController {
     public ResponseEntity<TenantResponse> update(
             @Parameter(description = "UUID of the tenant to update") @PathVariable UUID id,
             @Valid @RequestBody UpdateTenantRequest request) {
-        TenantPathGuard.requireMatchingTenant(id);
+        // G-4.4: TenantPathGuard removed — endpoint is @PlatformAdminOnly, the
+        // platform-operator JWT carries NO tenantId (Decision 3 + 13), so the
+        // guard would 404 on every legitimate platform-scoped call. The
+        // @PlatformAdminOnly + MFA_VERIFIED + audit chain provide the
+        // cross-tenant authorization story; the guard's tenant-A-can't-touch-B
+        // invariant is now enforced by role separation (COC_ADMIN can't reach
+        // this method at all; only PLATFORM_OPERATOR can, and PLATFORM_OPERATOR
+        // is intentionally cross-tenant). Service layer still uses the
+        // path-supplied id for the lookup, so the audit chain captures the
+        // exact target tenant.
         Tenant tenant = tenantService.update(id, request.name());
         return ResponseEntity.ok(TenantResponse.from(tenant));
     }
@@ -150,7 +158,7 @@ public class TenantController {
     @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
     public ResponseEntity<ObservabilityConfig> getObservabilityConfig(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id) {
-        TenantPathGuard.requireMatchingTenant(id);
+        // G-4.4: TenantPathGuard removed — see TenantController.update for rationale.
         return ResponseEntity.ok(observabilityConfigService.getConfig(id));
     }
 
@@ -168,7 +176,7 @@ public class TenantController {
     public ResponseEntity<ObservabilityConfig> updateObservabilityConfig(
             @Parameter(description = "UUID of the tenant") @PathVariable UUID id,
             @RequestBody Map<String, Object> observabilitySettings) {
-        TenantPathGuard.requireMatchingTenant(id);
+        // G-4.4: TenantPathGuard removed — see TenantController.update for rationale.
         Map<String, Object> currentConfig = tenantService.getConfig(id);
         currentConfig.put("observability", observabilitySettings);
         tenantService.updateConfig(id, currentConfig);
@@ -194,7 +202,7 @@ public class TenantController {
             @RequestHeader(value = "X-Confirm-Policy-Change", required = false) String confirmHeader,
             Authentication authentication) {
 
-        TenantPathGuard.requireMatchingTenant(id);
+        // G-4.4: TenantPathGuard removed — see TenantController.update for rationale.
 
         if (!"CONFIRM".equals(confirmHeader)) {
             return ResponseEntity.badRequest()

--- a/backend/src/main/java/org/fabt/tenant/api/TenantKeyRotationController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantKeyRotationController.java
@@ -24,12 +24,13 @@ import org.springframework.web.bind.annotation.RestController;
  * {@link TenantKeyRotationService} so it joins the rotation
  * transaction).
  *
- * <p>{@code @PreAuthorize PLATFORM_ADMIN} matches the existing pattern in
- * {@code AccessCodeController} / {@code AnalyticsController}. The cross-
- * tenant guard at the service layer ({@code findByIdAndTenantId} on the
- * tenant lookup, plus the rotation operating on whatever tenantId is
- * supplied) means a PLATFORM_ADMIN can rotate ANY tenant's key — that's
- * the intended platform-level capability for emergency response.
+ * <p>G-4.4 migrated this endpoint to {@code @PreAuthorize PLATFORM_OPERATOR
+ * + @PlatformAdminOnly} so the action requires (a) the platform-JWT
+ * iss=fabt-platform identity, (b) MFA_VERIFIED authority on that JWT,
+ * (c) X-Platform-Justification header (≥10 chars ASCII), and (d) lands
+ * a PAL row + chained audit_event. The PLATFORM_OPERATOR role is
+ * intentionally cross-tenant — they can rotate ANY tenant's key, which
+ * is the intended platform-level capability for emergency response.
  *
  * <p><b>Rate limit (deferred):</b> warroom Q4 + Marcus M3 + Jordan call
  * for 1 rotation/tenant/min to prevent accidental rapid-rotation that
@@ -37,9 +38,10 @@ import org.springframework.web.bind.annotation.RestController;
  * jwt_revocations growth. Phase A4.3 ships without the rate limiter
  * (current FABT rate-limit infrastructure is per-IP via Bucket4j; per-
  * tenant rate-limit-config table lives in Phase E task 6.1). Tracked as
- * a follow-up issue; safe interim because PLATFORM_ADMIN is a small
- * trusted group + every rotation produces an audit row visible to
- * incident responders.
+ * a follow-up issue; safe interim because PLATFORM_OPERATOR is a small
+ * trusted group with mandatory MFA, the @PlatformAdminOnly aspect
+ * captures every invocation in PAL, and every rotation also produces
+ * an audit_event row visible to incident responders.
  */
 @RestController
 @RequestMapping("/api/v1/admin/tenants")
@@ -54,7 +56,7 @@ public class TenantKeyRotationController {
     }
 
     @Operation(
-            summary = "Rotate a tenant's JWT signing key (PLATFORM_ADMIN)",
+            summary = "Rotate a tenant's JWT signing key (PLATFORM_OPERATOR + MFA + justification header)",
             description = "Bumps the tenant's jwt_key_generation, deactivates the prior "
                     + "generation, adds all outstanding kids to the jwt_revocations "
                     + "blocklist (7-day expires_at ceiling), and invalidates the "
@@ -74,7 +76,7 @@ public class TenantKeyRotationController {
             @PathVariable UUID tenantId,
             Authentication auth) {
         UUID actorUserId = parseActorOrNull(auth);
-        log.info("PLATFORM_ADMIN-triggered JWT key rotation: tenant={} actor={}",
+        log.info("PLATFORM_OPERATOR-triggered JWT key rotation: tenant={} actor={}",
                 tenantId, actorUserId);
 
         TenantKeyRotationService.RotationResult result =

--- a/backend/src/main/java/org/fabt/tenant/api/TenantKeyRotationController.java
+++ b/backend/src/main/java/org/fabt/tenant/api/TenantKeyRotationController.java
@@ -65,7 +65,10 @@ public class TenantKeyRotationController {
                     + "{tenantId, oldGen, newGen, actorUserId, revokedKidCount} for "
                     + "compliance trail. Returns 202 + summary.")
     @PostMapping("/{tenantId}/rotate-jwt-key")
-    @PreAuthorize("hasRole('PLATFORM_ADMIN')")
+    @PreAuthorize("hasRole('PLATFORM_OPERATOR')")
+    @org.fabt.auth.platform.PlatformAdminOnly(
+            reason = "Per-tenant JWT signing-key rotation — invalidates every in-flight token for the target tenant; platform authority required",
+            emits = org.fabt.shared.audit.AuditEventType.PLATFORM_KEY_ROTATED)
     public ResponseEntity<Map<String, Object>> rotateJwtKey(
             @Parameter(description = "UUID of the tenant whose JWT key to rotate")
             @PathVariable UUID tenantId,

--- a/backend/src/test/java/org/fabt/ArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/ArchitectureTest.java
@@ -1,5 +1,7 @@
 package org.fabt;
 
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -15,23 +17,43 @@ class ArchitectureTest {
 
     // shared.security is allowed to depend on auth module (Design D1 rule #5:
     // "auth module is a dependency exception — security filters need auth services")
+    //
+    // G-4.4 narrow exception: PlatformAdminOnly is a cross-cutting security
+    // annotation analogous to @PreAuthorize. The TestResetController in
+    // shared.api applies it for audit + justification capture; the annotation
+    // itself has no behavior (the AOP aspect lives in auth.platform). Treating
+    // it as a permitted cross-cutting dependency keeps the shared.api → audit
+    // contract clean without forcing a relocation of the controller.
+    private static final DescribedPredicate<JavaClass> domainModulesExceptPlatformAdminAnnotation =
+            new DescribedPredicate<JavaClass>("domain modules (except auth.platform.PlatformAdminOnly)") {
+                @Override
+                public boolean test(JavaClass input) {
+                    String name = input.getFullName();
+                    if ("org.fabt.auth.platform.PlatformAdminOnly".equals(name)) {
+                        return false;
+                    }
+                    String pkg = input.getPackageName();
+                    return pkg.startsWith("org.fabt.tenant")
+                            || pkg.startsWith("org.fabt.auth")
+                            || pkg.startsWith("org.fabt.shelter")
+                            || pkg.startsWith("org.fabt.dataimport")
+                            || pkg.startsWith("org.fabt.observability")
+                            || pkg.startsWith("org.fabt.subscription")
+                            || pkg.startsWith("org.fabt.availability")
+                            || pkg.startsWith("org.fabt.reservation")
+                            || pkg.startsWith("org.fabt.surge")
+                            || pkg.startsWith("org.fabt.analytics")
+                            || pkg.startsWith("org.fabt.notification");
+                }
+            };
+
     @ArchTest
     static final ArchRule shared_non_security_should_not_depend_on_modules =
             noClasses().that().resideInAPackage("org.fabt.shared..")
                     .and().resideOutsideOfPackage("org.fabt.shared.security..")
-                    .should().dependOnClassesThat().resideInAnyPackage(
-                            "org.fabt.tenant..",
-                            "org.fabt.auth..",
-                            "org.fabt.shelter..",
-                            "org.fabt.dataimport..",
-                            "org.fabt.observability..",
-                            "org.fabt.subscription..",
-                            "org.fabt.availability..",
-                            "org.fabt.reservation..",
-                            "org.fabt.surge..",
-                            "org.fabt.analytics..",
-                            "org.fabt.notification.."
-                    ).as("Shared kernel (except security) must not depend on any domain module");
+                    .should().dependOnClassesThat(domainModulesExceptPlatformAdminAnnotation)
+                    .as("Shared kernel (except security) must not depend on any domain module "
+                            + "(PlatformAdminOnly annotation excepted as cross-cutting security)");
 
     @ArchTest
     static final ArchRule shared_security_only_depends_on_auth =

--- a/backend/src/test/java/org/fabt/ArchitectureTest.java
+++ b/backend/src/test/java/org/fabt/ArchitectureTest.java
@@ -24,12 +24,19 @@ class ArchitectureTest {
     // itself has no behavior (the AOP aspect lives in auth.platform). Treating
     // it as a permitted cross-cutting dependency keeps the shared.api → audit
     // contract clean without forcing a relocation of the controller.
+    //
+    // Triage-pass-2 warroom narrowing (Alex MEDIUM): the exception requires
+    // BOTH (a) the fully-qualified name match AND (b) the target class be an
+    // annotation. If someone later adds a static helper or nested type to
+    // PlatformAdminOnly, the exception stays scoped to the annotation surface
+    // only — it cannot silently drag in non-annotation auth.platform symbols.
     private static final DescribedPredicate<JavaClass> domainModulesExceptPlatformAdminAnnotation =
-            new DescribedPredicate<JavaClass>("domain modules (except auth.platform.PlatformAdminOnly)") {
+            new DescribedPredicate<JavaClass>("domain modules (except auth.platform.PlatformAdminOnly annotation)") {
                 @Override
                 public boolean test(JavaClass input) {
                     String name = input.getFullName();
-                    if ("org.fabt.auth.platform.PlatformAdminOnly".equals(name)) {
+                    if ("org.fabt.auth.platform.PlatformAdminOnly".equals(name)
+                            && input.isAnnotation()) {
                         return false;
                     }
                     String pkg = input.getPackageName();

--- a/backend/src/test/java/org/fabt/TestAuthHelper.java
+++ b/backend/src/test/java/org/fabt/TestAuthHelper.java
@@ -327,6 +327,41 @@ public class TestAuthHelper {
     }
 
     /**
+     * Convenience: activate the bootstrap platform_user and return a fully
+     * formed {@link HttpHeaders} with the platform JWT bearer + the
+     * {@code X-Platform-Justification} header populated. Designed for the
+     * G-4.4 IT triage pass where every {@code @PlatformAdminOnly} endpoint
+     * call needs both pieces.
+     *
+     * <p>The justification header MUST be ASCII (JDK 17+ http client rejects
+     * non-ASCII) and at least 10 characters after trim.
+     */
+    public HttpHeaders platformOperatorHeaders(String justification) {
+        PlatformOperatorFixture fixture = setupPlatformOperator();
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", fixture.bearer());
+        headers.set("X-Platform-Justification", justification);
+        headers.set("Content-Type", "application/json");
+        return headers;
+    }
+
+    /**
+     * Convenience: build a {@code X-Platform-Justification}-only header set
+     * for tests that want to exercise the security/aspect rejection path
+     * for non-platform-operator roles. Without the justification header the
+     * JustificationValidationFilter rejects with 400 before security can
+     * reach the role check; this helper builds the bypass for non-platform
+     * JWTs so the security/aspect rejection (401/403) is what the test
+     * actually observes.
+     */
+    public HttpHeaders withJustification(HttpHeaders headers, String justification) {
+        HttpHeaders copy = new HttpHeaders();
+        copy.putAll(headers);
+        copy.set("X-Platform-Justification", justification);
+        return copy;
+    }
+
+    /**
      * Resets the bootstrap platform_user to the V87 INSERTed state.
      * IT classes call this in {@code @AfterEach} to keep the shared
      * Spring context clean for sibling test classes.

--- a/backend/src/test/java/org/fabt/analytics/AnalyticsIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/analytics/AnalyticsIntegrationTest.java
@@ -284,7 +284,7 @@ class AnalyticsIntegrationTest extends BaseIntegrationTest {
     @Test
     void batchJobsEndpoint_returnsJobList() {
         var platformAdmin = authHelper.setupUserWithDvAccess(
-                "batch-admin@test.fabt.org", "Batch Admin", new String[]{"PLATFORM_ADMIN"});
+                "batch-admin@test.fabt.org", "Batch Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders platformHeaders = authHelper.headersForUser(platformAdmin);
 
         ResponseEntity<List<Map<String, Object>>> response = restTemplate.exchange(

--- a/backend/src/test/java/org/fabt/architecture/NoPlatformAdminPreauthorizeTest.java
+++ b/backend/src/test/java/org/fabt/architecture/NoPlatformAdminPreauthorizeTest.java
@@ -1,0 +1,100 @@
+package org.fabt.architecture;
+
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaAnnotation;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchRule;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.access.prepost.PreAuthorize;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.methods;
+
+/**
+ * G-4.4 task §5.6 — ArchUnit guard preventing future re-introduction of
+ * {@code @PreAuthorize("...PLATFORM_ADMIN...")} on controller methods.
+ *
+ * <p><b>Why this rule.</b> The G-4.4 endpoint migration replaced
+ * {@code hasRole('PLATFORM_ADMIN')} with either {@code hasRole('COC_ADMIN')}
+ * (tenant-scoped) or {@code hasRole('PLATFORM_OPERATOR')} +
+ * {@code @PlatformAdminOnly} (platform-scoped). The {@code Role.PLATFORM_ADMIN}
+ * enum value is {@code @Deprecated(forRemoval=true, since="0.53.0")} and
+ * scheduled for removal in the cleanup release. A future PR that
+ * re-introduces a {@code @PreAuthorize} expression mentioning
+ * {@code PLATFORM_ADMIN} would silently re-attach the deprecated role to a
+ * production endpoint — exactly the regression we want to prevent.
+ *
+ * <p><b>Scope.</b> Only checks methods in {@code org.fabt.*.api} packages
+ * (controller layer). Comments / Javadoc / migration SQL files
+ * legitimately mention PLATFORM_ADMIN and are excluded by the
+ * import-option restriction. Test classes are also excluded — IT helpers
+ * may construct historical-state scenarios that reference the deprecated
+ * role.
+ *
+ * <p><b>Trigger to relax.</b> The cleanup release that removes
+ * {@code Role.PLATFORM_ADMIN} entirely should ALSO remove this rule (or
+ * at minimum re-purpose it as a literal-string scan, since the enum
+ * itself will be gone and Java compilation enforces the absence).
+ */
+@DisplayName("G-4.4 §5.6 — no @PreAuthorize references PLATFORM_ADMIN")
+class NoPlatformAdminPreauthorizeTest {
+
+    private static final JavaClasses MAIN_CLASSES = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
+            .importPackages("org.fabt");
+
+    @Test
+    @Disabled("G-4.4 migration in progress — un-disable in the same commit that completes "
+            + "the bulk @PreAuthorize migration. The rule is correct; main just isn't yet "
+            + "compliant with it on this feature branch.")
+    @DisplayName("no controller method's @PreAuthorize value contains PLATFORM_ADMIN")
+    void noControllerPreauthorizeReferencesPlatformAdmin() {
+        ArchRule rule = methods()
+                .that().areDeclaredInClassesThat().resideInAPackage("..api..")
+                .and().areAnnotatedWith(PreAuthorize.class)
+                .should(notReferencePlatformAdmin())
+                .as("@PreAuthorize on controller methods MUST NOT mention PLATFORM_ADMIN. "
+                        + "Migrated to COC_ADMIN (tenant-scoped) or PLATFORM_OPERATOR + "
+                        + "@PlatformAdminOnly (platform-scoped) per G-4.4. The deprecated "
+                        + "Role.PLATFORM_ADMIN enum value will be removed in the cleanup release.")
+                .allowEmptyShould(true);
+        rule.check(MAIN_CLASSES);
+    }
+
+    private static com.tngtech.archunit.lang.ArchCondition<com.tngtech.archunit.core.domain.JavaMethod>
+            notReferencePlatformAdmin() {
+        return new com.tngtech.archunit.lang.ArchCondition<>(
+                "not reference PLATFORM_ADMIN in @PreAuthorize value") {
+            @Override
+            public void check(com.tngtech.archunit.core.domain.JavaMethod method,
+                              com.tngtech.archunit.lang.ConditionEvents events) {
+                method.getAnnotations().stream()
+                        .filter(byTypeName(PreAuthorize.class.getName()))
+                        .forEach(a -> {
+                            Object value = a.get("value").orElse(null);
+                            if (value != null && value.toString().contains("PLATFORM_ADMIN")) {
+                                events.add(com.tngtech.archunit.lang.SimpleConditionEvent.violated(
+                                        method,
+                                        "Method " + method.getFullName()
+                                                + " has @PreAuthorize(\"" + value
+                                                + "\") which mentions PLATFORM_ADMIN — migrate to "
+                                                + "COC_ADMIN or PLATFORM_OPERATOR per G-4.4."));
+                            }
+                        });
+            }
+        };
+    }
+
+    private static DescribedPredicate<JavaAnnotation<?>> byTypeName(String fqn) {
+        return new DescribedPredicate<>("annotation type " + fqn) {
+            @Override
+            public boolean test(JavaAnnotation<?> a) {
+                return a.getRawType().getName().equals(fqn);
+            }
+        };
+    }
+}

--- a/backend/src/test/java/org/fabt/architecture/NoPlatformAdminPreauthorizeTest.java
+++ b/backend/src/test/java/org/fabt/architecture/NoPlatformAdminPreauthorizeTest.java
@@ -6,7 +6,6 @@ import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchRule;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -48,9 +47,6 @@ class NoPlatformAdminPreauthorizeTest {
             .importPackages("org.fabt");
 
     @Test
-    @Disabled("G-4.4 migration in progress — un-disable in the same commit that completes "
-            + "the bulk @PreAuthorize migration. The rule is correct; main just isn't yet "
-            + "compliant with it on this feature branch.")
     @DisplayName("no controller method's @PreAuthorize value contains PLATFORM_ADMIN")
     void noControllerPreauthorizeReferencesPlatformAdmin() {
         ArchRule rule = methods()

--- a/backend/src/test/java/org/fabt/architecture/TestControllerProfileGuardTest.java
+++ b/backend/src/test/java/org/fabt/architecture/TestControllerProfileGuardTest.java
@@ -1,0 +1,114 @@
+package org.fabt.architecture;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.context.annotation.Profile;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+/**
+ * Phase G-4.4 §5.13 prereq (warroom Pre-spec 2 Marcus HIGH) — every
+ * controller whose name starts with {@code Test} (test-only fixture
+ * controllers) MUST carry a {@code @Profile} annotation that excludes
+ * production profiles. The fixture pattern is to gate on
+ * {@code @Profile("dev | test")} so Spring never instantiates the bean
+ * outside dev/test contexts.
+ *
+ * <p><b>Why this rule.</b> Test-only controllers expose mutation
+ * surface area (test reset, account unlock, snapshot backdate) that
+ * MUST never be reachable in production. Profile gating is the
+ * security boundary — there is no auth check on the endpoint itself
+ * because the bean does not exist outside dev/test. A missing or
+ * mistyped {@code @Profile} annotation (e.g. {@code @Profile("default")}
+ * or no annotation) would leave the endpoint hot in production. This
+ * rule pins the contract.
+ *
+ * <p><b>Triggered by.</b> Adding a new {@code Test*Controller} class
+ * without a profile gate, or adding a profile gate whose value omits
+ * the dev/test discriminator. The error message tells you what to add.
+ *
+ * <p><b>Pattern reference.</b> See:
+ * <ul>
+ *   <li>{@code TestResetController} (shared.api) — {@code @Profile("dev | test")}</li>
+ *   <li>{@code TestDataController} (availability.api) — {@code @Profile("test")}</li>
+ *   <li>{@code TestPlatformUnlockController} (auth.platform.api) — {@code @Profile("dev | test")}</li>
+ * </ul>
+ */
+@DisplayName("Test-only controllers must carry a non-prod @Profile gate")
+class TestControllerProfileGuardTest {
+
+    private static final JavaClasses MAIN_CLASSES = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_JARS)
+            .importPackages("org.fabt");
+
+    @Test
+    @DisplayName("every Test*Controller has @Profile that includes 'dev' or 'test'")
+    void testControllersAreProfileGated() {
+        ArchRule rule = classes()
+                .that().haveSimpleNameStartingWith("Test")
+                .and().haveSimpleNameEndingWith("Controller")
+                .should(carryDevOrTestProfileGate())
+                .as("Every test-only controller (class name starting with 'Test' and "
+                        + "ending with 'Controller') MUST carry a @Profile annotation "
+                        + "whose expression includes 'dev' or 'test'. The profile gate "
+                        + "is the security boundary that keeps test-only mutation "
+                        + "surface area out of production. See TestResetController "
+                        + "+ TestDataController for the canonical patterns.")
+                .allowEmptyShould(true);
+        rule.check(MAIN_CLASSES);
+    }
+
+    private static ArchCondition<com.tngtech.archunit.core.domain.JavaClass>
+            carryDevOrTestProfileGate() {
+        return new ArchCondition<>(
+                "carry @Profile(\"...\") expression containing 'dev' or 'test'") {
+            @Override
+            public void check(com.tngtech.archunit.core.domain.JavaClass clazz,
+                              ConditionEvents events) {
+                if (!clazz.isAnnotatedWith(Profile.class)) {
+                    events.add(SimpleConditionEvent.violated(
+                            clazz,
+                            "Class " + clazz.getName() + " is a Test*Controller but "
+                                    + "carries NO @Profile annotation — it would be active "
+                                    + "in every Spring profile including prod. Add "
+                                    + "@Profile(\"dev | test\")."));
+                    return;
+                }
+                Profile profile = clazz.getAnnotationOfType(Profile.class);
+                String[] values = profile.value();
+                if (values == null || values.length == 0) {
+                    events.add(SimpleConditionEvent.violated(
+                            clazz,
+                            "Class " + clazz.getName() + " has @Profile() with empty value."));
+                    return;
+                }
+                boolean ok = false;
+                for (String expr : values) {
+                    if (expr == null) continue;
+                    String lower = expr.toLowerCase();
+                    if (lower.contains("dev") || lower.contains("test")) {
+                        ok = true;
+                        break;
+                    }
+                }
+                if (!ok) {
+                    events.add(SimpleConditionEvent.violated(
+                            clazz,
+                            "Class " + clazz.getName() + " has @Profile but its expression "
+                                    + "does NOT include 'dev' or 'test'. Found: "
+                                    + java.util.Arrays.toString(values)
+                                    + ". Test-only controllers MUST gate on dev or test profile "
+                                    + "so they are never instantiated in production."));
+                }
+            }
+        };
+    }
+}

--- a/backend/src/test/java/org/fabt/auth/RoleBasedAccessTest.java
+++ b/backend/src/test/java/org/fabt/auth/RoleBasedAccessTest.java
@@ -30,7 +30,14 @@ class RoleBasedAccessTest extends BaseIntegrationTest {
     }
 
     @Test
-    void test_platformAdmin_canCreateTenant() {
+    void test_platformAdmin_cannotCreateTenant_postG44() {
+        // G-4.4 §5.4 migrated /api/v1/tenants from PLATFORM_ADMIN to
+        // PLATFORM_OPERATOR + @PlatformAdminOnly. The legacy admin user
+        // (tenant JWT with PLATFORM_ADMIN role) MUST get 403 — tenant-scoped
+        // identities can no longer trigger platform actions. The positive
+        // case (PLATFORM_OPERATOR can create) is covered by the
+        // PlatformAdminAccessAspectTest IT family + the new G-4.4 endpoint
+        // tests using the platform_user fixture.
         HttpHeaders headers = authHelper.adminHeaders();
         String slug = "rbac-admin-" + UUID.randomUUID().toString().substring(0, 8);
         String body = """
@@ -44,7 +51,10 @@ class RoleBasedAccessTest extends BaseIntegrationTest {
                 String.class
         );
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.CREATED);
+        assertThat(response.getStatusCode())
+                .as("after G-4.4, tenant-scoped admin JWT cannot create tenants — "
+                        + "platform-operator login required")
+                .isIn(HttpStatus.FORBIDDEN, HttpStatus.BAD_REQUEST);
     }
 
     @Test

--- a/backend/src/test/java/org/fabt/auth/platform/PlatformAdminAccessAspectTest.java
+++ b/backend/src/test/java/org/fabt/auth/platform/PlatformAdminAccessAspectTest.java
@@ -256,6 +256,85 @@ class PlatformAdminAccessAspectTest extends BaseIntegrationTest {
     }
 
     // -----------------------------------------------------------------
+    // mfaVerified=false rejection (G-4.4 task 5.13a, F2 follow-up)
+    // -----------------------------------------------------------------
+
+    @Test
+    @DisplayName("forged platform JWT with mfaVerified=false → 401, no log rows (F2 defense-in-depth)")
+    void forgedMfaUnverifiedTokenRejected() throws Exception {
+        long palBefore = countPalRows();
+        long aeBefore = countAeRowsForAction("PLATFORM_BATCH_JOB_TRIGGERED");
+
+        // Build a JWT signed with the ACTIVE platform key but with
+        // mfaVerified=false in the payload. The JWT signature is valid;
+        // the only thing wrong is the claim. JwtAuthenticationFilter
+        // should refuse to bind SecurityContext (existing G-4.2 logic),
+        // so Spring Security rejects with 401 BEFORE the aspect runs.
+        String forged = forgeMfaUnverifiedPlatformToken();
+
+        ResponseEntity<Map> response = postCanary("Bearer " + forged, VALID_JUSTIFICATION, "{}");
+
+        assertThat(response.getStatusCode())
+                .as("mfaVerified=false MUST be rejected before reaching @PlatformAdminOnly")
+                .isIn(HttpStatus.UNAUTHORIZED, HttpStatus.FORBIDDEN);
+        assertThat(countPalRows())
+                .as("no PAL row written for mfaVerified=false token")
+                .isEqualTo(palBefore);
+        assertThat(countAeRowsForAction("PLATFORM_BATCH_JOB_TRIGGERED"))
+                .as("no AE row written for mfaVerified=false token")
+                .isEqualTo(aeBefore);
+    }
+
+    /**
+     * Builds a platform JWT signed with the ACTIVE platform key but with
+     * {@code mfaVerified=false}. Used by {@link #forgedMfaUnverifiedTokenRejected}
+     * to verify the F2 defense-in-depth check.
+     *
+     * <p>This bypasses {@code PlatformJwtService.generateAccessToken}
+     * (which always sets {@code mfaVerified=true}) by emitting the
+     * payload manually. Real attackers without the platform key cannot
+     * produce a valid signature, so this test scenario simulates either
+     * a key compromise OR a hypothetical regression in
+     * {@code PlatformJwtService} that could allow such a token.
+     */
+    private String forgeMfaUnverifiedPlatformToken() throws Exception {
+        org.fabt.auth.platform.PlatformKeyRotationService.ActiveKey active =
+                applicationContext.getBean(
+                        org.fabt.auth.platform.PlatformKeyRotationService.class).findActiveKey();
+
+        java.util.Map<String, Object> header = new java.util.LinkedHashMap<>();
+        header.put("alg", "HS256");
+        header.put("typ", "JWT");
+        header.put("kid", active.kid());
+
+        long now = java.time.Instant.now().getEpochSecond();
+        java.util.Map<String, Object> payload = new java.util.LinkedHashMap<>();
+        payload.put("iss", "fabt-platform");
+        payload.put("sub", java.util.UUID.randomUUID().toString());
+        payload.put("roles", java.util.List.of("PLATFORM_OPERATOR"));
+        payload.put("mfaVerified", false);  // ← the forged claim
+        payload.put("ver", 0);
+        payload.put("iat", now);
+        payload.put("exp", now + 900);
+
+        tools.jackson.databind.ObjectMapper json =
+                tools.jackson.databind.json.JsonMapper.builder().build();
+        String headerB64 = base64Url(json.writeValueAsBytes(header));
+        String payloadB64 = base64Url(json.writeValueAsBytes(payload));
+        String signingInput = headerB64 + "." + payloadB64;
+        javax.crypto.Mac mac = javax.crypto.Mac.getInstance("HmacSHA256");
+        mac.init(active.key());
+        byte[] sig = mac.doFinal(signingInput.getBytes(java.nio.charset.StandardCharsets.UTF_8));
+        return signingInput + "." + base64Url(sig);
+    }
+
+    private static String base64Url(byte[] data) {
+        return java.util.Base64.getUrlEncoder().withoutPadding().encodeToString(data);
+    }
+
+    @Autowired private org.springframework.context.ApplicationContext applicationContext;
+
+    // -----------------------------------------------------------------
     // FK enforcement (M-RV1 verification)
     // -----------------------------------------------------------------
 

--- a/backend/src/test/java/org/fabt/auth/platform/PlatformAdminAccessAspectTest.java
+++ b/backend/src/test/java/org/fabt/auth/platform/PlatformAdminAccessAspectTest.java
@@ -107,15 +107,41 @@ class PlatformAdminAccessAspectTest extends BaseIntegrationTest {
     // -----------------------------------------------------------------
 
     @Test
-    @DisplayName("unauthenticated request → 401; no log rows written")
-    void unauthenticatedRejectedAtSecurity() {
+    @DisplayName("unauthenticated request WITH justification → 401; no log rows written")
+    void unauthenticatedWithJustificationRejectedAtSecurity() {
         long palBefore = countPalRows();
 
         ResponseEntity<Map> response = postCanary(null, VALID_JUSTIFICATION, "{}");
 
-        // Post-Security ordering (warroom M-RV2): Spring Security rejects
-        // first — operator gets 401, NOT 400. No info-disclosure that
-        // the endpoint has @PlatformAdminOnly.
+        // Filter passes (justification present); Spring Security then rejects
+        // the missing/anonymous auth → 401. This proves the filter does NOT
+        // gate on auth state — it gates ONLY on justification-header presence.
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
+        assertThat(countPalRows()).isEqualTo(palBefore);
+    }
+
+    @Test
+    @DisplayName("unauthenticated WITHOUT justification → 401 (post-Security ordering pin)")
+    void unauthenticatedWithoutJustificationRejectedAtSecurity() {
+        long palBefore = countPalRows();
+
+        // Triage-pass-2 warroom pinning probe (Marcus/Alex HIGH): proves the
+        // JustificationValidationFilter is observably POST-Security in the
+        // current Spring Boot 4.x configuration — matching the original
+        // M-RV2 design intent + the filter's javadoc. An anonymous request
+        // to a @PlatformAdminOnly endpoint receives 401 from Spring
+        // Security's URL rule BEFORE the filter sees the missing-header
+        // case. If this assertion ever flips to 400, the filter has been
+        // promoted to pre-Security ordering and the security-posture
+        // analysis in JustificationValidationFilter's javadoc must be
+        // re-evaluated (the info-disclosure trade-off changes).
+        //
+        // Companion observation: a request that DOES carry the justification
+        // header but no auth also gets 401 (see
+        // unauthenticatedWithJustificationRejectedAtSecurity above), proving
+        // the filter does not gate on auth state — only on header presence.
+        ResponseEntity<Map> response = postCanary(null, null, "{}");
+
         assertThat(response.getStatusCode()).isEqualTo(HttpStatus.UNAUTHORIZED);
         assertThat(countPalRows()).isEqualTo(palBefore);
     }

--- a/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
@@ -196,7 +196,9 @@ class HmisBridgeIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void pushEndpoint_requiresPlatformAdmin() {
+    void pushEndpoint_requiresCocAdmin() {
+        // G-4.4 follow-up: HMIS push reverted to COC_ADMIN (tenant-scoped). A
+        // non-admin role like outreach must still 403.
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/hmis/push", HttpMethod.POST,
                 new HttpEntity<>(outreachHeaders), String.class);
@@ -204,7 +206,7 @@ class HmisBridgeIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void vendorsEndpoint_requiresPlatformAdmin() {
+    void vendorsEndpoint_requiresCocAdmin() {
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/hmis/vendors", HttpMethod.GET,
                 new HttpEntity<>(outreachHeaders), String.class);
@@ -221,6 +223,8 @@ class HmisBridgeIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void manualPush_succeeds() {
+        // G-4.4 follow-up: HMIS push is COC_ADMIN (tenant-scoped). Admin user
+        // has COC_ADMIN per V87 backfill, so adminHeaders is the right fixture.
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/hmis/push", HttpMethod.POST,
                 new HttpEntity<>(adminHeaders), String.class);

--- a/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
@@ -50,7 +50,13 @@ class HmisBridgeIntegrationTest extends BaseIntegrationTest {
         authHelper.setupOutreachWorkerUser();
 
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "dvadmin-hmis@test.fabt.org", "DV Admin HMIS", new String[]{"PLATFORM_ADMIN"});
+                "dvadmin-hmis@test.fabt.org", "DV Admin HMIS",
+                // G-4.4: PLATFORM_ADMIN + COC_ADMIN (matches V87 backfill +
+                // post-migration tenant-admin role list). The COC_ADMIN role
+                // satisfies the migrated tenant-scoped endpoints (/shelters
+                // POST etc.); PLATFORM_ADMIN remains for compat with any
+                // tests that still assert on it directly.
+                new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         adminHeaders = authHelper.headersForUser(dvAdmin);
         outreachHeaders = authHelper.outreachWorkerHeaders();
 

--- a/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/hmis/HmisBridgeIntegrationTest.java
@@ -222,14 +222,31 @@ class HmisBridgeIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void manualPush_succeeds() {
-        // G-4.4 follow-up: HMIS push is COC_ADMIN (tenant-scoped). Admin user
-        // has COC_ADMIN per V87 backfill, so adminHeaders is the right fixture.
+    void manualPush_succeeds_withConfirmHeader() {
+        // G-4.4 §F16: HMIS push is COC_ADMIN (tenant-scoped). Admin user has
+        // COC_ADMIN per V87 backfill. Requires X-Confirm-HMIS-Push: CONFIRM
+        // header to prevent accidental triggers.
+        HttpHeaders headers = new HttpHeaders();
+        headers.addAll(adminHeaders);
+        headers.set("X-Confirm-HMIS-Push", "CONFIRM");
+        ResponseEntity<String> resp = restTemplate.exchange(
+                "/api/v1/hmis/push", HttpMethod.POST,
+                new HttpEntity<>(headers), String.class);
+        assertEquals(HttpStatus.OK, resp.getStatusCode());
+        assertTrue(resp.getBody().contains("outboxEntriesCreated"));
+    }
+
+    @Test
+    void manualPush_withoutConfirmHeader_rejected() {
+        // G-4.4 §F16 mitigation: without X-Confirm-HMIS-Push: CONFIRM, the
+        // endpoint must 400 with missing_confirmation. Mirrors the
+        // X-Confirm-Policy-Change pattern on TenantController.
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/hmis/push", HttpMethod.POST,
                 new HttpEntity<>(adminHeaders), String.class);
-        assertEquals(HttpStatus.OK, resp.getStatusCode());
-        assertTrue(resp.getBody().contains("outboxEntriesCreated"));
+        assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
+        assertTrue(resp.getBody().contains("missing_confirmation"),
+                "Body should signal missing_confirmation: " + resp.getBody());
     }
 
     private void createShelter(String name, boolean dvShelter) {

--- a/backend/src/test/java/org/fabt/notification/ReferralEscalationFrozenPolicyTest.java
+++ b/backend/src/test/java/org/fabt/notification/ReferralEscalationFrozenPolicyTest.java
@@ -77,7 +77,7 @@ class ReferralEscalationFrozenPolicyTest extends BaseIntegrationTest {
         authHelper.setupAdminUser();
 
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "frozen-admin@test.fabt.org", "Frozen Admin", new String[]{"PLATFORM_ADMIN"});
+                "frozen-admin@test.fabt.org", "Frozen Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders adminHeaders = authHelper.headersForUser(dvAdmin);
 
         // Two outreach workers so we can create two referrals for the same shelter

--- a/backend/src/test/java/org/fabt/notification/ReferralEscalationIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/notification/ReferralEscalationIntegrationTest.java
@@ -54,7 +54,7 @@ class ReferralEscalationIntegrationTest extends BaseIntegrationTest {
 
         // DV admin for shelter creation
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "esc-admin@test.fabt.org", "Escalation Admin", new String[]{"PLATFORM_ADMIN"});
+                "esc-admin@test.fabt.org", "Escalation Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders adminHeaders = authHelper.headersForUser(dvAdmin);
 
         // DV outreach worker (creates referrals)

--- a/backend/src/test/java/org/fabt/notification/ReferralEscalationPerfTest.java
+++ b/backend/src/test/java/org/fabt/notification/ReferralEscalationPerfTest.java
@@ -108,7 +108,7 @@ class ReferralEscalationPerfTest extends BaseIntegrationTest {
         authHelper.setupAdminUser();
 
         User dvAdmin = authHelper.setupUserWithDvAccess(
-                "perf-admin@test.fabt.org", "Perf Admin", new String[]{"PLATFORM_ADMIN"});
+                "perf-admin@test.fabt.org", "Perf Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders adminHeaders = authHelper.headersForUser(dvAdmin);
 
         // DV coordinator so the 1h threshold resolves a real recipient list.

--- a/backend/src/test/java/org/fabt/observability/ObservabilityIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/observability/ObservabilityIntegrationTest.java
@@ -75,8 +75,12 @@ class ObservabilityIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void test_errorResponse_defaultEnglish() {
-        // Request a nonexistent tenant — should return English error
-        HttpHeaders headers = authHelper.adminHeaders();
+        // Request a nonexistent tenant — should return English error.
+        // G-4.4: GET /tenants/{id} is PLATFORM_OPERATOR-only; tenant JWT would
+        // 403 before reaching the controller's NotFound throw, so we use the
+        // platform-operator fixture to exercise the error-response shape path.
+        HttpHeaders headers = authHelper.platformOperatorHeaders(
+                "Observability IT - localized 404 shape verification");
 
         ResponseEntity<String> response = restTemplate.exchange(
                 "/api/v1/tenants/" + UUID.randomUUID(),
@@ -91,7 +95,8 @@ class ObservabilityIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void test_errorResponse_spanishLocale() {
-        HttpHeaders headers = authHelper.adminHeaders();
+        HttpHeaders headers = authHelper.platformOperatorHeaders(
+                "Observability IT - localized 404 shape (es)");
         headers.set("Accept-Language", "es");
 
         ResponseEntity<String> response = restTemplate.exchange(
@@ -111,7 +116,8 @@ class ObservabilityIntegrationTest extends BaseIntegrationTest {
     @Test
     void test_errorResponses_containStructuredErrorCode() {
         // Verify MCP-ready error response structure
-        HttpHeaders headers = authHelper.adminHeaders();
+        HttpHeaders headers = authHelper.platformOperatorHeaders(
+                "Observability IT - structured error shape verification");
 
         ResponseEntity<Map> response = restTemplate.exchange(
                 "/api/v1/tenants/" + UUID.randomUUID(),

--- a/backend/src/test/java/org/fabt/referral/AuditEventCoverageTest.java
+++ b/backend/src/test/java/org/fabt/referral/AuditEventCoverageTest.java
@@ -66,7 +66,7 @@ class AuditEventCoverageTest extends BaseIntegrationTest {
         authHelper.setupAdminUser();
 
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "audit-padmin@test.fabt.org", "Audit Platform Admin", new String[]{"PLATFORM_ADMIN"});
+                "audit-padmin@test.fabt.org", "Audit Platform Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders padminHeaders = authHelper.headersForUser(dvAdmin);
 
         var dvOutreach = authHelper.setupUserWithDvAccess(

--- a/backend/src/test/java/org/fabt/referral/ClaimReleaseTest.java
+++ b/backend/src/test/java/org/fabt/referral/ClaimReleaseTest.java
@@ -53,7 +53,7 @@ class ClaimReleaseTest extends BaseIntegrationTest {
         authHelper.setupAdminUser();
 
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "claim-padmin@test.fabt.org", "Claim Platform Admin", new String[]{"PLATFORM_ADMIN"});
+                "claim-padmin@test.fabt.org", "Claim Platform Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders padminHeaders = authHelper.headersForUser(dvAdmin);
 
         var dvOutreach = authHelper.setupUserWithDvAccess(

--- a/backend/src/test/java/org/fabt/referral/DvReferralExpiryRlsTest.java
+++ b/backend/src/test/java/org/fabt/referral/DvReferralExpiryRlsTest.java
@@ -56,7 +56,7 @@ class DvReferralExpiryRlsTest extends BaseIntegrationTest {
         authHelper.setupAdminUser();
 
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "rls-dvadmin@test.fabt.org", "RLS DV Admin", new String[]{"PLATFORM_ADMIN"});
+                "rls-dvadmin@test.fabt.org", "RLS DV Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         adminHeaders = authHelper.headersForUser(dvAdmin);
 
         var dvOutreach = authHelper.setupUserWithDvAccess(

--- a/backend/src/test/java/org/fabt/referral/DvReferralIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/referral/DvReferralIntegrationTest.java
@@ -78,7 +78,7 @@ class DvReferralIntegrationTest extends BaseIntegrationTest {
 
         // DV operations require dvAccess=true — use a DV-access admin for setup
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "dvadmin@test.fabt.org", "DV Admin", new String[]{"PLATFORM_ADMIN"});
+                "dvadmin@test.fabt.org", "DV Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         adminHeaders = authHelper.headersForUser(dvAdmin);
         // Outreach worker with dvAccess=true (can see DV shelters via RLS)
         var dvOutreach = authHelper.setupUserWithDvAccess(
@@ -1048,7 +1048,7 @@ class DvReferralIntegrationTest extends BaseIntegrationTest {
         // Create a separate tenant with NO DV coordinators
         var isolatedTenant = authHelper.setupTestTenant("no-coord-tenant");
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "nocord-admin@test.fabt.org", "No-Coord Admin", new String[]{"PLATFORM_ADMIN"});
+                "nocord-admin@test.fabt.org", "No-Coord Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders isolatedAdminHeaders = authHelper.headersForUser(dvAdmin);
         var dvOutreach = authHelper.setupUserWithDvAccess(
                 "nocord-outreach@test.fabt.org", "No-Coord Outreach", new String[]{"OUTREACH_WORKER"});

--- a/backend/src/test/java/org/fabt/referral/EscalatedQueueEndpointTest.java
+++ b/backend/src/test/java/org/fabt/referral/EscalatedQueueEndpointTest.java
@@ -94,7 +94,7 @@ class EscalatedQueueEndpointTest extends BaseIntegrationTest {
 
         // A platform admin in tenantA used for shelter creation in both tenants.
         var platformAdmin = authHelper.setupUserWithDvAccess(
-                "queue-padmin@test.fabt.org", "Queue Platform Admin", new String[]{"PLATFORM_ADMIN"});
+                "queue-padmin@test.fabt.org", "Queue Platform Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders platformAdminHeaders = authHelper.headersForUser(platformAdmin);
 
         // Clean prior queue/notification state in both tenants so the assertion math is exact.
@@ -107,7 +107,7 @@ class EscalatedQueueEndpointTest extends BaseIntegrationTest {
 
         // Tenant B shelter creation needs an admin in tenantB context. Create one ad-hoc.
         var platformAdminB = createUserInTenant(tenantB, "queue-padmin-b@test.fabt.org",
-                "Queue Platform Admin B", new String[]{"PLATFORM_ADMIN"}, true);
+                "Queue Platform Admin B", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"}, true);
         HttpHeaders platformAdminBHeaders = jwtHeaders(platformAdminB);
         TenantContext.runWithContext(tenantB.getId(), true, () ->
                 shelterBId = createDvShelter(platformAdminBHeaders, "Shelter Tenant B"));
@@ -147,7 +147,7 @@ class EscalatedQueueEndpointTest extends BaseIntegrationTest {
         // duplicate-pending guard means we need either three users or three
         // shelters per outreach worker. Three shelters is simpler.
         var platformAdmin = authHelper.setupUserWithDvAccess(
-                "queue-padmin@test.fabt.org", "Queue Platform Admin", new String[]{"PLATFORM_ADMIN"});
+                "queue-padmin@test.fabt.org", "Queue Platform Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders padminHeaders = authHelper.headersForUser(platformAdmin);
 
         UUID[] shelters = new UUID[3];

--- a/backend/src/test/java/org/fabt/referral/ReassignTest.java
+++ b/backend/src/test/java/org/fabt/referral/ReassignTest.java
@@ -49,7 +49,7 @@ class ReassignTest extends BaseIntegrationTest {
         authHelper.setupAdminUser();
 
         var dvAdmin = authHelper.setupUserWithDvAccess(
-                "reassign-padmin@test.fabt.org", "Reassign Platform Admin", new String[]{"PLATFORM_ADMIN"});
+                "reassign-padmin@test.fabt.org", "Reassign Platform Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders padminHeaders = authHelper.headersForUser(dvAdmin);
 
         var dvOutreach = authHelper.setupUserWithDvAccess(

--- a/backend/src/test/java/org/fabt/security/DvShelterConcurrentIsolationTest.java
+++ b/backend/src/test/java/org/fabt/security/DvShelterConcurrentIsolationTest.java
@@ -79,7 +79,7 @@ class DvShelterConcurrentIsolationTest extends BaseIntegrationTest {
 
         // Create users scoped to this unique tenant
         User dvAdmin = createUser(tenantId, "dv-admin-" + suffix + "@test.fabt.org",
-                new String[]{"PLATFORM_ADMIN"}, true);
+                new String[]{"PLATFORM_ADMIN", "COC_ADMIN"}, true);
         dvAdminToken = jwtService.generateAccessToken(dvAdmin);
 
         User outreach = createUser(tenantId, "outreach-" + suffix + "@test.fabt.org",

--- a/backend/src/test/java/org/fabt/security/TenantPathGuardIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/security/TenantPathGuardIntegrationTest.java
@@ -85,28 +85,37 @@ class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("PUT /tenants/{B} from Tenant A → 404 (display-name update)")
-    void crossTenantUpdateName_returns404() {
+    @DisplayName("PUT /tenants/{B} from Tenant A → 403 (G-4.4: now @PlatformAdminOnly)")
+    void crossTenantUpdateName_returnsForbidden() {
+        // G-4.4: PUT /tenants/{id} migrated to @PlatformAdminOnly, so a tenant-
+        // scoped JWT (even with COC_ADMIN/PLATFORM_ADMIN-legacy) cannot reach
+        // it — security rejects with 403 BEFORE any path guard could fire. The
+        // cross-tenant attack is structurally prevented by role separation:
+        // PLATFORM_OPERATOR is the only role that can manage tenants, and it
+        // is a platform-scoped role with no tenant context to "cross from".
+        // Justification header satisfies the JustificationValidationFilter
+        // (which fires pre-Security in this context); the 403 we expect comes
+        // from Spring Security after method @PreAuthorize evaluates.
         ResponseEntity<String> response = put(
                 "/api/v1/tenants/" + tenantB.getId(),
                 "{\"name\":\"Attacker-renamed\"}");
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     @Test
-    @DisplayName("PUT /tenants/{B}/observability from Tenant A → 404")
-    void crossTenantUpdateObservability_returns404() {
+    @DisplayName("PUT /tenants/{B}/observability from Tenant A → 403 (G-4.4: @PlatformAdminOnly)")
+    void crossTenantUpdateObservability_returnsForbidden() {
         ResponseEntity<String> response = put(
                 "/api/v1/tenants/" + tenantB.getId() + "/observability",
                 "{\"prometheus_enabled\":false}");
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     @Test
-    @DisplayName("GET /tenants/{B}/observability from Tenant A → 404 (reads are symmetric)")
-    void crossTenantGetObservability_returns404() {
+    @DisplayName("GET /tenants/{B}/observability from Tenant A → 403 (G-4.4: @PlatformAdminOnly)")
+    void crossTenantGetObservability_returnsForbidden() {
         ResponseEntity<String> response = get("/api/v1/tenants/" + tenantB.getId() + "/observability");
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     @Test
@@ -145,8 +154,8 @@ class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("PUT /tenants/{B}/dv-address-policy from Tenant A → 404 (guard fires before CONFIRM header check)")
-    void crossTenantUpdateDvAddressPolicy_returns404() {
+    @DisplayName("PUT /tenants/{B}/dv-address-policy from Tenant A → 403 (G-4.4: @PlatformAdminOnly)")
+    void crossTenantUpdateDvAddressPolicy_returnsForbidden() {
         HttpHeaders headers = authHeaders();
         headers.set("X-Confirm-Policy-Change", "CONFIRM");
         ResponseEntity<String> response = restTemplate.exchange(
@@ -154,7 +163,7 @@ class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
                 HttpMethod.PUT,
                 new HttpEntity<>("{\"policy\":\"NONE\"}", headers),
                 String.class);
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.FORBIDDEN);
     }
 
     /**
@@ -245,6 +254,12 @@ class TenantPathGuardIntegrationTest extends BaseIntegrationTest {
         HttpHeaders headers = new HttpHeaders();
         headers.setBearerAuth(tenantAToken);
         headers.setContentType(MediaType.APPLICATION_JSON);
+        // G-4.4: include justification so the JustificationValidationFilter
+        // doesn't 400 before security can evaluate role. Tests asserting 403
+        // (cross-tenant via tenant JWT) need security/aspect to be the gate
+        // that fires, not the filter.
+        headers.set("X-Platform-Justification",
+                "TenantPathGuard IT - cross-tenant attack scenario, tenant JWT must not reach platform endpoint");
         return headers;
     }
 

--- a/backend/src/test/java/org/fabt/shared/security/TenantKeyRotationServiceIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/shared/security/TenantKeyRotationServiceIntegrationTest.java
@@ -54,7 +54,7 @@ class TenantKeyRotationServiceIntegrationTest extends BaseIntegrationTest {
                 "rotation-test-" + UUID.randomUUID()).getId();
         freshUser = authHelper.createUserInTenant(freshTenant,
                 "rotation-test-" + UUID.randomUUID() + "@test.fabt.org",
-                "Rotation Test User", new String[]{"PLATFORM_ADMIN"}, false);
+                "Rotation Test User", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"}, false);
     }
 
     @Test

--- a/backend/src/test/java/org/fabt/shelter/DvAddressRedactionTest.java
+++ b/backend/src/test/java/org/fabt/shelter/DvAddressRedactionTest.java
@@ -47,7 +47,7 @@ class DvAddressRedactionTest extends BaseIntegrationTest {
         TenantContext.runWithContext(authHelper.getTestTenantId(), true, () -> {
             // Admin with dvAccess
             var dvAdmin = authHelper.setupUserWithDvAccess(
-                    "dvadmin-redact@test.fabt.org", "DV Admin", new String[]{"PLATFORM_ADMIN"});
+                    "dvadmin-redact@test.fabt.org", "DV Admin", new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
             adminHeaders = authHelper.headersForUser(dvAdmin);
 
             // Outreach with dvAccess

--- a/backend/src/test/java/org/fabt/shelter/DvAddressRedactionTest.java
+++ b/backend/src/test/java/org/fabt/shelter/DvAddressRedactionTest.java
@@ -168,16 +168,24 @@ class DvAddressRedactionTest extends BaseIntegrationTest {
 
     @Test
     void policyChange_withoutConfirmation_rejected() {
+        // G-4.4: endpoint is PLATFORM_OPERATOR-only. Use platform-operator
+        // fixture so we exercise the missing-confirmation branch (400) rather
+        // than the missing-platform-justification branch.
+        HttpHeaders headers = authHelper.platformOperatorHeaders(
+                "DvAddressRedaction IT - missing confirmation should yield 400");
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/tenants/" + authHelper.getTestTenantId() + "/dv-address-policy",
-                HttpMethod.PUT, new HttpEntity<>("{\"policy\": \"NONE\"}", adminHeaders), String.class);
+                HttpMethod.PUT, new HttpEntity<>("{\"policy\": \"NONE\"}", headers), String.class);
         assertEquals(HttpStatus.BAD_REQUEST, resp.getStatusCode());
     }
 
     @Test
     void policyChange_nonAdmin_rejected() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.addAll(outreachHeaders);
+        // G-4.4: outreach JWT cannot reach PLATFORM_OPERATOR endpoint. Provide
+        // justification so the JustificationValidationFilter doesn't 400 first;
+        // we want security/aspect to issue 403 here.
+        HttpHeaders headers = authHelper.withJustification(outreachHeaders,
+                "DvAddressRedaction IT - outreach must not change policy");
         headers.set("X-Confirm-Policy-Change", "CONFIRM");
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/tenants/" + authHelper.getTestTenantId() + "/dv-address-policy",
@@ -187,8 +195,11 @@ class DvAddressRedactionTest extends BaseIntegrationTest {
 
     @Test
     void policyChange_invalidValue_rejected() {
-        HttpHeaders headers = new HttpHeaders();
-        headers.addAll(adminHeaders);
+        // G-4.4: endpoint requires PLATFORM_OPERATOR; switch to platform-operator
+        // fixture so we exercise the invalid-policy branch (400 + valid list)
+        // rather than auth/filter rejection branches.
+        HttpHeaders headers = authHelper.platformOperatorHeaders(
+                "DvAddressRedaction IT - invalid policy must yield list of valid policies");
         headers.set("X-Confirm-Policy-Change", "CONFIRM");
         ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/tenants/" + authHelper.getTestTenantId() + "/dv-address-policy",
@@ -280,12 +291,17 @@ class DvAddressRedactionTest extends BaseIntegrationTest {
     }
 
     private void setPolicy(String policy) {
-        HttpHeaders headers = new HttpHeaders();
-        headers.addAll(adminHeaders);
+        // G-4.4: /dv-address-policy is @PlatformAdminOnly + PLATFORM_OPERATOR.
+        // Use the platform-operator fixture so the policy change actually
+        // applies (admin/tenant JWT now 403s here).
+        HttpHeaders headers = authHelper.platformOperatorHeaders(
+                "DvAddressRedaction IT - setting tenant policy to " + policy);
         headers.set("X-Confirm-Policy-Change", "CONFIRM");
-        restTemplate.exchange(
+        ResponseEntity<String> resp = restTemplate.exchange(
                 "/api/v1/tenants/" + authHelper.getTestTenantId() + "/dv-address-policy",
                 HttpMethod.PUT, new HttpEntity<>("{\"policy\": \"" + policy + "\"}", headers), String.class);
+        assertEquals(HttpStatus.OK, resp.getStatusCode(),
+                "setPolicy(" + policy + ") must succeed — body: " + resp.getBody());
     }
 
     private ResponseEntity<Map<String, Object>> getDetail(UUID shelterId, HttpHeaders headers) {

--- a/backend/src/test/java/org/fabt/shelter/UserShelterControllerTest.java
+++ b/backend/src/test/java/org/fabt/shelter/UserShelterControllerTest.java
@@ -116,7 +116,7 @@ class UserShelterControllerTest extends BaseIntegrationTest {
         Tenant tenantB = authHelper.setupTestTenant("tenant-b-shelter-isolation");
         User tenantBAdmin = authHelper.setupUserWithDvAccess(
                 "admin-b-shelter@test.fabt.org", "Tenant B Admin",
-                new String[]{"PLATFORM_ADMIN"});
+                new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders tenantBHeaders = authHelper.headersForUser(tenantBAdmin);
 
         UUID tenantBShelter = createShelterWithHeaders("Tenant B Shelter", tenantBHeaders);
@@ -179,7 +179,7 @@ class UserShelterControllerTest extends BaseIntegrationTest {
     void getUserShelters_adminWithDvAccess_seesDvShelters() {
         User dvAdmin = authHelper.setupUserWithDvAccess(
                 "dv-admin-shelter@test.fabt.org", "DV Admin",
-                new String[]{"PLATFORM_ADMIN"});
+                new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders dvAdminHeaders = authHelper.headersForUser(dvAdmin);
 
         // Create DV shelter (needs dvAccess admin)
@@ -206,7 +206,7 @@ class UserShelterControllerTest extends BaseIntegrationTest {
     void getUserShelters_adminWithoutDvAccess_doesNotSeeDvShelters() {
         User dvAdmin = authHelper.setupUserWithDvAccess(
                 "dv-admin-shelter2@test.fabt.org", "DV Admin 2",
-                new String[]{"PLATFORM_ADMIN"});
+                new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
         HttpHeaders dvAdminHeaders = authHelper.headersForUser(dvAdmin);
 
         // Create DV shelter (needs dvAccess admin)

--- a/backend/src/test/java/org/fabt/tenant/TenantIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/TenantIntegrationTest.java
@@ -28,9 +28,17 @@ class TenantIntegrationTest extends BaseIntegrationTest {
         authHelper.setupAdminUser();
     }
 
+    /**
+     * G-4.4: /api/v1/tenants/* is @PlatformAdminOnly + PLATFORM_OPERATOR.
+     * Each test gets a fresh platform-operator JWT via the bootstrap fixture.
+     */
+    private HttpHeaders platformHeaders(String purpose) {
+        return authHelper.platformOperatorHeaders("Tenant IT - " + purpose);
+    }
+
     @Test
     void test_createTenant_success() {
-        HttpHeaders headers = authHelper.adminHeaders();
+        HttpHeaders headers = platformHeaders("create tenant happy-path");
         String body = """
                 {"name": "New CoC Tenant", "slug": "new-coc-tenant"}
                 """;
@@ -52,7 +60,7 @@ class TenantIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void test_createTenant_duplicateSlug() {
-        HttpHeaders headers = authHelper.adminHeaders();
+        HttpHeaders headers = platformHeaders("create tenant duplicate-slug rejection");
 
         // Create first tenant with a unique slug for this test
         String uniqueSlug = "dup-slug-" + UUID.randomUUID().toString().substring(0, 8);
@@ -85,7 +93,7 @@ class TenantIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void test_getTenant_byId() {
-        HttpHeaders headers = authHelper.adminHeaders();
+        HttpHeaders headers = platformHeaders("get tenant by id happy-path");
 
         // Create a tenant to retrieve
         String slug = "get-test-" + UUID.randomUUID().toString().substring(0, 8);
@@ -119,7 +127,7 @@ class TenantIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void test_getTenant_notFound() {
-        HttpHeaders headers = authHelper.adminHeaders();
+        HttpHeaders headers = platformHeaders("get tenant not-found shape");
         UUID fakeId = UUID.randomUUID();
 
         ResponseEntity<String> response = restTemplate.exchange(
@@ -134,10 +142,12 @@ class TenantIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void test_updateTenant_selfTenant_ok() {
-        // Admin PUT on their OWN tenant must succeed. Per D15, PLATFORM_ADMIN is
-        // tenant-scoped (see openspec multi-tenant-production-readiness Phase M
-        // platform-admin-tenant-scoping-v0.48 + Phase D TenantPathGuard D11).
-        HttpHeaders headers = authHelper.adminHeaders();
+        // G-4.4: PUT /tenants/{id} is now @PlatformAdminOnly. The D15
+        // "platform-admin is tenant-scoped" model is superseded by the
+        // platform-operator role: PLATFORM_OPERATOR can manage any tenant
+        // (the cross-tenant invariant is now enforced by role separation
+        // and audit chain, not by TenantPathGuard).
+        HttpHeaders headers = platformHeaders("update tenant happy-path");
         UUID ownTenantId = authHelper.getTestTenantId();
 
         // Read the original name so we can restore it (setupTestTenant is idempotent
@@ -171,13 +181,17 @@ class TenantIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    void test_updateTenant_otherTenant_rejectedBy_D11_guard() {
-        // D11 URL-path-sink: an admin in tenant A creates tenant B (bootstrap
-        // path is still open under D15), but then cannot rename B via
-        // PUT /api/v1/tenants/{B} — the TenantPathGuard rejects with 404
-        // (symmetric with D3 existence-leak posture). Phase F will revisit
-        // with a dedicated platform-operator role.
-        HttpHeaders headers = authHelper.adminHeaders();
+    void test_updateTenant_otherTenant_okForPlatformOperator() {
+        // G-4.4: PLATFORM_OPERATOR can manage any tenant by design. The D11
+        // URL-path-sink concern is now structurally mitigated:
+        //   - PLATFORM_OPERATOR (the only role that can hit this endpoint) is
+        //     intentionally cross-tenant — a "foreign" tenant simply isn't
+        //     foreign to the operator.
+        //   - tenant-scoped JWTs (COC_ADMIN/etc.) cannot reach the endpoint at
+        //     all — Spring Security 403 on the @PreAuthorize gate.
+        // The audit chain (PAL row + audit_event) captures the exact target
+        // tenantId for compliance review, replacing the per-request guard.
+        HttpHeaders headers = platformHeaders("update foreign tenant - platform-operator legitimate cross-tenant action");
 
         String slug = "update-rejected-" + UUID.randomUUID().toString().substring(0, 8);
         ResponseEntity<TenantResponse> created = restTemplate.exchange(
@@ -188,13 +202,14 @@ class TenantIntegrationTest extends BaseIntegrationTest {
         assertThat(created.getStatusCode()).isEqualTo(HttpStatus.CREATED);
         UUID foreignTenantId = created.getBody().id();
 
-        ResponseEntity<String> response = restTemplate.exchange(
+        ResponseEntity<TenantResponse> response = restTemplate.exchange(
                 "/api/v1/tenants/" + foreignTenantId,
                 HttpMethod.PUT,
-                new HttpEntity<>("{\"name\": \"Attacker Name\"}", headers),
-                String.class);
+                new HttpEntity<>("{\"name\": \"Renamed By Operator\"}", headers),
+                TenantResponse.class);
 
-        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+        assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(response.getBody().name()).isEqualTo("Renamed By Operator");
     }
 
     @Test
@@ -247,7 +262,7 @@ class TenantIntegrationTest extends BaseIntegrationTest {
 
     @Test
     void test_tenantIsolation_separateTenants() {
-        HttpHeaders headers = authHelper.adminHeaders();
+        HttpHeaders headers = platformHeaders("isolation: create + verify two tenants");
 
         // Create two separate tenants
         String slugA = "tenant-a-" + UUID.randomUUID().toString().substring(0, 8);

--- a/backend/src/test/java/org/fabt/tenant/api/TenantKeyRotationControllerIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/tenant/api/TenantKeyRotationControllerIntegrationTest.java
@@ -44,15 +44,18 @@ class TenantKeyRotationControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("PLATFORM_ADMIN gets 202 + rotation summary body")
-    void platformAdminTriggers202() {
-        // Bootstrap tenantA's first kid by issuing a token
-        User platformAdmin = authHelper.createUserInTenant(tenantA,
-                "platform-admin-" + UUID.randomUUID() + "@test.fabt.org",
-                "Platform Admin", new String[]{"PLATFORM_ADMIN"}, false);
-        jwtService.generateAccessToken(platformAdmin);
+    @DisplayName("PLATFORM_OPERATOR gets 202 + rotation summary body")
+    void platformOperatorTriggers202() {
+        // Bootstrap tenantA's first kid by issuing a token for any user
+        // (so the first generation exists in tenant_jwt_kid before rotation).
+        User seed = authHelper.createUserInTenant(tenantA,
+                "kid-seed-" + UUID.randomUUID() + "@test.fabt.org",
+                "Kid Seed", new String[]{"COC_ADMIN"}, false);
+        jwtService.generateAccessToken(seed);
 
-        HttpHeaders headers = authHelper.headersForUser(platformAdmin);
+        // G-4.4: endpoint migrated to PLATFORM_OPERATOR + @PlatformAdminOnly.
+        HttpHeaders headers = authHelper.platformOperatorHeaders(
+                "G-4.4 IT - rotate JWT key for tenant " + tenantA);
         ResponseEntity<java.util.Map<String, Object>> response = restTemplate.exchange(
                 "/api/v1/admin/tenants/" + tenantA + "/rotate-jwt-key",
                 HttpMethod.POST,
@@ -73,13 +76,17 @@ class TenantKeyRotationControllerIntegrationTest extends BaseIntegrationTest {
     }
 
     @Test
-    @DisplayName("COC_ADMIN gets 403 — endpoint is PLATFORM_ADMIN-only")
+    @DisplayName("COC_ADMIN gets 403 — endpoint is PLATFORM_OPERATOR-only")
     void cocAdminGets403() {
         User cocAdmin = authHelper.createUserInTenant(tenantA,
                 "coc-admin-" + UUID.randomUUID() + "@test.fabt.org",
                 "Tenant CoC Admin", new String[]{"COC_ADMIN"}, false);
 
-        HttpHeaders headers = authHelper.headersForUser(cocAdmin);
+        // G-4.4: provide justification so JustificationValidationFilter doesn't
+        // 400 first; the security/aspect rejection (403) is what we want.
+        HttpHeaders headers = authHelper.withJustification(
+                authHelper.headersForUser(cocAdmin),
+                "G-4.4 IT - COC_ADMIN must not be able to rotate keys");
         ResponseEntity<String> response = restTemplate.exchange(
                 "/api/v1/admin/tenants/" + tenantA + "/rotate-jwt-key",
                 HttpMethod.POST,
@@ -114,7 +121,9 @@ class TenantKeyRotationControllerIntegrationTest extends BaseIntegrationTest {
                 "outreach-" + UUID.randomUUID() + "@test.fabt.org",
                 "Outreach Worker", new String[]{"OUTREACH_WORKER"}, false);
 
-        HttpHeaders headers = authHelper.headersForUser(outreach);
+        HttpHeaders headers = authHelper.withJustification(
+                authHelper.headersForUser(outreach),
+                "G-4.4 IT - OUTREACH_WORKER must not be able to rotate keys");
         ResponseEntity<String> response = restTemplate.exchange(
                 "/api/v1/admin/tenants/" + tenantA + "/rotate-jwt-key",
                 HttpMethod.POST,

--- a/docs/oracle-update-notes-v0.53.0.md
+++ b/docs/oracle-update-notes-v0.53.0.md
@@ -1,22 +1,38 @@
 # Oracle Deploy Notes — v0.53.0
 
 **Tag:** v0.53.0 (DRAFT, not yet tagged)
-**Branch:** `main` post-merge of PR for `feature/g-4.4-endpoint-migration` (Phase G-4.1, G-4.2, G-4.3, G-4.4 — and tracking G-4.5, G-4.6 as still-open scope below)
+**Branch:** `feature/g-4.4-endpoint-migration` post-merge to `main`
 **Theme:** Phase G-4 — platform admin authority split + per-action audit log.
 
 ---
 
 ## 1. Consulted Memories
 
-- `feedback_runbook_template_v1.md` — every oracle-update-notes follows the v1 template shape
-- `feedback_runbook_compose_chain.md` — prod docker compose up needs ALL override files in order
-- `feedback_never_print_rendered_secrets.md` — never cat / head / grep secret-containing config files
-- `feedback_release_after_scans.md` — don't tag releases until CI scans are green
-- `feedback_legal_claims_review.md` — scan all docs for overclaimed compliance before any release
-- `feedback_dev_keys_prod_guard.md` — runtime guards on dev-only keys / endpoints
-- `feedback_no_guessing_security.md` — never guess on security issues
-- `project_phase_g_implementation_plan.md` — Phase G slice plan
-- `project_resume_point.md` — current branch state
+```yaml
+consulted:
+  - feedback_runbook_template_v1.md   # why-cited: every oracle-update-notes from v0.50 onward must follow runbook-template.md shape
+  - feedback_runbook_compose_chain.md # why-cited: prod compose up needs ALL override files in order; missing v0.44-pgaudit.yml = postgres crash loop (v0.50 lesson)
+  - feedback_smoke_config_on_prod.md  # why-cited: post-deploy Playwright smoke needs FABT_BASE_URL + --config=deploy/playwright.config.ts + positional filter; test 13/14 flake = rate-limit not regression
+  - feedback_never_print_rendered_secrets.md  # why-cited: never cat / head / grep secret-containing config files (.env.prod, alertmanager.yml). Leaked SMTP password during v0.49 deploy.
+  - feedback_release_after_scans.md   # why-cited: never tag GitHub release until CI scans (Trivy, ZAP, deps, SBOM) green
+  - feedback_pgaudit_include_dir_existing_volume.md  # why-cited: V44 pgaudit Dockerfile include_dir only on fresh pgdata
+  - feedback_prod_docker_build_pattern.md  # why-cited: canonical prod deploy = explicit docker build --no-cache BEFORE compose up --force-recreate; three no-op traps caught during v0.48 live deploy
+  - feedback_verify_doc_facts_against_source.md  # why-cited: read source files before writing docs; v0.49 had 7/9 wrong Prom rule names
+  - feedback_no_named_stakeholders_in_docs.md  # why-cited: no real external stakeholder names in committed docs
+  - feedback_persona_transparency.md  # why-cited: never reference AI personas as real contributors
+  - feedback_legal_claims_review.md   # why-cited: scan for overclaim language before any release
+  - feedback_deploy_old_jars.md       # why-cited: always mvn clean — old JARs cause Docker to deploy stale code
+  - feedback_deploy_checklist_v031.md # why-cited: full deploy checklist including pg_dump backup
+  - feedback_flyway_immutable_after_apply.md  # why-cited: never modify an applied Flyway migration file
+  - feedback_cleanup_old_artifacts.md # why-cited: remove stale JARs and Docker images post-deploy
+  - feedback_no_ip_in_repo.md         # why-cited: VM IP fine in memory, must NOT appear in git-tracked files
+  - feedback_no_ssh_tunnels.md        # why-cited: share SSH tunnel commands, don't auto-execute them
+  - feedback_truthfulness_above_all.md  # why-cited: never claim pilots, partnerships, or compliance that does not exist
+  - feedback_actuator_security.md     # why-cited: actuator binds 9091 localhost-only — public URL returns 404
+  - project_live_deployment_status.md # why-cited: prod compose chain currently 5 files; actuator on 9091 localhost-only; v0.52 OCI anchor live
+  - project_phase_g_implementation_plan.md  # why-cited: Phase G slice plan, G-4.x landed
+  - project_resume_point.md           # why-cited: branch HEAD + test status snapshot at deploy time
+```
 
 ## 2. Scope & Non-Scope
 
@@ -24,36 +40,48 @@
 
 - Backend JAR `0.52.0 → 0.53.0`
 - Flyway HWM `V85 → V89` — three new migrations:
-  - **V87** — `platform_user` + `platform_user_backup_code` + `platform_key_material` schema; bootstrap row at id `0fab` inserted locked
-  - **V88** — `platform_user_lockout_columns` (failed_mfa_attempts_at, locked_out_at, last_totp_code, last_totp_used_at) + SECURITY DEFINER wrappers
+  - **V87** — `platform_user` + `platform_user_backup_code` + `platform_key_material` schema; bootstrap row at id `00000000-0000-0000-0000-000000000fab` inserted **LOCKED with no credentials** (operator must activate post-deploy — see §5.10)
+  - **V88** — `platform_user_lockout_columns` (`failed_mfa_attempts_at`, `locked_out_at`, `last_totp_code`, `last_totp_used_at`) + SECURITY DEFINER wrappers
   - **V89** — `platform_admin_access_log` append-only audit table
-- Frontend rebuild not required (v0.53.0 is backend-only — no platform-operator UI in this slice; admin actions still happen through existing tenant-admin pages + a new fabt-cli for platform actions)
-- New SecurityConfig URL rule layer:
+- Frontend rebuild **not required** (v0.53.0 is backend-only — no platform-operator UI in this slice; admin actions still happen through existing tenant-admin pages)
+- New SecurityConfig URL rule layer (verified at `SecurityConfig.java:179-220`):
   - `/api/v1/auth/platform/**` — public (login flow)
   - `/api/v1/admin/tenants/**` — `PLATFORM_OPERATOR` only (lifecycle, key rotation)
-  - `/api/v1/test/platform/unlock-expired` — `permitAll` (profile-gated controller; dev/test only — bean does not exist in prod)
-  - `/api/v1/tenants/**` widened from `PLATFORM_ADMIN` to `hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")` to let method @PreAuthorize be the real gate during the deprecation window
+  - `/api/v1/test/platform/unlock-expired` — `permitAll` (profile-gated controller; dev/test only — bean does not exist in prod, gated by `@Profile("dev | test")`)
+  - `/api/v1/tenants/**` widened from `PLATFORM_ADMIN` to `hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")` for the deprecation window
 - New ArchUnit rules:
-  - `NoPlatformAdminPreauthorizeTest` (no controller @PreAuthorize references PLATFORM_ADMIN)
-  - `TestControllerProfileGuardTest` (every Test*Controller has @Profile dev | test)
+  - `NoPlatformAdminPreauthorizeTest` (no controller `@PreAuthorize` references PLATFORM_ADMIN)
+  - `TestControllerProfileGuardTest` (every Test*Controller has `@Profile("dev | test")` gate)
 - 2 new Playwright specs (`platform-admin-access-log.spec.ts`, `platform-totp-lockout.spec.ts`) + 1 smoke spec
-- 3 new dev-seed `platform_user` rows (bootstrap `0fab`, smoke `0fa1`, lockout-target `0fa2`) — local dev only
+- 3 new dev-seed `platform_user` rows (bootstrap `0fab`, smoke `0fa1`, lockout-target `0fa2`) — LOCAL DEV ONLY; `seed-data.sql` has a runtime DB-name guard that REFUSES non-dev/test DBs
 
 ### What does NOT change in this deploy
 
 - Tenant authentication flow (`POST /api/v1/auth/login`) — unchanged
-- Existing PLATFORM_ADMIN-bearing app_user accounts — V87 backfills `COC_ADMIN` so they continue to work for tenant-scoped admin tasks
-- HMIS push (`POST /api/v1/hmis/push`) authority — remains COC_ADMIN-tenant-scoped (a brief @PlatformAdminOnly migration in G-4.4 was reverted because the service contract reads TenantContext); see §F16 below for the audit-trail compensation
+- Existing PLATFORM_ADMIN-bearing app_user accounts — V87 backfills `COC_ADMIN` so they continue to work for tenant-scoped admin tasks (user mgmt, shelter mgmt, OAuth2 provider config, API keys, TOTP admin)
+- HMIS push (`POST /api/v1/hmis/push`) authority — remains COC_ADMIN-tenant-scoped per F16; new confirm-header gate + audit row added
 - Prometheus rules / Grafana dashboards — no new alerts in this deploy (F18 deferred to G-4.5)
 - Nginx config — no changes
+- Compose override chain — same 5 files as v0.52 (no new override file in v0.53)
+
+### Known limitations shipped intentionally
+
+- **F13** — `after_state` always NULL on PAL rows in v0.53 (Decision 11)
+- **F14** — Cross-tenant operator-driven HMIS push deferred to post-v0.53
+- **F16** — HMIS push authority broadening + audit-chain regression vs G-4.3 baseline (mitigated, customer-comms includes disclosure — see §3)
+- **F17** — Playwright fixture caching deferred to G-4.5 (CI runtime cost)
+- **F18** — Prometheus alert on per-operator tenant-update rate deferred to G-4.5
+- **F19** — Platform-operator observability config persistence IT deferred to G-4.5
+- **F20** — Audit gaps on platform-scoped reads + cross-tenant batch metadata reads (deliberate v0.53 decision; see design.md F20)
 
 ---
 
 ## 3. Customer-comms note (C-S1)
 
-**Required reading for every CoC pilot operator before deploy.** Send the
-text below verbatim to each pilot's operator-of-record (Devon's training
-cohort + Sarah Dickerson at Asheville).
+**Required reading for every CoC pilot operator-of-record before deploy.**
+**Timing: send ≥24 hours before deploy + confirm read-receipt from each operator-of-record before opening §4 deploy gates.**
+
+Send the text below verbatim to each pilot's operator-of-record via the contact email used during pilot onboarding. (Do NOT use any name, role, or affiliation in the committed runbook — pilot mappings live in private operator-comms ledgers.)
 
 > **FABT v0.53 — what's changing for your account**
 >
@@ -66,9 +94,10 @@ cohort + Sarah Dickerson at Asheville).
 > offboarding tenants, rotating per-tenant JWT keys, triggering platform
 > batch jobs, OAuth2 connection-test calls) now require a separate
 > "platform operator" login at `https://findabed.org/auth/platform/login`
-> with mandatory two-factor authentication. The platform operator is a
+> with mandatory time-based one-time password (TOTP) using an authenticator
+> app (Google Authenticator, Authy, etc.). The platform operator is a
 > distinct identity from your tenant operator account; if you need access
-> to these actions, contact platform-ops@findabed.org for activation.
+> to these actions, reply to this email to coordinate activation.
 >
 > One usability change you'll see day-one: the **HMIS export trigger**
 > (`Push to HMIS Vendors` button on the HMIS settings page, or
@@ -78,91 +107,291 @@ cohort + Sarah Dickerson at Asheville).
 > Every HMIS push now leaves an audit-event row with your user id, the
 > vendor list, and the bed-inventory snapshot count — visible in the
 > tenant audit-events report.
+>
+> One scope-of-authority disclosure (F16): in v0.53 the HMIS push
+> endpoint accepts the COC_ADMIN role (previously required PLATFORM_ADMIN).
+> Operators with COC_ADMIN-only roles who never had PLATFORM_ADMIN are
+> now authorized to trigger HMIS pushes for their tenant. The
+> confirmation header + audit-event row are the mitigations.
 
 ---
 
-## 4. Pre-deploy checklist
+## 4. Pre-Deploy Gates
 
-- [ ] CI green on `feature/g-4.4-endpoint-migration` (full mvn + Playwright)
-- [ ] PR opened with per-endpoint OLD-role → NEW-role + AuditEventType table (M-S1)
-- [ ] PR merged to main; tag `v0.53.0` cut from main HEAD
-- [ ] CI scans green on tag (Trivy, ZAP, deps, SBOM)
-- [ ] CHANGELOG entry promoted from `[Unreleased]` to `[v0.53.0]` with date
-- [ ] `pom.xml` version bumped to `0.53.0` (NOT a snapshot)
-- [ ] Customer-comms email sent to pilot operators (§3 text)
+Phases run in chronological order. Each phase blocks the next.
+
+### Phase A — Pre-PR-merge
+
+- [ ] Backend full `mvn test` green on the feature branch (1246+/1246+ at this writing; new G-4.4 enum-type cases land at HEAD)
+- [ ] Playwright full suite green via `dev-start.sh --nginx` + `BASE_URL=http://localhost:8081 npx playwright test --project=chromium --trace on 2>&1 | tee logs/g-4.4-playwright-post-f16.log`
+- [ ] PR description includes the per-endpoint role-migration table linked at `openspec/changes/platform-admin-split-and-access-log/role-migration-table.md` (M-S1)
+- [ ] Reviewer signs off endpoint-by-endpoint on the role-migration table
+
+### Phase B — Pre-tag (post-merge)
+
+- [ ] CI green on `main` post-merge (Trivy, ZAP, deps, SBOM all pass — per `feedback_release_after_scans.md`, do NOT tag until all scans green)
+- [ ] CHANGELOG entry promoted from `[Unreleased]` to `[v0.53.0]` with deploy date
+- [ ] `backend/pom.xml` version bumped to `0.53.0` (NOT a snapshot)
+- [ ] Tag `v0.53.0` cut from `main` HEAD: `git tag -a v0.53.0 -m "G-4.4 platform-admin-split"; git push origin v0.53.0`
+- [ ] GitHub release created from the tag with CHANGELOG entry as body
+
+### Phase C — Pre-deploy (≥24h before deploy)
+
+- [ ] Customer-comms email sent to each pilot operator-of-record (§3 verbatim text)
+- [ ] Read-receipt confirmed from each operator
+- [ ] Memory `project_resume_point.md` updated with branch HEAD + intent to deploy
 - [ ] Flyway dry-run executed against a copy of prod DB; V87+V88+V89 verified clean
-- [ ] OCI WORM lock activation date confirmed (still applies — Phase G-3 contract from v0.52)
 
-## 5. Deploy sequence
+### Phase D — At-deploy (operator on the VM)
 
-(Stub — fill in concrete commands during the deploy session per
-runbook-template.md. Standard deploy:
-backup → scp jar → flyway → docker compose up → smoke verify.)
+- [ ] `docker images` confirms the prior backend image is preserved before pulling new tag (rollback safety)
+- [ ] `pg_dump` backup taken — store off-VM with timestamp
+- [ ] Confirm 5-file compose chain on the VM (see §5)
+- [ ] OCI WORM lock activation date still in window (active per v0.52 deploy)
 
-## 6. Smoke verification
+---
 
-- [ ] `GET /actuator/health` returns 200 on the new JAR
-- [ ] `GET /api/v1/version` returns 0.53.0
-- [ ] Existing tenant operator can log in (no regression on `/api/v1/auth/login`)
-- [ ] Platform login flow works against the seeded prod platform_user
-- [ ] HMIS push admin UI button still works (confirm header attached automatically)
-- [ ] Tenant audit-events list shows the new HMIS_EXPORT_TRIGGERED action
+## 5. Deploy Steps
+
+### 5.1. Preserve last-good image tag
+
+```bash
+ssh <VM_USER>@<VM_IP>
+docker tag fabt-backend:latest fabt-backend:v0.52.0
+docker images fabt-backend
+```
+
+### 5.2. Checkout the v0.53.0 tag
+
+```bash
+cd ~/finding-a-bed-tonight
+git fetch origin --tags
+git checkout v0.53.0
+git log --oneline -1
+git describe --tags --exact-match
+# Expected: v0.53.0
+```
+
+> **Do NOT `git pull origin main`.** The deployed commit must equal the tag for audit traceability.
+
+### 5.3. Verify pom.xml version bump
+
+```bash
+grep -A 2 "<artifactId>finding-a-bed-tonight" backend/pom.xml | head -4
+# Expected: <version>0.53.0</version>
+```
+
+### 5.4. pg_dump backup
+
+```bash
+docker exec fabt-postgres pg_dump -U fabt -d fabt --schema-only > ~/fabt-backups/v0.53.0-pre-schema.sql
+docker exec fabt-postgres pg_dump -U fabt -d fabt --data-only > ~/fabt-backups/v0.53.0-pre-data.sql
+ls -la ~/fabt-backups/v0.53.0-*.sql
+```
+
+Store off-VM. Do NOT skip — V87 introduces append-only triggers + REVOKEs; rollback options are limited if anything goes wrong.
+
+### 5.5. mvn clean + build backend JAR + build backend image
+
+```bash
+cd ~/finding-a-bed-tonight/backend
+mvn clean package -DskipTests
+ls -la target/*.jar | tail -2
+# Expected: target/finding-a-bed-tonight-0.53.0.jar (~ 100+ MB fat jar)
+
+cd ~/finding-a-bed-tonight
+docker build --no-cache -f infra/docker/Dockerfile.backend -t fabt-backend:latest .
+docker images fabt-backend | head -3
+```
+
+(`--no-cache` per `feedback_prod_docker_build_pattern.md` — three no-op traps caught during v0.48 live deploy because Docker honored stale layers.)
+
+### 5.6. Force-recreate backend (triggers Flyway V87 + V88 + V89)
+
+**5-file compose chain** — order matters; later override files win.
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f ~/fabt-secrets/docker-compose.prod.yml \
+  -f ~/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml \
+  -f ~/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml \
+  -f ~/fabt-secrets/docker-compose.prod-v0.52-oci-anchor.yml \
+  --env-file ~/fabt-secrets/.env.prod \
+  up -d --force-recreate backend
+```
+
+The v0.52 OCI anchor override stays in the chain — v0.53 does not introduce a new override file.
+
+### 5.7. Wait for backend health (localhost:9091, NOT public URL)
+
+Per `project_live_deployment_status.md` v0.47 lesson — actuator binds **port 9091 localhost-only**. The public URL returns 404.
+
+```bash
+until curl -fsS http://localhost:9091/actuator/health 2>/dev/null | grep -q '"status":"UP"'; do
+  sleep 3
+  echo "waiting for backend..."
+done
+echo "backend UP"
+```
+
+If the container fails to come up healthy, check logs:
+
+```bash
+docker logs fabt-backend --tail 100 2>&1 | grep -E "ERROR|FATAL|Flyway"
+```
+
+### 5.8. Verify Flyway HWM advanced
+
+```bash
+docker exec fabt-postgres psql -U fabt -d fabt \
+  -c "SELECT version, description, installed_on, success FROM flyway_schema_history WHERE version IN ('V85','V87','V88','V89') ORDER BY installed_rank DESC;"
+```
+
+Expected: V87, V88, V89 each show `success=t` with `installed_on` matching the deploy window.
+
+### 5.9. Verify backend app version
+
+Per the v0.52 prod pattern: `/api/v1/version` returns the SemVer with the trailing `.0` stripped.
+
+```bash
+curl -s https://findabed.org/api/v1/version
+# Expected: {"version":"0.53"}
+```
+
+If you see `"0.52"` the new image isn't live — re-check §5.1 / §5.5.
+
+### 5.10. Activate the bootstrap platform_user
+
+V87 ships the bootstrap row LOCKED with no email/password. `seed-data.sql` is dev/test only (refuses prod DB names), so the operator must activate manually before any platform-operator login can succeed. This step replaces what dev does via seed-data.
+
+```bash
+# Step 1 — generate a bcrypt hash for the chosen platform-operator password.
+# Use the existing fabt-cli hash-password tool on the VM (or any laptop):
+ssh <VM_USER>@<VM_IP>
+cd ~/finding-a-bed-tonight
+java -jar fabt-cli/target/fabt-cli.jar hash-password
+# Tool prompts for password (no echo); prints the bcrypt hash.
+
+# Step 2 — UPDATE the bootstrap row with the chosen email + bcrypt hash.
+# REVOKEs prevent fabt_app from doing this; run as fabt OWNER.
+# Note: account_locked stays TRUE until first successful MFA enrollment.
+docker exec fabt-postgres psql -U fabt -d fabt -c "
+UPDATE platform_user
+SET email          = '<chosen-operator-email>',
+    password_hash  = '<bcrypt-hash-from-step-1>',
+    account_locked = false
+WHERE id = '00000000-0000-0000-0000-000000000fab';
+"
+
+# Step 3 — operator opens https://findabed.org/auth/platform/login and:
+#   (a) submits email + password
+#   (b) is forced through MFA setup on first login (mfa_enabled=false initially)
+#   (c) scans QR / enters TOTP secret in their authenticator app
+#   (d) confirms the first TOTP code to complete enrollment
+# After step 3, mfa_enabled=true and platform-operator login flow is live.
+```
+
+> **Do NOT print the .env.prod file or any rendered config to confirm credentials**, per `feedback_never_print_rendered_secrets.md` — the SMTP password leak in v0.49 was caused by exactly this. Validate via the web flow only.
+
+---
+
+## 6. Post-Deploy Smoke Verification
+
+### 6.1. Backend health (localhost:9091)
+
+Already done in §5.7. Re-run if doubt: `curl -fsS http://localhost:9091/actuator/health | jq .`
+
+### 6.2. Version literal
+
+```bash
+curl -s https://findabed.org/api/v1/version
+# Expected: {"version":"0.53"} (note: trailing ".0" is stripped by maven property substitution)
+```
+
+### 6.3. Existing tenant operator login still works (no regression)
+
+Run the deploy-verify Playwright suite per `feedback_smoke_config_on_prod.md`:
+
+```bash
+cd ~/finding-a-bed-tonight/e2e/playwright
+FABT_BASE_URL=https://findabed.org \
+  npx playwright test \
+  --config=deploy/playwright.config.ts \
+  --project=deploy-verify
+```
+
+**Acceptable flake:** test 13/14 (rate-limit-triggered fail) is NOT a regression per memory — re-run once if it trips. Real regressions show up consistently.
+
+### 6.4. Platform login flow (only after §5.10 activation completes)
+
+**Skip this gate if §5.10 has not yet been completed by the operator.**
+
+In a browser:
+1. Open `https://findabed.org/auth/platform/login`
+2. Enter the email + password set in §5.10
+3. Confirm: redirected to MFA setup (first time) OR MFA verify (subsequent)
+4. Complete MFA flow
+5. Confirm: returns access token (browser shows the success page or returns to a target URL)
+
+If §5.10 hasn't run yet, this gate cannot pass — and that is the correct state. Document the activation date in the deploy log.
+
+### 6.5. HMIS push admin UI (no regression)
+
+Have any existing tenant operator (admin@dev or staging-tenant cocadmin):
+1. Log in via `/auth/login`
+2. Navigate to HMIS Settings page
+3. Click `Push to HMIS Vendors` button
+4. Confirm: returns success (status: push initiated, outboxEntriesCreated number)
+5. Navigate to tenant audit-events report
+6. Confirm: new row with action=`HMIS_EXPORT_TRIGGERED`, actor matches the logged-in user, vendor list + count populated
+
+### 6.6. Tenant-scoped admin operations regression sweep
+
+Spot-check (one each):
+- User CRUD: list users → create user → deactivate
+- Shelter CRUD: edit a shelter
+- OAuth2 provider: list providers
+- API key: list keys
+- TOTP admin: disable a user's TOTP (test user only)
+
+All should succeed for COC_ADMIN-bearing accounts (the previous PLATFORM_ADMIN-bearing accounts now also have COC_ADMIN per V87 backfill).
+
+---
 
 ## 7. Rollback
 
-- Backend JAR rollback to v0.52.0 + `flyway undo` is **NOT supported** for
-  V87 (platform_user + REVOKEs) — V87 is forward-only.
-- If post-deploy verification reveals a critical issue, the only safe
-  rollback is forward-fix (v0.53.1 hotfix) or restoring the pre-v0.53
-  DB snapshot taken in step 5.
-- Drop the operator account credentials immediately if rollback is
-  required (V87 bootstrap row activated in prod) — operator must
-  re-activate on the rolled-forward release.
+| Failure mode | Action | Recovery time |
+|---|---|---|
+| Backend fails to start (Flyway error, OCI key missing, etc.) | Re-pin to v0.52: `docker tag fabt-backend:v0.52.0 fabt-backend:latest` + `docker compose ... up -d --force-recreate backend`. V87/V88/V89 stay applied — Flyway is forward-only — but a v0.52 JAR running against V89 schema works (the new tables are unused by v0.52 code). | ~10 min |
+| Critical security bug post-deploy | Lock the bootstrap operator account immediately: `docker exec fabt-postgres psql -U fabt -d fabt -c "SELECT platform_user_set_account_locked('00000000-0000-0000-0000-000000000fab', true);"` (the V88 SECURITY DEFINER setter — fabt_app cannot direct-UPDATE due to V87 REVOKE). Then cut a v0.53.1 hotfix branch from `feature/g-4.4-endpoint-migration`, fix, scan-skip-allowed-for-hotfix, tag, push. | 30-60 min from bug-found to v0.53.1 deployed |
+| Critical data corruption | Restore the pg_dump from §5.4. Both schema-only and data-only dumps are required. Re-deploy v0.52.0 against the restored DB. | 60-120 min |
+| Backend healthy but HMIS push failing (F16 audit row not landing) | Check `tail -50 logs/backend.log | grep "HMIS push audit event publish failed"`. The push itself succeeds even if audit row publish fails (intentional — push is irreversible, audit is best-effort with WARN log). Forward-fix in v0.53.1. | 0 min (no rollback; log + monitor) |
+| Platform-operator login flow broken | If §5.10 activation completed but login 401s, the bcrypt hash is wrong. Re-run §5.10 step 2 with a fresh hash. The bootstrap row is the only entry point. | 5 min |
+
+> **`flyway undo` is NOT supported** for V87 (REVOKEs) or V89 (append-only triggers). Forward-fix is the only path for schema-level issues.
 
 ---
 
-## 8. Known limitations + deferred follow-ups
-
-- **F13 — `after_state` always NULL on PAL rows in v0.53.** Decision 11
-  commits PAL+AE rows BEFORE proceed() runs the controller method, so
-  `before_state` is captured but `after_state` is not. The append-only
-  trigger from V89 prevents post-proceed UPDATE. Documented limitation;
-  Phase H+ options captured in design.md.
-
-- **F14 — Cross-tenant operator-driven HMIS push.** Currently
-  `/api/v1/hmis/push` reads TenantContext (COC_ADMIN-only). A
-  PLATFORM_OPERATOR cannot trigger an HMIS push for an arbitrary tenant.
-  Future change adds `POST /api/v1/admin/tenants/{id}/hmis/push` that
-  takes tenantId in the path. ~3-4h slice, slot in G-4.5 or post-v0.53.
-
-- **F16 — HMIS push authority broadening (mitigated, not eliminated).**
-  Pre-G-4.3 the endpoint required PLATFORM_ADMIN. V87 backfill grants
-  COC_ADMIN to former PLATFORM_ADMIN-bearers, so existing tooling
-  continues to work. CoC admins who never had PLATFORM_ADMIN are
-  authorized in v0.53. Mitigations: confirm-header gate on the endpoint
-  + per-tenant audit_event row with actor identity. Customer-comms note
-  (§3) discloses to pilot operators.
-
-- **F17 — Playwright fixture caching.** `setupPlatformOperator()`
-  resets the bootstrap row on every IT call (~30s of CI bloat per run).
-  Cache fixture across tests; defer to G-4.5.
-
-- **F18 — Prometheus alert on per-operator tenant-update rate.** New
-  threat surface post-G-4.4: a compromised PLATFORM_OPERATOR could
-  mass-rename / mass-config-change tenants. Alert on per-operator
-  mutation rate; lands in F3 / G-4.5 monitoring buildout.
-
-- **F19 — Platform-operator observability config persistence IT.**
-  Pin that PUT-then-GET observability round-trips on the @PlatformAdminOnly
-  endpoint actually persist (in case a future RLS addition silently drops
-  the write). ~30 min slice; defer to G-4.5.
-
----
-
-## 9. Post-deploy housekeeping
+## 8. Post-Deploy Housekeeping
 
 - [ ] Archive OpenSpec change `platform-admin-split-and-access-log` via `/opsx:archive`
 - [ ] Update `project_resume_point.md` memory to v0.53 deployed state
-- [ ] Update `project_live_deployment_status.md` memory
-- [ ] Smoke-verify against findabed.org with the deploy-verify Playwright suite
+- [ ] Update `project_live_deployment_status.md` memory (compose-file count + Flyway HWM + JAR version)
+- [ ] Smoke-verify post-deploy via §6 sweep
 - [ ] Coordinate G-4.5 / G-4.6 kickoff in next session
+- [ ] Update fabt-cli runbook entries for new platform-operator activation flow
+
+---
+
+## 9. Known limitations + deferred follow-ups
+
+See `openspec/changes/platform-admin-split-and-access-log/design.md` §F1-F20 for full follow-up list. Highlights for v0.53:
+
+- **F13** — `after_state` always NULL on PAL rows in v0.53 (Decision 11)
+- **F14** — Cross-tenant operator-driven HMIS push (`POST /api/v1/admin/tenants/{id}/hmis/push`) deferred to G-4.5 / dedicated micro-change
+- **F16** — HMIS push authority broadening + audit-chain regression mitigated via confirm-header + per-tenant audit_event row; customer-comms in §3 includes the disclosure
+- **F17** — Playwright fixture caching across tests (CI runtime cost); G-4.5
+- **F18** — Prometheus alert on per-operator tenant-update rate; G-4.5 monitoring
+- **F19** — Platform-operator observability config persistence IT; G-4.5
+- **F20** — Audit gaps on platform-scoped reads + cross-tenant batch metadata reads (deliberate v0.53 decision)

--- a/docs/oracle-update-notes-v0.53.0.md
+++ b/docs/oracle-update-notes-v0.53.0.md
@@ -1,0 +1,168 @@
+# Oracle Deploy Notes — v0.53.0
+
+**Tag:** v0.53.0 (DRAFT, not yet tagged)
+**Branch:** `main` post-merge of PR for `feature/g-4.4-endpoint-migration` (Phase G-4.1, G-4.2, G-4.3, G-4.4 — and tracking G-4.5, G-4.6 as still-open scope below)
+**Theme:** Phase G-4 — platform admin authority split + per-action audit log.
+
+---
+
+## 1. Consulted Memories
+
+- `feedback_runbook_template_v1.md` — every oracle-update-notes follows the v1 template shape
+- `feedback_runbook_compose_chain.md` — prod docker compose up needs ALL override files in order
+- `feedback_never_print_rendered_secrets.md` — never cat / head / grep secret-containing config files
+- `feedback_release_after_scans.md` — don't tag releases until CI scans are green
+- `feedback_legal_claims_review.md` — scan all docs for overclaimed compliance before any release
+- `feedback_dev_keys_prod_guard.md` — runtime guards on dev-only keys / endpoints
+- `feedback_no_guessing_security.md` — never guess on security issues
+- `project_phase_g_implementation_plan.md` — Phase G slice plan
+- `project_resume_point.md` — current branch state
+
+## 2. Scope & Non-Scope
+
+### What ships
+
+- Backend JAR `0.52.0 → 0.53.0`
+- Flyway HWM `V85 → V89` — three new migrations:
+  - **V87** — `platform_user` + `platform_user_backup_code` + `platform_key_material` schema; bootstrap row at id `0fab` inserted locked
+  - **V88** — `platform_user_lockout_columns` (failed_mfa_attempts_at, locked_out_at, last_totp_code, last_totp_used_at) + SECURITY DEFINER wrappers
+  - **V89** — `platform_admin_access_log` append-only audit table
+- Frontend rebuild not required (v0.53.0 is backend-only — no platform-operator UI in this slice; admin actions still happen through existing tenant-admin pages + a new fabt-cli for platform actions)
+- New SecurityConfig URL rule layer:
+  - `/api/v1/auth/platform/**` — public (login flow)
+  - `/api/v1/admin/tenants/**` — `PLATFORM_OPERATOR` only (lifecycle, key rotation)
+  - `/api/v1/test/platform/unlock-expired` — `permitAll` (profile-gated controller; dev/test only — bean does not exist in prod)
+  - `/api/v1/tenants/**` widened from `PLATFORM_ADMIN` to `hasAnyRole("PLATFORM_OPERATOR", "PLATFORM_ADMIN")` to let method @PreAuthorize be the real gate during the deprecation window
+- New ArchUnit rules:
+  - `NoPlatformAdminPreauthorizeTest` (no controller @PreAuthorize references PLATFORM_ADMIN)
+  - `TestControllerProfileGuardTest` (every Test*Controller has @Profile dev | test)
+- 2 new Playwright specs (`platform-admin-access-log.spec.ts`, `platform-totp-lockout.spec.ts`) + 1 smoke spec
+- 3 new dev-seed `platform_user` rows (bootstrap `0fab`, smoke `0fa1`, lockout-target `0fa2`) — local dev only
+
+### What does NOT change in this deploy
+
+- Tenant authentication flow (`POST /api/v1/auth/login`) — unchanged
+- Existing PLATFORM_ADMIN-bearing app_user accounts — V87 backfills `COC_ADMIN` so they continue to work for tenant-scoped admin tasks
+- HMIS push (`POST /api/v1/hmis/push`) authority — remains COC_ADMIN-tenant-scoped (a brief @PlatformAdminOnly migration in G-4.4 was reverted because the service contract reads TenantContext); see §F16 below for the audit-trail compensation
+- Prometheus rules / Grafana dashboards — no new alerts in this deploy (F18 deferred to G-4.5)
+- Nginx config — no changes
+
+---
+
+## 3. Customer-comms note (C-S1)
+
+**Required reading for every CoC pilot operator before deploy.** Send the
+text below verbatim to each pilot's operator-of-record (Devon's training
+cohort + Sarah Dickerson at Asheville).
+
+> **FABT v0.53 — what's changing for your account**
+>
+> Existing operator accounts continue to work for everyday admin tasks:
+> user management, shelter management, OAuth2 provider setup, API keys,
+> coordinator assignments, TOTP admin operations. No re-login required.
+> Your existing username + password + TOTP enrolment carries forward.
+>
+> A small set of platform-wide actions (creating new tenants, suspending /
+> offboarding tenants, rotating per-tenant JWT keys, triggering platform
+> batch jobs, OAuth2 connection-test calls) now require a separate
+> "platform operator" login at `https://findabed.org/auth/platform/login`
+> with mandatory two-factor authentication. The platform operator is a
+> distinct identity from your tenant operator account; if you need access
+> to these actions, contact platform-ops@findabed.org for activation.
+>
+> One usability change you'll see day-one: the **HMIS export trigger**
+> (`Push to HMIS Vendors` button on the HMIS settings page, or
+> `POST /api/v1/hmis/push` if you script against the API) now requires a
+> confirmation header (`X-Confirm-HMIS-Push: CONFIRM`). The admin UI
+> wires this automatically; if you script the call, add the header.
+> Every HMIS push now leaves an audit-event row with your user id, the
+> vendor list, and the bed-inventory snapshot count — visible in the
+> tenant audit-events report.
+
+---
+
+## 4. Pre-deploy checklist
+
+- [ ] CI green on `feature/g-4.4-endpoint-migration` (full mvn + Playwright)
+- [ ] PR opened with per-endpoint OLD-role → NEW-role + AuditEventType table (M-S1)
+- [ ] PR merged to main; tag `v0.53.0` cut from main HEAD
+- [ ] CI scans green on tag (Trivy, ZAP, deps, SBOM)
+- [ ] CHANGELOG entry promoted from `[Unreleased]` to `[v0.53.0]` with date
+- [ ] `pom.xml` version bumped to `0.53.0` (NOT a snapshot)
+- [ ] Customer-comms email sent to pilot operators (§3 text)
+- [ ] Flyway dry-run executed against a copy of prod DB; V87+V88+V89 verified clean
+- [ ] OCI WORM lock activation date confirmed (still applies — Phase G-3 contract from v0.52)
+
+## 5. Deploy sequence
+
+(Stub — fill in concrete commands during the deploy session per
+runbook-template.md. Standard deploy:
+backup → scp jar → flyway → docker compose up → smoke verify.)
+
+## 6. Smoke verification
+
+- [ ] `GET /actuator/health` returns 200 on the new JAR
+- [ ] `GET /api/v1/version` returns 0.53.0
+- [ ] Existing tenant operator can log in (no regression on `/api/v1/auth/login`)
+- [ ] Platform login flow works against the seeded prod platform_user
+- [ ] HMIS push admin UI button still works (confirm header attached automatically)
+- [ ] Tenant audit-events list shows the new HMIS_EXPORT_TRIGGERED action
+
+## 7. Rollback
+
+- Backend JAR rollback to v0.52.0 + `flyway undo` is **NOT supported** for
+  V87 (platform_user + REVOKEs) — V87 is forward-only.
+- If post-deploy verification reveals a critical issue, the only safe
+  rollback is forward-fix (v0.53.1 hotfix) or restoring the pre-v0.53
+  DB snapshot taken in step 5.
+- Drop the operator account credentials immediately if rollback is
+  required (V87 bootstrap row activated in prod) — operator must
+  re-activate on the rolled-forward release.
+
+---
+
+## 8. Known limitations + deferred follow-ups
+
+- **F13 — `after_state` always NULL on PAL rows in v0.53.** Decision 11
+  commits PAL+AE rows BEFORE proceed() runs the controller method, so
+  `before_state` is captured but `after_state` is not. The append-only
+  trigger from V89 prevents post-proceed UPDATE. Documented limitation;
+  Phase H+ options captured in design.md.
+
+- **F14 — Cross-tenant operator-driven HMIS push.** Currently
+  `/api/v1/hmis/push` reads TenantContext (COC_ADMIN-only). A
+  PLATFORM_OPERATOR cannot trigger an HMIS push for an arbitrary tenant.
+  Future change adds `POST /api/v1/admin/tenants/{id}/hmis/push` that
+  takes tenantId in the path. ~3-4h slice, slot in G-4.5 or post-v0.53.
+
+- **F16 — HMIS push authority broadening (mitigated, not eliminated).**
+  Pre-G-4.3 the endpoint required PLATFORM_ADMIN. V87 backfill grants
+  COC_ADMIN to former PLATFORM_ADMIN-bearers, so existing tooling
+  continues to work. CoC admins who never had PLATFORM_ADMIN are
+  authorized in v0.53. Mitigations: confirm-header gate on the endpoint
+  + per-tenant audit_event row with actor identity. Customer-comms note
+  (§3) discloses to pilot operators.
+
+- **F17 — Playwright fixture caching.** `setupPlatformOperator()`
+  resets the bootstrap row on every IT call (~30s of CI bloat per run).
+  Cache fixture across tests; defer to G-4.5.
+
+- **F18 — Prometheus alert on per-operator tenant-update rate.** New
+  threat surface post-G-4.4: a compromised PLATFORM_OPERATOR could
+  mass-rename / mass-config-change tenants. Alert on per-operator
+  mutation rate; lands in F3 / G-4.5 monitoring buildout.
+
+- **F19 — Platform-operator observability config persistence IT.**
+  Pin that PUT-then-GET observability round-trips on the @PlatformAdminOnly
+  endpoint actually persist (in case a future RLS addition silently drops
+  the write). ~30 min slice; defer to G-4.5.
+
+---
+
+## 9. Post-deploy housekeeping
+
+- [ ] Archive OpenSpec change `platform-admin-split-and-access-log` via `/opsx:archive`
+- [ ] Update `project_resume_point.md` memory to v0.53 deployed state
+- [ ] Update `project_live_deployment_status.md` memory
+- [ ] Smoke-verify against findabed.org with the deploy-verify Playwright suite
+- [ ] Coordinate G-4.5 / G-4.6 kickoff in next session

--- a/e2e/karate/src/test/java/features/dv-address/dv-address-policy.feature
+++ b/e2e/karate/src/test/java/features/dv-address/dv-address-policy.feature
@@ -27,10 +27,15 @@ Feature: DV Address Policy — Change Endpoint Safeguards
     When method PUT
     Then status 403
 
-  Scenario: Valid policy change succeeds
-    * configure headers = { Authorization: '#(adminAuthHeader)', 'X-Confirm-Policy-Change': 'CONFIRM' }
-    Given path '/api/v1/tenants', tenantId, 'dv-address-policy'
-    And request { "policy": "ADMIN_AND_ASSIGNED" }
-    When method PUT
-    Then status 200
-    And match response.policy == 'ADMIN_AND_ASSIGNED'
+  # G-4.4 §F21 follow-up: the "valid policy change succeeds" happy-path
+  # scenario was removed from this feature on 2026-04-26. After G-4.4 the
+  # /dv-address-policy endpoint is @PlatformAdminOnly, requiring a
+  # platform-operator JWT (iss=fabt-platform, mfaVerified=true) +
+  # X-Platform-Justification header + X-Confirm-Policy-Change header.
+  # Karate currently has no platform-operator login helper (TOTP
+  # generation in JS + /auth/platform/login + /verify-mfa flow). The
+  # backend IT DvAddressRedactionTest covers the happy path with 13
+  # scenarios + the helper TestAuthHelper.platformOperatorHeaders().
+  # Coverage parity is preserved without the Karate refactor; F21
+  # tracks adding Karate platform-operator support for future cross-
+  # layer coverage if needed.

--- a/e2e/karate/src/test/java/features/hmis/hmis-push.feature
+++ b/e2e/karate/src/test/java/features/hmis/hmis-push.feature
@@ -19,8 +19,17 @@ Feature: HMIS Bridge — Push and Preview
     And match response.deadLetterCount == '#number'
 
   Scenario: Manual push succeeds for admin
-    * configure headers = { Authorization: '#(adminAuthHeader)' }
+    # G-4.4 §F16: COC_ADMIN-tenant-scoped; X-Confirm-HMIS-Push: CONFIRM required.
+    * configure headers = { Authorization: '#(adminAuthHeader)', 'X-Confirm-HMIS-Push': 'CONFIRM' }
     Given path '/api/v1/hmis/push'
     When method POST
     Then status 200
     And match response.outboxEntriesCreated == '#number'
+
+  Scenario: Manual push without confirm header → 400 missing_confirmation
+    # G-4.4 §F16: confirm-header gate prevents accidental triggers.
+    * configure headers = { Authorization: '#(adminAuthHeader)' }
+    Given path '/api/v1/hmis/push'
+    When method POST
+    Then status 400
+    And match response.error == 'missing_confirmation'

--- a/e2e/playwright/.gitignore
+++ b/e2e/playwright/.gitignore
@@ -2,6 +2,8 @@ node_modules/
 playwright-report/
 test-results/
 blob-report/
-# Storage-state JSON files contain access tokens — never commit these.
-# But helper TypeScript modules in the same directory ARE source code.
-auth/*.json
+# Storage-state JSON files contain access tokens. Source-code helpers live
+# in helpers/auth/ (tracked) — /auth/ at the playwright root is exclusively
+# storage state. The leading slash anchors the pattern so the helpers/auth/
+# subdirectory is NOT swept by the same rule.
+/auth/

--- a/e2e/playwright/.gitignore
+++ b/e2e/playwright/.gitignore
@@ -2,4 +2,6 @@ node_modules/
 playwright-report/
 test-results/
 blob-report/
-auth/
+# Storage-state JSON files contain access tokens — never commit these.
+# But helper TypeScript modules in the same directory ARE source code.
+auth/*.json

--- a/e2e/playwright/auth/platform-operator.ts
+++ b/e2e/playwright/auth/platform-operator.ts
@@ -1,0 +1,147 @@
+import { APIRequestContext, expect } from '@playwright/test';
+import { generateTotp, PLATFORM_BOOTSTRAP_TOTP_SECRET } from './totp-helper';
+
+/**
+ * Phase G-4.4 §5.10 — helpers for minting a platform-operator JWT and
+ * driving `@PlatformAdminOnly` endpoints from Playwright tests.
+ *
+ * <p>There is no platform-operator UI in v0.53 — all platform admin
+ * actions are backend API surface only — so we expose helper functions
+ * rather than a {@link Page} fixture. Tests that need a logged-in
+ * platform operator pull these into their `test.beforeEach` and use
+ * the returned token + helper to call `@PlatformAdminOnly` endpoints
+ * directly.
+ *
+ * <p>Login flow (matches `PlatformAuthController`):
+ * <ol>
+ *   <li>POST `/api/v1/auth/platform/login` with email + password →
+ *       receives a 5-minute MFA-verify-scoped token (since the seeded
+ *       bootstrap user has `mfa_enabled = true`).</li>
+ *   <li>POST `/api/v1/auth/platform/login/mfa-verify` with the
+ *       MFA-verify token + a fresh TOTP code → receives the actual
+ *       15-minute access token (with `mfaVerified=true`).</li>
+ * </ol>
+ *
+ * <p>Justification: the access token alone is NOT enough to call a
+ * `@PlatformAdminOnly` endpoint. Every such call also needs the
+ * `X-Platform-Justification` header (≥10 chars after trim, ASCII).
+ * {@link platformAdminFetch} bundles both into one helper.
+ */
+
+const API_URL = process.env.API_URL || 'http://localhost:8080';
+
+/**
+ * Default credentials for the dev-seeded bootstrap `platform_user`
+ * (id `0fab`). Provisioned by `infra/scripts/seed-data.sql`. NOT a
+ * production credential.
+ */
+export const PLATFORM_OPERATOR_EMAIL = 'platform-ops@dev.fabt.org';
+export const PLATFORM_OPERATOR_PASSWORD = 'admin123';
+
+/**
+ * The token + secret bundle returned from {@link loginPlatformOperator}.
+ * Holds the post-MFA access token for backend calls + the same secret
+ * used to mint the verify code, so tests that need to mint additional
+ * codes (e.g. step-up flows) don't have to re-derive.
+ */
+export interface PlatformOperatorSession {
+  /** 15-min access token; MFA_VERIFIED authority granted. */
+  accessToken: string;
+  /** Base32 TOTP secret, same as `PLATFORM_BOOTSTRAP_TOTP_SECRET`. */
+  mfaSecret: string;
+  /** Platform user UUID (id `0fab` for the bootstrap row). */
+  platformUserId: string;
+}
+
+/**
+ * Drive the full platform login → MFA-verify flow against the dev
+ * backend. Returns a session bundle the caller can plug into
+ * {@link platformAdminFetch}.
+ *
+ * <p>Assumes the bootstrap `platform_user` row has been activated via
+ * `seed-data.sql`. If the seed has not run, the login call returns
+ * 401 invalid_credentials and this helper throws.
+ *
+ * @param request Playwright APIRequestContext (typically `page.request`)
+ */
+export async function loginPlatformOperator(
+  request: APIRequestContext
+): Promise<PlatformOperatorSession> {
+  // Step 1 — initial login. Bootstrap user has mfa_enabled=true so the
+  // server returns scope=mfa-verify-required.
+  const loginResp = await request.post(`${API_URL}/api/v1/auth/platform/login`, {
+    data: {
+      email: PLATFORM_OPERATOR_EMAIL,
+      password: PLATFORM_OPERATOR_PASSWORD,
+    },
+  });
+  expect(
+    loginResp.ok(),
+    `Platform login failed (${loginResp.status()}): ${await loginResp.text()}`
+  ).toBeTruthy();
+  const loginBody = await loginResp.json();
+  expect(loginBody.scope, `Expected mfa-verify scope; got ${loginBody.scope}`)
+    .toBe('mfa-verify');
+  const verifyToken: string = loginBody.token;
+
+  // Step 2 — verify TOTP. Mint a fresh code from the seeded secret.
+  const code = generateTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET);
+  const verifyResp = await request.post(
+    `${API_URL}/api/v1/auth/platform/login/mfa-verify`,
+    {
+      headers: { Authorization: `Bearer ${verifyToken}` },
+      data: { code },
+    }
+  );
+  expect(
+    verifyResp.ok(),
+    `Platform MFA verify failed (${verifyResp.status()}): ${await verifyResp.text()}`
+  ).toBeTruthy();
+  const verifyBody = await verifyResp.json();
+
+  return {
+    accessToken: verifyBody.token,
+    mfaSecret: PLATFORM_BOOTSTRAP_TOTP_SECRET,
+    platformUserId: '00000000-0000-0000-0000-000000000fab',
+  };
+}
+
+/**
+ * Convenience wrapper for calling a `@PlatformAdminOnly` endpoint with
+ * the bearer + justification headers pre-populated.
+ *
+ * @param request Playwright APIRequestContext
+ * @param session result from {@link loginPlatformOperator}
+ * @param method HTTP method
+ * @param path full URL path (e.g. `/api/v1/batch/jobs/{date}`)
+ * @param justification ≥10-char ASCII reason string; lands verbatim in
+ *        the platform_admin_access_log row
+ * @param body optional JSON body
+ */
+export async function platformAdminFetch(
+  request: APIRequestContext,
+  session: PlatformOperatorSession,
+  method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE',
+  path: string,
+  justification: string,
+  body?: unknown
+) {
+  const url = path.startsWith('http') ? path : `${API_URL}${path}`;
+  const headers = {
+    Authorization: `Bearer ${session.accessToken}`,
+    'X-Platform-Justification': justification,
+    'Content-Type': 'application/json',
+  };
+  switch (method) {
+    case 'GET':
+      return request.get(url, { headers });
+    case 'POST':
+      return request.post(url, { headers, data: body });
+    case 'PUT':
+      return request.put(url, { headers, data: body });
+    case 'PATCH':
+      return request.patch(url, { headers, data: body });
+    case 'DELETE':
+      return request.delete(url, { headers, data: body });
+  }
+}

--- a/e2e/playwright/auth/totp-helper.ts
+++ b/e2e/playwright/auth/totp-helper.ts
@@ -1,0 +1,102 @@
+import * as crypto from 'crypto';
+
+/**
+ * RFC 6238 TOTP code generator for Playwright fixtures.
+ *
+ * Phase G-4.4 §5.8 (warroom R-S1 amendment): tests do NOT read
+ * `platform_user.mfa_secret` directly from the test DB — V87 REVOKEs the
+ * `platform_user` table from `fabt_app`, and a test-only HTTP wrapper
+ * adds runtime surface area. Instead, the secret is provisioned at seed
+ * time (`infra/scripts/seed-data.sql`) with a deterministic value, and
+ * this helper reproduces the standard RFC 6238 algorithm to mint codes
+ * on demand.
+ *
+ * The base32 alphabet is RFC 4648; the time step is 30s; the digit
+ * count is 6; the HMAC is SHA-1 (the standards-track default — RFC 6238
+ * §1.2 documents SHA-256 / SHA-512 as alternatives but the FABT
+ * platform_user.mfa_secret column stores codes minted with SHA-1).
+ *
+ * Usage:
+ *   import { generateTotp, PLATFORM_BOOTSTRAP_TOTP_SECRET } from './totp-helper';
+ *   const code = generateTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET);
+ */
+
+/**
+ * The dev-seeded TOTP secret for the bootstrap `platform_user` row (id
+ * `0fab`). Provisioned by `infra/scripts/seed-data.sql`. Standard RFC
+ * 4648 base32 test secret — NOT a production credential.
+ */
+export const PLATFORM_BOOTSTRAP_TOTP_SECRET = 'JBSWY3DPEHPK3PXP';
+
+/**
+ * Decode a base32-encoded string (RFC 4648, no padding required) to bytes.
+ * Tolerates lowercase + spaces + missing `=` padding.
+ */
+function base32Decode(input: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567';
+  const cleaned = input.toUpperCase().replace(/[^A-Z2-7]/g, '');
+  const bytes: number[] = [];
+  let bits = 0;
+  let value = 0;
+  for (const ch of cleaned) {
+    const idx = alphabet.indexOf(ch);
+    if (idx === -1) continue;
+    value = (value << 5) | idx;
+    bits += 5;
+    if (bits >= 8) {
+      bits -= 8;
+      bytes.push((value >>> bits) & 0xff);
+    }
+  }
+  return Buffer.from(bytes);
+}
+
+/**
+ * Compute the RFC 6238 TOTP code for the given base32 secret at the
+ * given Unix-seconds time (default: now).
+ *
+ * @param secret base32-encoded HMAC key (RFC 4648; the canonical
+ *               representation stored in `platform_user.mfa_secret`)
+ * @param atUnixSeconds optional override for the current time (used
+ *               by the lockout spec to look at the future window)
+ * @returns 6-digit zero-padded numeric code
+ */
+export function generateTotp(secret: string, atUnixSeconds?: number): string {
+  const nowSec = atUnixSeconds ?? Math.floor(Date.now() / 1000);
+  const counter = Math.floor(nowSec / 30);
+
+  // 8-byte big-endian counter
+  const counterBuf = Buffer.alloc(8);
+  // Counter fits in a 53-bit double well past year 2200; split high/low 32 bits.
+  const high = Math.floor(counter / 0x100000000);
+  const low = counter % 0x100000000;
+  counterBuf.writeUInt32BE(high, 0);
+  counterBuf.writeUInt32BE(low, 4);
+
+  const key = base32Decode(secret);
+  const hmac = crypto.createHmac('sha1', key).update(counterBuf).digest();
+
+  const offset = hmac[hmac.length - 1] & 0x0f;
+  const truncated =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff);
+
+  const code = (truncated % 1_000_000).toString().padStart(6, '0');
+  return code;
+}
+
+/**
+ * Generate the next deterministically-different TOTP code by looking
+ * one window into the future. Useful for the lockout spec which needs
+ * to submit 5 distinct WRONG codes — we generate the current code, then
+ * mutate the last digit to produce a guaranteed-wrong-but-well-formed
+ * 6-digit number.
+ */
+export function generateWrongTotp(secret: string): string {
+  const correct = generateTotp(secret);
+  const lastDigit = parseInt(correct[correct.length - 1], 10);
+  const wrongLast = (lastDigit + 1) % 10;
+  return correct.slice(0, 5) + wrongLast.toString();
+}

--- a/e2e/playwright/fixtures/auth.fixture.ts
+++ b/e2e/playwright/fixtures/auth.fixture.ts
@@ -92,10 +92,10 @@ async function loginAndSaveState(page: Page, role: Role): Promise<void> {
  * Note: there is intentionally NO `platformOperatorPage` fixture here.
  * Platform-operator actions (Phase G-4.4 +) are backend API surface only —
  * v0.53 has no platform-operator UI. Tests that need a platform JWT call
- * `loginPlatformOperator()` from `../auth/platform-operator.ts` in their
- * `test.beforeEach` and use `platformAdminFetch()` for `@PlatformAdminOnly`
- * endpoint calls. See `platform-admin-access-log.spec.ts` for the canonical
- * pattern.
+ * `loginPlatformOperator()` from `../helpers/auth/platform-operator.ts` in
+ * their `test.beforeEach` and use `platformAdminFetch()` for
+ * `@PlatformAdminOnly` endpoint calls. See `platform-admin-access-log.spec.ts`
+ * for the canonical pattern.
  */
 export const test = base.extend<{
   outreachPage: Page;

--- a/e2e/playwright/fixtures/auth.fixture.ts
+++ b/e2e/playwright/fixtures/auth.fixture.ts
@@ -88,6 +88,14 @@ async function loginAndSaveState(page: Page, role: Role): Promise<void> {
  * Extended test fixture that provides pre-authenticated browser contexts per role.
  * Usage: import { test } from '../fixtures/auth.fixture';
  *        test('my test', async ({ outreachPage }) => { ... });
+ *
+ * Note: there is intentionally NO `platformOperatorPage` fixture here.
+ * Platform-operator actions (Phase G-4.4 +) are backend API surface only —
+ * v0.53 has no platform-operator UI. Tests that need a platform JWT call
+ * `loginPlatformOperator()` from `../auth/platform-operator.ts` in their
+ * `test.beforeEach` and use `platformAdminFetch()` for `@PlatformAdminOnly`
+ * endpoint calls. See `platform-admin-access-log.spec.ts` for the canonical
+ * pattern.
  */
 export const test = base.extend<{
   outreachPage: Page;

--- a/e2e/playwright/helpers/auth/platform-operator.ts
+++ b/e2e/playwright/helpers/auth/platform-operator.ts
@@ -158,11 +158,13 @@ export async function loginPlatformOperator(
 }
 
 /**
- * Convenience login for the lockout-target user (id `0fa2`). Used by
+ * Convenience login as the lockout-test-only user (id `0fa2`). Used by
  * `platform-totp-lockout.spec.ts` so its lockout pollution stays
- * isolated from the bootstrap row's other consumers.
+ * isolated from the bootstrap row's other consumers. Function name
+ * starts with "loginAs" to read as a fixture login (vs an attacker
+ * targeting a victim — the user IS the test fixture, not a victim).
  */
-export async function loginLockoutTarget(
+export async function loginAsLockoutTestUser(
   request: APIRequestContext
 ): Promise<PlatformOperatorSession> {
   return loginPlatformOperator(request, {

--- a/e2e/playwright/helpers/auth/platform-operator.ts
+++ b/e2e/playwright/helpers/auth/platform-operator.ts
@@ -54,6 +54,22 @@ export const PLATFORM_LOCKOUT_TARGET_PASSWORD = 'admin123';
 export const PLATFORM_LOCKOUT_TARGET_USER_ID = '00000000-0000-0000-0000-000000000fa2';
 
 /**
+ * Dev-seeded TERTIARY platform_user (id `0fa1`) dedicated to the
+ * platform-operator-smoke canary. V88's TOTP replay protection
+ * (last_totp_code, 89s window) means each platform_user can complete
+ * at most one /mfa-verify per ~30s window. The smoke spec runs every
+ * CI invocation; it cannot share its row with the access-log spec
+ * (which logs in via beforeAll and would set last_totp_code first if
+ * it ran earlier alphabetically).
+ *
+ * Provisioned by `infra/scripts/seed-data.sql` (G-4.4 §5.13). NOT a
+ * production credential.
+ */
+export const PLATFORM_SMOKE_USER_EMAIL = 'platform-smoke@dev.fabt.org';
+export const PLATFORM_SMOKE_USER_PASSWORD = 'admin123';
+export const PLATFORM_SMOKE_USER_ID = '00000000-0000-0000-0000-000000000fa1';
+
+/**
  * The token + secret bundle returned from {@link loginPlatformOperator}.
  * Holds the post-MFA access token for backend calls + the same secret
  * used to mint the verify code, so tests that need to mint additional
@@ -171,6 +187,22 @@ export async function loginAsLockoutTestUser(
     email: PLATFORM_LOCKOUT_TARGET_EMAIL,
     password: PLATFORM_LOCKOUT_TARGET_PASSWORD,
     expectedUserId: PLATFORM_LOCKOUT_TARGET_USER_ID,
+  });
+}
+
+/**
+ * Convenience login as the smoke-canary user (id `0fa1`). Used by
+ * `platform-operator-smoke.spec.ts` so its single-login canary does
+ * not trip V88's 89s TOTP replay protection on the bootstrap row that
+ * the access-log spec uses for its beforeAll.
+ */
+export async function loginAsSmokeUser(
+  request: APIRequestContext
+): Promise<PlatformOperatorSession> {
+  return loginPlatformOperator(request, {
+    email: PLATFORM_SMOKE_USER_EMAIL,
+    password: PLATFORM_SMOKE_USER_PASSWORD,
+    expectedUserId: PLATFORM_SMOKE_USER_ID,
   });
 }
 

--- a/e2e/playwright/helpers/auth/platform-operator.ts
+++ b/e2e/playwright/helpers/auth/platform-operator.ts
@@ -37,6 +37,21 @@ const API_URL = process.env.API_URL || 'http://localhost:8080';
  */
 export const PLATFORM_OPERATOR_EMAIL = 'platform-ops@dev.fabt.org';
 export const PLATFORM_OPERATOR_PASSWORD = 'admin123';
+export const PLATFORM_OPERATOR_USER_ID = '00000000-0000-0000-0000-000000000fab';
+
+/**
+ * Dev-seeded SECONDARY platform_user (id `0fa2`) dedicated to the
+ * platform-totp-lockout spec. Same password + secret as the bootstrap
+ * row, but its account_locked + lockout-counter state is independent.
+ * Lets the lockout spec run in parallel with the access-log spec on a
+ * CI worker pool without colliding on shared state.
+ *
+ * Provisioned by `infra/scripts/seed-data.sql` (G-4.4 §5.13). NOT a
+ * production credential.
+ */
+export const PLATFORM_LOCKOUT_TARGET_EMAIL = 'platform-lockout@dev.fabt.org';
+export const PLATFORM_LOCKOUT_TARGET_PASSWORD = 'admin123';
+export const PLATFORM_LOCKOUT_TARGET_USER_ID = '00000000-0000-0000-0000-000000000fa2';
 
 /**
  * The token + secret bundle returned from {@link loginPlatformOperator}.
@@ -54,26 +69,45 @@ export interface PlatformOperatorSession {
 }
 
 /**
+ * Identity overrides for {@link loginPlatformOperator}. Defaults target
+ * the bootstrap `platform_user` (id `0fab`) seeded for the access-log
+ * spec; the lockout spec passes the lockout-target identity instead.
+ */
+export interface PlatformLoginIdentity {
+  email?: string;
+  password?: string;
+  /** Expected `platform_user.id` for the assertion-level UUID pin. */
+  expectedUserId?: string;
+}
+
+/**
  * Drive the full platform login → MFA-verify flow against the dev
  * backend. Returns a session bundle the caller can plug into
  * {@link platformAdminFetch}.
  *
- * <p>Assumes the bootstrap `platform_user` row has been activated via
+ * <p>Assumes the seeded `platform_user` row has been activated via
  * `seed-data.sql`. If the seed has not run, the login call returns
  * 401 invalid_credentials and this helper throws.
  *
+ * <p>By default targets the bootstrap row (id `0fab`); pass an
+ * {@link PlatformLoginIdentity} to target the lockout-target row
+ * (id `0fa2`) or any other dev-seeded platform_user.
+ *
  * @param request Playwright APIRequestContext (typically `page.request`)
+ * @param identity optional identity override
  */
 export async function loginPlatformOperator(
-  request: APIRequestContext
+  request: APIRequestContext,
+  identity: PlatformLoginIdentity = {}
 ): Promise<PlatformOperatorSession> {
-  // Step 1 — initial login. Bootstrap user has mfa_enabled=true so the
+  const email = identity.email ?? PLATFORM_OPERATOR_EMAIL;
+  const password = identity.password ?? PLATFORM_OPERATOR_PASSWORD;
+  const userId = identity.expectedUserId ?? PLATFORM_OPERATOR_USER_ID;
+
+  // Step 1 — initial login. Seeded users have mfa_enabled=true so the
   // server returns scope=mfa-verify-required.
   const loginResp = await request.post(`${API_URL}/api/v1/auth/platform/login`, {
-    data: {
-      email: PLATFORM_OPERATOR_EMAIL,
-      password: PLATFORM_OPERATOR_PASSWORD,
-    },
+    data: { email, password },
   });
   // Failure-message hygiene (Riley): keep the assertion message status-only
   // so the body doesn't get inlined into CI failure logs verbatim. On a real
@@ -82,12 +116,12 @@ export async function loginPlatformOperator(
   if (!loginResp.ok()) {
     // eslint-disable-next-line no-console
     console.error(
-      `loginPlatformOperator: /login failed status=${loginResp.status()} body=${await loginResp.text()}`
+      `loginPlatformOperator(${email}): /login failed status=${loginResp.status()} body=${await loginResp.text()}`
     );
   }
   expect(
     loginResp.ok(),
-    `Platform login failed status=${loginResp.status()} (see console.error for body)`
+    `Platform login (${email}) failed status=${loginResp.status()} (see console.error for body)`
   ).toBeTruthy();
   const loginBody = await loginResp.json();
   expect(loginBody.scope, `Expected mfa-verify scope; got ${loginBody.scope}`)
@@ -95,6 +129,7 @@ export async function loginPlatformOperator(
   const verifyToken: string = loginBody.token;
 
   // Step 2 — verify TOTP. Mint a fresh code from the seeded secret.
+  // (Both bootstrap + lockout-target share the same RFC 4648 §10 secret.)
   const code = generateTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET);
   const verifyResp = await request.post(
     `${API_URL}/api/v1/auth/platform/login/mfa-verify`,
@@ -106,20 +141,35 @@ export async function loginPlatformOperator(
   if (!verifyResp.ok()) {
     // eslint-disable-next-line no-console
     console.error(
-      `loginPlatformOperator: /login/mfa-verify failed status=${verifyResp.status()} body=${await verifyResp.text()}`
+      `loginPlatformOperator(${email}): /login/mfa-verify failed status=${verifyResp.status()} body=${await verifyResp.text()}`
     );
   }
   expect(
     verifyResp.ok(),
-    `Platform MFA verify failed status=${verifyResp.status()} (see console.error for body)`
+    `Platform MFA verify (${email}) failed status=${verifyResp.status()} (see console.error for body)`
   ).toBeTruthy();
   const verifyBody = await verifyResp.json();
 
   return {
     accessToken: verifyBody.token,
     mfaSecret: PLATFORM_BOOTSTRAP_TOTP_SECRET,
-    platformUserId: '00000000-0000-0000-0000-000000000fab',
+    platformUserId: userId,
   };
+}
+
+/**
+ * Convenience login for the lockout-target user (id `0fa2`). Used by
+ * `platform-totp-lockout.spec.ts` so its lockout pollution stays
+ * isolated from the bootstrap row's other consumers.
+ */
+export async function loginLockoutTarget(
+  request: APIRequestContext
+): Promise<PlatformOperatorSession> {
+  return loginPlatformOperator(request, {
+    email: PLATFORM_LOCKOUT_TARGET_EMAIL,
+    password: PLATFORM_LOCKOUT_TARGET_PASSWORD,
+    expectedUserId: PLATFORM_LOCKOUT_TARGET_USER_ID,
+  });
 }
 
 /**

--- a/e2e/playwright/helpers/auth/platform-operator.ts
+++ b/e2e/playwright/helpers/auth/platform-operator.ts
@@ -75,9 +75,19 @@ export async function loginPlatformOperator(
       password: PLATFORM_OPERATOR_PASSWORD,
     },
   });
+  // Failure-message hygiene (Riley): keep the assertion message status-only
+  // so the body doesn't get inlined into CI failure logs verbatim. On a real
+  // failure we log the body via console.error so debugging is still possible
+  // without the body landing in the final assertion message.
+  if (!loginResp.ok()) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `loginPlatformOperator: /login failed status=${loginResp.status()} body=${await loginResp.text()}`
+    );
+  }
   expect(
     loginResp.ok(),
-    `Platform login failed (${loginResp.status()}): ${await loginResp.text()}`
+    `Platform login failed status=${loginResp.status()} (see console.error for body)`
   ).toBeTruthy();
   const loginBody = await loginResp.json();
   expect(loginBody.scope, `Expected mfa-verify scope; got ${loginBody.scope}`)
@@ -93,9 +103,15 @@ export async function loginPlatformOperator(
       data: { code },
     }
   );
+  if (!verifyResp.ok()) {
+    // eslint-disable-next-line no-console
+    console.error(
+      `loginPlatformOperator: /login/mfa-verify failed status=${verifyResp.status()} body=${await verifyResp.text()}`
+    );
+  }
   expect(
     verifyResp.ok(),
-    `Platform MFA verify failed (${verifyResp.status()}): ${await verifyResp.text()}`
+    `Platform MFA verify failed status=${verifyResp.status()} (see console.error for body)`
   ).toBeTruthy();
   const verifyBody = await verifyResp.json();
 

--- a/e2e/playwright/helpers/auth/totp-helper.ts
+++ b/e2e/playwright/helpers/auth/totp-helper.ts
@@ -88,15 +88,42 @@ export function generateTotp(secret: string, atUnixSeconds?: number): string {
 }
 
 /**
- * Generate the next deterministically-different TOTP code by looking
- * one window into the future. Useful for the lockout spec which needs
- * to submit 5 distinct WRONG codes — we generate the current code, then
- * mutate the last digit to produce a guaranteed-wrong-but-well-formed
- * 6-digit number.
+ * Generate a TOTP code at the same window as {@link generateTotp}, then
+ * flip the last digit so the result is well-formed but typically wrong.
+ * NOT "guaranteed wrong" — server-side ±1 window tolerance leaves a
+ * tiny collision chance (~3 / 1,000,000 per call) where the mutated
+ * digit happens to match the code at counter±1. Acceptable for
+ * "submit a code that's almost-certainly different from a fresh
+ * {@link generateTotp}" use cases; NOT acceptable for the lockout spec
+ * where every attempt must be wrong with zero ambiguity. Use
+ * {@link generateFutureWrongTotp} for that.
  */
 export function generateWrongTotp(secret: string): string {
   const correct = generateTotp(secret);
   const lastDigit = parseInt(correct[correct.length - 1], 10);
   const wrongLast = (lastDigit + 1) % 10;
   return correct.slice(0, 5) + wrongLast.toString();
+}
+
+/**
+ * Generate a TOTP code at counter+10 windows (5 minutes in the future,
+ * well past the server's ±1 acceptance band). Guaranteed to be rejected
+ * by the server even with the most generous tolerance window — the
+ * verify path checks counters [N-1, N, N+1] for the current epoch N;
+ * we mint at N+10, which is outside any reasonable acceptance band.
+ *
+ * <p>Used by `platform-totp-lockout.spec.ts` to submit 5 wrong codes
+ * with zero collision probability. Each call advances the offset to
+ * keep submissions distinct (V88's TOTP-replay table may track distinct
+ * codes per attempt — different offset → different code, even within
+ * the same 30s window).
+ *
+ * @param secret base32 TOTP secret
+ * @param offsetWindows additional 30s windows past the base +10 offset
+ *        (default 0 — i.e. counter+10). The lockout spec passes 0..4
+ *        across its 5 attempts to mint 5 distinct future codes.
+ */
+export function generateFutureWrongTotp(secret: string, offsetWindows = 0): string {
+  const futureSec = Math.floor(Date.now() / 1000) + 300 + offsetWindows * 30;
+  return generateTotp(secret, futureSec);
 }

--- a/e2e/playwright/helpers/auth/totp-helper.ts
+++ b/e2e/playwright/helpers/auth/totp-helper.ts
@@ -106,11 +106,13 @@ export function generateWrongTotp(secret: string): string {
 }
 
 /**
- * Generate a TOTP code at counter+10 windows (5 minutes in the future,
- * well past the server's ±1 acceptance band). Guaranteed to be rejected
- * by the server even with the most generous tolerance window — the
- * verify path checks counters [N-1, N, N+1] for the current epoch N;
- * we mint at N+10, which is outside any reasonable acceptance band.
+ * Generate a TOTP code at counter+10 windows (5 minutes in the future).
+ * Designed to fall outside the server's configured ±1 acceptance band:
+ * the verify path checks counters [N-1, N, N+1] for the current epoch
+ * N; we mint at N+10, which is outside the v0.53 default tolerance. If
+ * the server's drift tolerance is ever widened past ±10 windows, this
+ * helper would need to advance further — pin the assumption in
+ * `platform-totp-lockout.spec.ts` rather than asserting it server-side.
  *
  * <p>Used by `platform-totp-lockout.spec.ts` to submit 5 wrong codes
  * with zero collision probability. Each call advances the offset to

--- a/e2e/playwright/tests/platform-admin-access-log.spec.ts
+++ b/e2e/playwright/tests/platform-admin-access-log.spec.ts
@@ -58,23 +58,22 @@ test.describe('Platform admin access log — end-to-end pipeline (G-4.4 §5.12)'
     );
 
     // Either 200 (controller accepted, job runner silently no-op'd) or
-    // 4xx (controller rejected the unknown job id) — both prove the
-    // request reached the controller. Critically NOT 401 (security
-    // rejected before controller) and NOT 403 (role gate or aspect
-    // MFA_VERIFIED check rejected). The aspect's PAL+AE writes
-    // committed regardless of the controller's downstream verdict
-    // (Decision 11).
+    // 400 (controller rejected the unknown job id) — both prove the
+    // request reached the controller. Each negative assertion pins a
+    // specific regression: 401 = security/JWT broken; 403 = role gate
+    // or MFA_VERIFIED missing; 404 = controller bean unloaded or route
+    // renamed (the loudest regression we want to catch); 5xx = aspect
+    // or persistence broken. The aspect's PAL+AE writes committed
+    // regardless of the controller's downstream 4xx (Decision 11).
     const status = resp.status();
-    expect(
-      status >= 200 && status < 500,
-      `Expected request to reach BatchJobController.run, got ${status}. ` +
-        `401 = security/JWT broken; 403 = role gate or MFA_VERIFIED missing; ` +
-        `5xx = aspect / persistence broken.`
-    ).toBeTruthy();
     expect(status, 'must NOT be 401 — security must accept platform JWT')
       .not.toBe(401);
     expect(status, 'must NOT be 403 — role gate / MFA_VERIFIED must pass')
       .not.toBe(403);
+    expect(status, 'must NOT be 404 — BatchJobController.run route must be registered')
+      .not.toBe(404);
+    expect(status, 'must NOT be 5xx — aspect / persistence must commit cleanly')
+      .toBeLessThan(500);
   });
 
   test('missing justification header → 400 (filter rejects)', async ({ request }) => {
@@ -154,6 +153,16 @@ test.describe('Platform admin access log — end-to-end pipeline (G-4.4 §5.12)'
       `Tenant cocadmin login failed status=${tenantLoginResp.status()}`
     ).toBeTruthy();
     const tenantBody = await tenantLoginResp.json();
+    // Guard: if a prior dev session enabled TOTP on cocadmin, /auth/login
+    // returns {mfaRequired: true, mfaToken} instead of {accessToken}. The
+    // seed forces totp_enabled=false on cocadmin (seed-data.sql line ~75);
+    // if you see this assertion fail, re-seed: ./dev-start.sh --fresh OR
+    // psql -f infra/scripts/seed-data.sql.
+    expect(
+      tenantBody.mfaRequired,
+      'cocadmin must NOT have TOTP enabled — re-seed via ./dev-start.sh --fresh '
+        + 'or psql -f infra/scripts/seed-data.sql'
+    ).toBeFalsy();
     const tenantToken: string = tenantBody.accessToken;
     expect(tenantToken, '/auth/login response missing accessToken').toBeTruthy();
 

--- a/e2e/playwright/tests/platform-admin-access-log.spec.ts
+++ b/e2e/playwright/tests/platform-admin-access-log.spec.ts
@@ -1,0 +1,176 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginPlatformOperator,
+  platformAdminFetch,
+  PlatformOperatorSession,
+} from '../helpers/auth/platform-operator';
+
+/**
+ * Phase G-4.4 §5.12 — pin the END-TO-END contract that an authenticated
+ * platform-operator request flowing through real Spring Security + the
+ * JustificationValidationFilter + the `@PlatformAdminOnly` aspect
+ * reaches the controller and returns a sane HTTP response. Covers the
+ * stack the IT layer (`PlatformAdminAccessAspectTest`, 10 tests) cannot
+ * exercise: the actual servlet filter chain, JWT-iss-routed dispatch,
+ * MFA_VERIFIED authority binding, and method-level @PreAuthorize.
+ *
+ * <p>Trigger: `BatchJobController.run` (the G-4.3 canary endpoint). Job
+ * id is intentionally bogus so the controller's own logic 400s — the
+ * aspect commits PAL+AE rows BEFORE proceed() runs (Decision 11), so
+ * the audit pair is written even on the controller's 400. The spec
+ * doesn't read those rows back (covered by IT); it pins the HTTP
+ * pipeline shape only.
+ *
+ * <p><b>Out of scope</b> (covered by `PlatformAdminAccessAspectTest`):
+ * row-content correctness, before_state / after_state snapshots,
+ * request_body_excerpt redaction, audit_event chain hash, F13's
+ * after_state-always-NULL limitation. This spec runs through the real
+ * HTTP stack; the IT layer runs in-process and validates contents.
+ *
+ * <p><b>Failure-mode locations:</b>
+ * <ul>
+ *   <li>Seed not run → `loginPlatformOperator()` throws on /login 401.
+ *       Caught by the platform-operator-smoke spec first.</li>
+ *   <li>Filter ordering regression → unauthenticated probe returns 400
+ *       instead of expected 401. Caught by the
+ *       `unauthenticatedWithoutJustificationRejectedAtSecurity` IT,
+ *       not this spec.</li>
+ *   <li>JWT-iss-routed dispatch broken → /batch returns 401 even with
+ *       a valid platform JWT. Caught here.</li>
+ * </ul>
+ */
+test.describe('Platform admin access log — end-to-end pipeline (G-4.4 §5.12)', () => {
+  let session: PlatformOperatorSession;
+
+  test.beforeAll(async ({ request }) => {
+    session = await loginPlatformOperator(request);
+  });
+
+  test('happy path: platform-operator + valid justification reaches BatchJobController.run', async ({
+    request,
+  }) => {
+    const resp = await platformAdminFetch(
+      request,
+      session,
+      'POST',
+      '/api/v1/batch/jobs/nonexistent-canary-job/run',
+      'Playwright G-4.4 §5.12 access-log pipeline pin'
+    );
+
+    // Either 200 (controller accepted, job runner silently no-op'd) or
+    // 4xx (controller rejected the unknown job id) — both prove the
+    // request reached the controller. Critically NOT 401 (security
+    // rejected before controller) and NOT 403 (role gate or aspect
+    // MFA_VERIFIED check rejected). The aspect's PAL+AE writes
+    // committed regardless of the controller's downstream verdict
+    // (Decision 11).
+    const status = resp.status();
+    expect(
+      status >= 200 && status < 500,
+      `Expected request to reach BatchJobController.run, got ${status}. ` +
+        `401 = security/JWT broken; 403 = role gate or MFA_VERIFIED missing; ` +
+        `5xx = aspect / persistence broken.`
+    ).toBeTruthy();
+    expect(status, 'must NOT be 401 — security must accept platform JWT')
+      .not.toBe(401);
+    expect(status, 'must NOT be 403 — role gate / MFA_VERIFIED must pass')
+      .not.toBe(403);
+  });
+
+  test('missing justification header → 400 (filter rejects)', async ({ request }) => {
+    // Bypass platformAdminFetch — we deliberately omit X-Platform-Justification
+    // to verify the filter's missing-header branch fires.
+    const resp = await request.post(
+      `${process.env.API_URL || 'http://localhost:8080'}/api/v1/batch/jobs/nonexistent-canary-job/run`,
+      {
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          'Content-Type': 'application/json',
+        },
+        data: {},
+      }
+    );
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toBe('missing_justification');
+  });
+
+  test('justification < 10 chars → 400 (filter rejects)', async ({ request }) => {
+    const resp = await request.post(
+      `${process.env.API_URL || 'http://localhost:8080'}/api/v1/batch/jobs/nonexistent-canary-job/run`,
+      {
+        headers: {
+          Authorization: `Bearer ${session.accessToken}`,
+          'X-Platform-Justification': 'short',
+          'Content-Type': 'application/json',
+        },
+        data: {},
+      }
+    );
+    expect(resp.status()).toBe(400);
+    const body = await resp.json();
+    expect(body.error).toBe('justification_too_short');
+  });
+
+  test('unauthenticated request → 401 (security URL rule rejects)', async ({ request }) => {
+    // Pin the post-Security filter ordering: anonymous POST gets 401
+    // even with a valid justification header. Mirrors the IT
+    // unauthenticatedWithJustificationRejectedAtSecurity probe but
+    // through the real servlet filter chain end-to-end.
+    const resp = await request.post(
+      `${process.env.API_URL || 'http://localhost:8080'}/api/v1/batch/jobs/nonexistent-canary-job/run`,
+      {
+        headers: {
+          'X-Platform-Justification': 'Playwright G-4.4 §5.12 anon probe',
+          'Content-Type': 'application/json',
+        },
+        data: {},
+      }
+    );
+    expect(
+      resp.status(),
+      'Anonymous probe must hit Spring Security URL rule (401), NOT filter (400)'
+    ).toBe(401);
+  });
+
+  test('tenant JWT (cocadmin) → 403 (URL rule role gate rejects)', async ({ request }) => {
+    // Mint a fresh COC_ADMIN tenant JWT via the regular /api/v1/auth/login
+    // endpoint — self-contained, no dependency on prior fixture state.
+    // The tenant JWT carries iss=fabt-tenant; URL rule /api/v1/batch/**
+    // for write methods admits only PLATFORM_OPERATOR / PLATFORM_ADMIN.
+    // COC_ADMIN's role array does NOT include either → 403 from Spring
+    // Security URL rule, BEFORE the JustificationValidationFilter or
+    // the @PlatformAdminOnly aspect even runs.
+    const apiUrl = process.env.API_URL || 'http://localhost:8080';
+    const tenantLoginResp = await request.post(`${apiUrl}/api/v1/auth/login`, {
+      data: {
+        tenantSlug: 'dev-coc',
+        email: 'cocadmin@dev.fabt.org',
+        password: 'admin123',
+      },
+    });
+    expect(
+      tenantLoginResp.ok(),
+      `Tenant cocadmin login failed status=${tenantLoginResp.status()}`
+    ).toBeTruthy();
+    const tenantBody = await tenantLoginResp.json();
+    const tenantToken: string = tenantBody.accessToken;
+    expect(tenantToken, '/auth/login response missing accessToken').toBeTruthy();
+
+    const resp = await request.post(
+      `${apiUrl}/api/v1/batch/jobs/nonexistent-canary-job/run`,
+      {
+        headers: {
+          Authorization: `Bearer ${tenantToken}`,
+          'X-Platform-Justification': 'Playwright G-4.4 §5.12 tenant-JWT probe',
+          'Content-Type': 'application/json',
+        },
+        data: {},
+      }
+    );
+    expect(
+      resp.status(),
+      'COC_ADMIN tenant JWT must NOT pass /api/v1/batch/** write URL rule'
+    ).toBe(403);
+  });
+});

--- a/e2e/playwright/tests/platform-operator-smoke.spec.ts
+++ b/e2e/playwright/tests/platform-operator-smoke.spec.ts
@@ -1,7 +1,8 @@
 import { test, expect } from '@playwright/test';
 import {
-  loginPlatformOperator,
-  PLATFORM_OPERATOR_EMAIL,
+  loginAsSmokeUser,
+  PLATFORM_SMOKE_USER_EMAIL,
+  PLATFORM_SMOKE_USER_ID,
 } from '../helpers/auth/platform-operator';
 import {
   generateTotp,
@@ -49,7 +50,11 @@ import {
  */
 test.describe('Platform-operator smoke (G-4.4 prereq)', () => {
   test('login + MFA verify returns access token (~2s)', async ({ request }) => {
-    const session = await loginPlatformOperator(request);
+    // Logs in as the dedicated smoke user (id 0fa1) — separate from the
+    // bootstrap row used by the access-log spec, so the two specs can
+    // run in the same Playwright invocation without colliding on V88's
+    // 89s TOTP replay protection.
+    const session = await loginAsSmokeUser(request);
 
     // Token shape — JWT has 3 base64url segments separated by '.'
     expect(session.accessToken).toBeTruthy();
@@ -59,9 +64,9 @@ test.describe('Platform-operator smoke (G-4.4 prereq)', () => {
     expect(parts[1].length).toBeGreaterThan(0);
     expect(parts[2].length).toBeGreaterThan(0);
 
-    // Bootstrap row id pin — if this changes, the seed UPDATE block
+    // Smoke-user row id pin — if this changes, the seed INSERT block
     // shifted off the well-known UUID.
-    expect(session.platformUserId).toBe('00000000-0000-0000-0000-000000000fab');
+    expect(session.platformUserId).toBe(PLATFORM_SMOKE_USER_ID);
 
     // TOTP secret round-trip pin — the helper-side constant must match
     // the seed-side value. If either drifts, login would have failed
@@ -77,12 +82,12 @@ test.describe('Platform-operator smoke (G-4.4 prereq)', () => {
     expect(code).toMatch(/^\d{6}$/);
   });
 
-  test('platform operator email matches the seeded value', () => {
+  test('smoke user email matches the seeded value', () => {
     // Pin the seed contract — if the email constant in seed-data.sql
     // changes without updating the TS helper, login would 401 with
     // invalid_credentials. This isolates the diagnosis to "the seed
     // and the helper are out of sync" rather than "the password is
-    // wrong" or "the bootstrap row was deleted."
-    expect(PLATFORM_OPERATOR_EMAIL).toBe('platform-ops@dev.fabt.org');
+    // wrong" or "the smoke row was deleted."
+    expect(PLATFORM_SMOKE_USER_EMAIL).toBe('platform-smoke@dev.fabt.org');
   });
 });

--- a/e2e/playwright/tests/platform-operator-smoke.spec.ts
+++ b/e2e/playwright/tests/platform-operator-smoke.spec.ts
@@ -1,0 +1,88 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginPlatformOperator,
+  PLATFORM_OPERATOR_EMAIL,
+} from '../helpers/auth/platform-operator';
+import {
+  generateTotp,
+  PLATFORM_BOOTSTRAP_TOTP_SECRET,
+} from '../helpers/auth/totp-helper';
+
+/**
+ * Phase G-4.4 §5.13 prereq (warroom Pre-spec 7 Jordan MEDIUM) — smoke
+ * spec that runs FIRST and fails LOUD if the platform-operator login
+ * pipeline regresses. Three things this spec pins:
+ *
+ * <ol>
+ *   <li><b>Seed activation.</b> {@code seed-data.sql} populates the
+ *       bootstrap {@code platform_user} row (id 0fab) with the
+ *       deterministic email + bcrypt(admin123) + RFC 4648 §10 TOTP
+ *       secret. If the seed regresses (e.g. someone removes the
+ *       activation block, or deploys without running seed-data.sql
+ *       on a fresh DB), step 1's {@code POST /login} returns 401
+ *       invalid_credentials.</li>
+ *
+ *   <li><b>TOTP correctness.</b> The TS-side {@link generateTotp}
+ *       implementation must agree with the server's HMAC-SHA1 RFC 6238
+ *       computation on the seeded secret. If either side drifts
+ *       (algorithm change, base32 decoder bug, time-window mismatch),
+ *       step 2's {@code /login/mfa-verify} returns 401 invalid_mfa_code.</li>
+ *
+ *   <li><b>Bucket4j off in dev.</b> {@code application-lite.yml} disables
+ *       the {@code rate-limit-platform-login} bucket. If a future config
+ *       change re-enables it (or a CI env activates a non-lite profile),
+ *       spec runs after the 5/15min cap will return 429 instead of 200.</li>
+ * </ol>
+ *
+ * <p><b>Why this matters.</b> Both downstream specs
+ * ({@code platform-admin-access-log.spec.ts} and
+ * {@code platform-totp-lockout.spec.ts}) call {@link loginPlatformOperator}
+ * in their {@code beforeEach}. A regression in any of the three pinned
+ * pieces would cascade into N test failures with the same root cause
+ * but distinct surface symptoms. This smoke spec is the single canary
+ * — runs in ~2 seconds, points at the actual broken layer.
+ *
+ * <p><b>Ordering.</b> Filename starts with "platform-operator-smoke" so
+ * Playwright's default alphabetical project file ordering puts it
+ * BEFORE both downstream specs (which start with "platform-admin-..."
+ * and "platform-totp-..."). No special config required.
+ */
+test.describe('Platform-operator smoke (G-4.4 prereq)', () => {
+  test('login + MFA verify returns access token (~2s)', async ({ request }) => {
+    const session = await loginPlatformOperator(request);
+
+    // Token shape — JWT has 3 base64url segments separated by '.'
+    expect(session.accessToken).toBeTruthy();
+    const parts = session.accessToken.split('.');
+    expect(parts).toHaveLength(3);
+    expect(parts[0].length).toBeGreaterThan(0);
+    expect(parts[1].length).toBeGreaterThan(0);
+    expect(parts[2].length).toBeGreaterThan(0);
+
+    // Bootstrap row id pin — if this changes, the seed UPDATE block
+    // shifted off the well-known UUID.
+    expect(session.platformUserId).toBe('00000000-0000-0000-0000-000000000fab');
+
+    // TOTP secret round-trip pin — the helper-side constant must match
+    // the seed-side value. If either drifts, login would have failed
+    // above; this assertion is belt-and-suspenders.
+    expect(session.mfaSecret).toBe(PLATFORM_BOOTSTRAP_TOTP_SECRET);
+  });
+
+  test('seeded TOTP secret produces a 6-digit numeric code', async () => {
+    // Pure-TS check — does not hit the backend. Fails fast if the
+    // generateTotp implementation regresses (e.g. base32 decoder bug,
+    // HMAC byte-order mistake) before any backend round-trip.
+    const code = generateTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET);
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  test('platform operator email matches the seeded value', () => {
+    // Pin the seed contract — if the email constant in seed-data.sql
+    // changes without updating the TS helper, login would 401 with
+    // invalid_credentials. This isolates the diagnosis to "the seed
+    // and the helper are out of sync" rather than "the password is
+    // wrong" or "the bootstrap row was deleted."
+    expect(PLATFORM_OPERATOR_EMAIL).toBe('platform-ops@dev.fabt.org');
+  });
+});

--- a/e2e/playwright/tests/platform-totp-lockout.spec.ts
+++ b/e2e/playwright/tests/platform-totp-lockout.spec.ts
@@ -1,0 +1,198 @@
+import { test, expect } from '@playwright/test';
+import {
+  loginLockoutTarget,
+  PLATFORM_LOCKOUT_TARGET_EMAIL,
+  PLATFORM_LOCKOUT_TARGET_PASSWORD,
+  PLATFORM_LOCKOUT_TARGET_USER_ID,
+} from '../helpers/auth/platform-operator';
+import {
+  generateFutureWrongTotp,
+  generateTotp,
+  PLATFORM_BOOTSTRAP_TOTP_SECRET,
+} from '../helpers/auth/totp-helper';
+
+/**
+ * Phase G-4.4 §5.13 — pin the END-TO-END contract that 5 wrong TOTP
+ * verifications lock a `platform_user`, that a 6th attempt with the
+ * CORRECT code is still rejected (lockout supersedes valid TOTP), and
+ * that the test-only unlock endpoint clears the lockout for subsequent
+ * runs.
+ *
+ * <p><b>Isolation strategy.</b> This spec deliberately exhausts the
+ * per-account 5-fail counter and locks the target row. To stay
+ * parallel-safe with the access-log spec (which targets the bootstrap
+ * row at id `0fab`), this spec targets a SECOND seeded platform_user
+ * at id `0fa2` (`platform-lockout@dev.fabt.org`). Both rows are
+ * provisioned by `infra/scripts/seed-data.sql`; they share password +
+ * TOTP secret but their lockout counters are independent. F17 tracks
+ * full N-way isolation via per-call UUIDs as a G-4.5 follow-up.
+ *
+ * <p><b>Wrong-code strategy.</b> Each attempt mints a code at
+ * counter+10..14 windows (5..7 minutes in the future), well past the
+ * server's ±1 acceptance band. Zero collision probability with the
+ * current valid window — see {@link generateFutureWrongTotp} docstring.
+ *
+ * <p><b>Cleanup.</b> The {@code afterAll} hook calls the dev-profile-
+ * gated `POST /api/v1/test/platform/unlock-expired?windowMin=0` to
+ * clear the lockout immediately, even though the lockout-target row
+ * is isolated from the bootstrap. Required for re-runs (CI retries +
+ * local iteration) so the spec's first attempt of a fresh run starts
+ * with `account_locked = false`.
+ *
+ * <p><b>Out of scope</b> (covered elsewhere):
+ * <ul>
+ *   <li>Per-IP password-attempt throttling on `/login` — Bucket4j
+ *       layer; tested by `PlatformAuthIntegrationTest`.</li>
+ *   <li>The `PLATFORM_USER_LOCKED_OUT` audit_event row content —
+ *       covered by `PlatformAuthServiceTest` IT.</li>
+ *   <li>Backup-code-based recovery flow — separate slice; not in
+ *       v0.53 scope.</li>
+ * </ul>
+ */
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
+  const apiUrl = process.env.API_URL || 'http://localhost:8080';
+
+  test.afterAll(async ({ request }) => {
+    // Cleanup: unlock any rows the spec's wrong-code attempts may have
+    // locked, including the lockout-target row. windowMin=0 means
+    // "unlock everything currently locked, regardless of how recently."
+    // Idempotent — if no rows are locked, returns {"unlocked": 0}.
+    const resp = await request.post(
+      `${apiUrl}/api/v1/test/platform/unlock-expired?windowMin=0`
+    );
+    if (!resp.ok()) {
+      // eslint-disable-next-line no-console
+      console.error(
+        `lockout afterAll: unlock-expired failed status=${resp.status()} ` +
+          `body=${await resp.text()} — next run starts polluted`
+      );
+    }
+    expect(
+      resp.ok(),
+      `Unlock-expired cleanup failed status=${resp.status()} — next ` +
+        `lockout-spec run will see account_locked=true`
+    ).toBeTruthy();
+  });
+
+  test('happy path baseline: lockout-target user can log in before the test', async ({
+    request,
+  }) => {
+    // Sanity: confirm the target row is unlocked + credentials are
+    // correct before we start exhausting attempts. If this fails, the
+    // afterAll cleanup from a prior run did not execute, OR the seed
+    // did not run, OR the lockout-target row was deleted. Diagnostic
+    // ordering matters: this test fails BEFORE the wrong-code attempts
+    // pollute state further.
+    const session = await loginLockoutTarget(request);
+    expect(session.platformUserId).toBe(PLATFORM_LOCKOUT_TARGET_USER_ID);
+  });
+
+  test('5 wrong TOTP codes lock the account', async ({ request }) => {
+    // Acquire 5 fresh mfa-verify-scoped tokens (one per attempt, since
+    // each /login resets the verify token to a new value) and submit a
+    // distinct future-window wrong code with each. After the 5th
+    // failed verify, the account_locked counter trips to true.
+    for (let i = 0; i < 5; i++) {
+      // Step 1 — login to get the verify-scoped token.
+      const loginResp = await request.post(
+        `${apiUrl}/api/v1/auth/platform/login`,
+        {
+          data: {
+            email: PLATFORM_LOCKOUT_TARGET_EMAIL,
+            password: PLATFORM_LOCKOUT_TARGET_PASSWORD,
+          },
+        }
+      );
+      expect(
+        loginResp.ok(),
+        `Wrong-code attempt ${i + 1}: /login should still succeed (account ` +
+          `not yet locked, password correct). Got status=${loginResp.status()}.`
+      ).toBeTruthy();
+      const verifyToken = (await loginResp.json()).token;
+
+      // Step 2 — submit a future-window wrong code (counter+10+i).
+      const wrongCode = generateFutureWrongTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET, i);
+      const verifyResp = await request.post(
+        `${apiUrl}/api/v1/auth/platform/login/mfa-verify`,
+        {
+          headers: { Authorization: `Bearer ${verifyToken}` },
+          data: { code: wrongCode },
+        }
+      );
+      expect(
+        verifyResp.status(),
+        `Wrong-code attempt ${i + 1} must be rejected (401 invalid_mfa_code).`
+      ).toBe(401);
+    }
+  });
+
+  test('after 5 wrong codes, even a CORRECT code is rejected', async ({ request }) => {
+    // Account should now be locked. Validate the contract: a 6th
+    // login attempt either (a) returns 401 from /login itself
+    // (account-locked path on the password check), OR (b) succeeds
+    // at /login but rejects /login/mfa-verify even with a fresh,
+    // valid TOTP code. Either is acceptable — both prove that
+    // lockout supersedes valid credentials. The exact branch depends
+    // on whether PlatformAuthService.login returns REJECTED on locked
+    // accounts before issuing the verify-scoped token (current impl
+    // does — V88 lockout state checked in login()).
+    const loginResp = await request.post(
+      `${apiUrl}/api/v1/auth/platform/login`,
+      {
+        data: {
+          email: PLATFORM_LOCKOUT_TARGET_EMAIL,
+          password: PLATFORM_LOCKOUT_TARGET_PASSWORD,
+        },
+      }
+    );
+
+    if (loginResp.status() === 401) {
+      // Locked-on-/login path — no verify-scoped token issued. Done.
+      const body = await loginResp.json();
+      expect(body.error, 'expected invalid_credentials per Decision 5')
+        .toBe('invalid_credentials');
+      return;
+    }
+
+    // Locked-on-/verify path — login returns a verify token but
+    // verify rejects even with a fresh valid code.
+    expect(loginResp.ok(), 'login should issue verify token or 401').toBeTruthy();
+    const verifyToken = (await loginResp.json()).token;
+    const correctCode = generateTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET);
+    const verifyResp = await request.post(
+      `${apiUrl}/api/v1/auth/platform/login/mfa-verify`,
+      {
+        headers: { Authorization: `Bearer ${verifyToken}` },
+        data: { code: correctCode },
+      }
+    );
+    expect(
+      verifyResp.status(),
+      'CORRECT code must still be rejected when account is locked'
+    ).toBe(401);
+  });
+
+  test('test-only unlock-expired endpoint clears the lockout', async ({ request }) => {
+    // Pin the cleanup contract: the dev-profile-gated unlock endpoint
+    // actually unlocks rows. If this regresses (e.g. profile gate
+    // accidentally widened or removed, endpoint route changes), the
+    // afterAll hook of every future run silently no-ops and the next
+    // run inherits a locked row.
+    const resp = await request.post(
+      `${apiUrl}/api/v1/test/platform/unlock-expired?windowMin=0`
+    );
+    expect(resp.ok(), `unlock-expired status=${resp.status()}`).toBeTruthy();
+    const body = await resp.json();
+    expect(typeof body.unlocked).toBe('number');
+    expect(
+      body.unlocked,
+      'expected at least the lockout-target row (id 0fa2) to be unlocked'
+    ).toBeGreaterThanOrEqual(1);
+
+    // Confirm the row is actually unlocked by re-attempting login.
+    const session = await loginLockoutTarget(request);
+    expect(session.platformUserId).toBe(PLATFORM_LOCKOUT_TARGET_USER_ID);
+  });
+});

--- a/e2e/playwright/tests/platform-totp-lockout.spec.ts
+++ b/e2e/playwright/tests/platform-totp-lockout.spec.ts
@@ -1,6 +1,6 @@
 import { test, expect } from '@playwright/test';
 import {
-  loginLockoutTarget,
+  loginAsLockoutTestUser,
   PLATFORM_LOCKOUT_TARGET_EMAIL,
   PLATFORM_LOCKOUT_TARGET_PASSWORD,
   PLATFORM_LOCKOUT_TARGET_USER_ID,
@@ -74,6 +74,24 @@ test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
       `Unlock-expired cleanup failed status=${resp.status()} — next ` +
         `lockout-spec run will see account_locked=true`
     ).toBeTruthy();
+    // Diagnostic-only: surface zero-count silently-failing unlock. We don't
+    // FAIL on zero (a passing prior run + clean re-run is a legit zero), but
+    // a zero count after a run that should have locked a row hints at a
+    // cleanup-contract regression. Logged as a warning for the operator
+    // reviewing CI output.
+    try {
+      const body = await resp.json();
+      if (typeof body.unlocked === 'number' && body.unlocked === 0) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          'lockout afterAll: unlock-expired returned {unlocked: 0}. If the ' +
+            'spec actually locked a row this run, the SECURITY DEFINER '
+            + 'function may have a windowMin comparison bug. Diagnostic only.'
+        );
+      }
+    } catch {
+      // Body parse error — ignore; afterAll already asserted resp.ok().
+    }
   });
 
   test('happy path baseline: lockout-target user can log in before the test', async ({
@@ -85,7 +103,7 @@ test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
     // did not run, OR the lockout-target row was deleted. Diagnostic
     // ordering matters: this test fails BEFORE the wrong-code attempts
     // pollute state further.
-    const session = await loginLockoutTarget(request);
+    const session = await loginAsLockoutTestUser(request);
     expect(session.platformUserId).toBe(PLATFORM_LOCKOUT_TARGET_USER_ID);
   });
 
@@ -149,10 +167,52 @@ test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
     );
 
     if (loginResp.status() === 401) {
-      // Locked-on-/login path — no verify-scoped token issued. Done.
+      // Locked-on-/login path — no verify-scoped token issued.
       const body = await loginResp.json();
       expect(body.error, 'expected invalid_credentials per Decision 5')
         .toBe('invalid_credentials');
+      // Positive proof the row is actually locked (vs e.g. anonymized,
+      // disabled, or hit by a /login service-layer regression that 401s
+      // for unrelated reasons). The cleanup endpoint reports how many
+      // rows it unlocked; if the count is zero, the prior 5-attempt
+      // test failed to lock anything and this test passed for the
+      // wrong reason.
+      const unlockResp = await request.post(
+        `${apiUrl}/api/v1/test/platform/unlock-expired?windowMin=0`
+      );
+      expect(unlockResp.ok(),
+        `unlock-expired probe failed status=${unlockResp.status()}`).toBeTruthy();
+      const unlockBody = await unlockResp.json();
+      expect(
+        unlockBody.unlocked,
+        'expected unlock-expired to unlock at least the lockout-target row '
+          + '— if zero, the 5-wrong-codes test did not actually lock anything '
+          + 'and this 6th-attempt 401 came from a different code path'
+      ).toBeGreaterThanOrEqual(1);
+      // We just unlocked the row to prove it was locked. Re-lock it with
+      // 5 more wrong attempts so the afterAll cleanup is still operating
+      // on a locked row (preserves test 4's pre-condition without making
+      // it temporally coupled).
+      for (let i = 0; i < 5; i++) {
+        const reLockLogin = await request.post(
+          `${apiUrl}/api/v1/auth/platform/login`,
+          {
+            data: {
+              email: PLATFORM_LOCKOUT_TARGET_EMAIL,
+              password: PLATFORM_LOCKOUT_TARGET_PASSWORD,
+            },
+          }
+        );
+        if (!reLockLogin.ok()) break;
+        const verifyToken = (await reLockLogin.json()).token;
+        await request.post(
+          `${apiUrl}/api/v1/auth/platform/login/mfa-verify`,
+          {
+            headers: { Authorization: `Bearer ${verifyToken}` },
+            data: { code: generateFutureWrongTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET, 5 + i) },
+          }
+        );
+      }
       return;
     }
 
@@ -174,12 +234,39 @@ test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
     ).toBe(401);
   });
 
-  test('test-only unlock-expired endpoint clears the lockout', async ({ request }) => {
-    // Pin the cleanup contract: the dev-profile-gated unlock endpoint
-    // actually unlocks rows. If this regresses (e.g. profile gate
-    // accidentally widened or removed, endpoint route changes), the
-    // afterAll hook of every future run silently no-ops and the next
-    // run inherits a locked row.
+  test('test-only unlock-expired endpoint clears the lockout (self-contained)', async ({ request }) => {
+    // Pin the cleanup contract independent of the prior tests' state.
+    // Sequence: clear any inherited state → lock the target → unlock →
+    // verify unlocked. This makes the test's pre-condition self-owned,
+    // so a regression in tests 2 or 3 doesn't muddy the diagnostic.
+
+    // Step A — start clean. Idempotent unlock; if previous tests didn't
+    // actually lock anything (regression), this is a no-op.
+    await request.post(`${apiUrl}/api/v1/test/platform/unlock-expired?windowMin=0`);
+
+    // Step B — lock the target with 5 fresh wrong attempts.
+    for (let i = 0; i < 5; i++) {
+      const loginResp = await request.post(
+        `${apiUrl}/api/v1/auth/platform/login`,
+        {
+          data: {
+            email: PLATFORM_LOCKOUT_TARGET_EMAIL,
+            password: PLATFORM_LOCKOUT_TARGET_PASSWORD,
+          },
+        }
+      );
+      if (!loginResp.ok()) break;  // already locked from a prior /login probe
+      const verifyToken = (await loginResp.json()).token;
+      await request.post(
+        `${apiUrl}/api/v1/auth/platform/login/mfa-verify`,
+        {
+          headers: { Authorization: `Bearer ${verifyToken}` },
+          data: { code: generateFutureWrongTotp(PLATFORM_BOOTSTRAP_TOTP_SECRET, 20 + i) },
+        }
+      );
+    }
+
+    // Step C — invoke the unlock contract under test.
     const resp = await request.post(
       `${apiUrl}/api/v1/test/platform/unlock-expired?windowMin=0`
     );
@@ -188,11 +275,13 @@ test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
     expect(typeof body.unlocked).toBe('number');
     expect(
       body.unlocked,
-      'expected at least the lockout-target row (id 0fa2) to be unlocked'
+      'expected at least the lockout-target row (id 0fa2) to be unlocked '
+        + 'by Step C — if zero, Step B did not lock anything OR the unlock '
+        + 'function has a windowMin=0 boundary bug'
     ).toBeGreaterThanOrEqual(1);
 
-    // Confirm the row is actually unlocked by re-attempting login.
-    const session = await loginLockoutTarget(request);
+    // Step D — confirm the row is actually unlocked by re-attempting login.
+    const session = await loginAsLockoutTestUser(request);
     expect(session.platformUserId).toBe(PLATFORM_LOCKOUT_TARGET_USER_ID);
   });
 });

--- a/e2e/playwright/tests/platform-totp-lockout.spec.ts
+++ b/e2e/playwright/tests/platform-totp-lockout.spec.ts
@@ -266,7 +266,18 @@ test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
       );
     }
 
-    // Step C — invoke the unlock contract under test.
+    // Step C — invoke the unlock contract under test. The `unlocked >= 1`
+    // count IS the proof: the function reports how many rows it unlocked,
+    // so a non-zero count for a single-row spec means the lockout-target
+    // row went from `account_locked=true` to `account_locked=false` in
+    // the same UPDATE statement. We deliberately do NOT do a re-login
+    // here as a "second proof" — V88's TOTP replay protection
+    // (last_totp_code, 89s window) would reject a second successful
+    // login from the same TOTP window as test 1's sanity baseline,
+    // producing a 401 invalid_mfa_code that masks an unrelated layer.
+    // If you need a stronger proof in the future, query account_locked
+    // via a test-only DB readback endpoint rather than re-driving the
+    // login flow.
     const resp = await request.post(
       `${apiUrl}/api/v1/test/platform/unlock-expired?windowMin=0`
     );
@@ -279,9 +290,5 @@ test.describe('Platform TOTP lockout — end-to-end (G-4.4 §5.13)', () => {
         + 'by Step C — if zero, Step B did not lock anything OR the unlock '
         + 'function has a windowMin=0 boundary bug'
     ).toBeGreaterThanOrEqual(1);
-
-    // Step D — confirm the row is actually unlocked by re-attempting login.
-    const session = await loginAsLockoutTestUser(request);
-    expect(session.platformUserId).toBe(PLATFORM_LOCKOUT_TARGET_USER_ID);
   });
 });

--- a/infra/scripts/seed-data.sql
+++ b/infra/scripts/seed-data.sql
@@ -808,3 +808,34 @@ SET email          = 'platform-ops@dev.fabt.org',
     mfa_enabled    = true,
     account_locked = false
 WHERE id = '00000000-0000-0000-0000-000000000fab';
+
+-- ============================================================================
+-- PHASE G-4.4 §5.13: Lockout-target platform_user (parallel-safe Spec 2 isolation)
+-- ============================================================================
+--
+-- The platform-totp-lockout.spec.ts deliberately exhausts the per-account
+-- TOTP-failure counter and locks its target row. If that target were the
+-- bootstrap row above (0fab), the lockout spec running concurrent with the
+-- platform-admin-access-log.spec.ts on a parallel CI worker would lock the
+-- shared row and fail every concurrent loginPlatformOperator() call.
+--
+-- Solution: a SECOND seeded platform_user at id 0fa2, dedicated to the
+-- lockout spec. Independent lockout counter + identical credentials means
+-- both specs can run in parallel without colliding on shared state.
+-- F17 (per-call UUIDs for full N-way isolation) remains deferred to G-4.5;
+-- this two-row approach handles v0.53's test surface.
+INSERT INTO platform_user (id, email, password_hash, mfa_secret, mfa_enabled, account_locked, created_at)
+VALUES (
+    '00000000-0000-0000-0000-000000000fa2',
+    'platform-lockout@dev.fabt.org',
+    '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+    'JBSWY3DPEHPK3PXP',
+    true,
+    false,
+    NOW()
+) ON CONFLICT (id) DO UPDATE SET
+    email          = EXCLUDED.email,
+    password_hash  = EXCLUDED.password_hash,
+    mfa_secret     = EXCLUDED.mfa_secret,
+    mfa_enabled    = EXCLUDED.mfa_enabled,
+    account_locked = EXCLUDED.account_locked;

--- a/infra/scripts/seed-data.sql
+++ b/infra/scripts/seed-data.sql
@@ -13,6 +13,10 @@ VALUES (
 
 -- Admin user (dvAccess=true, password: admin123)
 -- BCrypt hash of 'admin123'
+-- G-4.4: roles array includes both PLATFORM_ADMIN and COC_ADMIN to mirror the
+-- V87 backfill on existing app_users. Without COC_ADMIN, fresh dev databases
+-- would have admin@dev unable to hit /api/v1/users/** etc. (G-4.4 stripped
+-- PLATFORM_ADMIN from the URL rules per V87 backfill posture).
 INSERT INTO app_user (id, tenant_id, email, password_hash, display_name, roles, dv_access, created_at, updated_at)
 VALUES (
     'b0000000-0000-0000-0000-000000000001',
@@ -20,7 +24,7 @@ VALUES (
     'admin@dev.fabt.org',
     '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
     'Dev Admin',
-    ARRAY['PLATFORM_ADMIN'],
+    ARRAY['PLATFORM_ADMIN', 'COC_ADMIN'],
     true,
     NOW(), NOW()
 ) ON CONFLICT (tenant_id, email) DO UPDATE SET
@@ -544,9 +548,10 @@ VALUES (
 -- Blue Ridge users — 6-role matrix mirroring dev-coc (all passwords: admin123)
 INSERT INTO app_user (id, tenant_id, email, password_hash, display_name, roles, dv_access, created_at, updated_at)
 VALUES
+    -- G-4.4: roles include COC_ADMIN to mirror V87 backfill (fresh dev DB)
     ('b0000001-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000002',
      'admin@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
-     'Blue Ridge Admin', ARRAY['PLATFORM_ADMIN'], true, NOW(), NOW()),
+     'Blue Ridge Admin', ARRAY['PLATFORM_ADMIN', 'COC_ADMIN'], true, NOW(), NOW()),
     ('b0000001-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000002',
      'cocadmin@blueridge.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
      'Blue Ridge CoC Admin', ARRAY['COC_ADMIN'], true, NOW(), NOW()),
@@ -623,9 +628,10 @@ VALUES (
 -- Pamlico Sound users — 6-role matrix (all passwords: admin123)
 INSERT INTO app_user (id, tenant_id, email, password_hash, display_name, roles, dv_access, created_at, updated_at)
 VALUES
+    -- G-4.4: roles include COC_ADMIN to mirror V87 backfill (fresh dev DB)
     ('b0000002-0000-0000-0000-000000000001', 'a0000000-0000-0000-0000-000000000003',
      'admin@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
-     'Pamlico Sound Admin', ARRAY['PLATFORM_ADMIN'], true, NOW(), NOW()),
+     'Pamlico Sound Admin', ARRAY['PLATFORM_ADMIN', 'COC_ADMIN'], true, NOW(), NOW()),
     ('b0000002-0000-0000-0000-000000000002', 'a0000000-0000-0000-0000-000000000003',
      'cocadmin@pamlico.fabt.org', '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
      'Pamlico Sound CoC Admin', ARRAY['COC_ADMIN'], true, NOW(), NOW()),
@@ -730,3 +736,34 @@ INSERT INTO coordinator_assignment (user_id, shelter_id) VALUES
     ('b0000002-0000-0000-0000-000000000003', 'd0000002-0000-0000-0000-000000000002'),  -- coord → Pamlico Example
     ('b0000002-0000-0000-0000-000000000005', 'd0000002-0000-0000-0000-000000000003')   -- dv-coord → DV East
 ON CONFLICT DO NOTHING;
+
+-- ============================================================================
+-- PHASE G-4.4: Activate the bootstrap platform_user for dev/Playwright
+-- ============================================================================
+--
+-- The V87 migration inserts a LOCKED bootstrap row at id 0fab with NO email
+-- and NO credentials. Production operators activate it via the fabt-cli
+-- hash-password tool + manual UPDATE. For local dev + the Playwright
+-- platformOperatorPage fixture, we activate it here with deterministic
+-- credentials so tests can mint a platform JWT without per-run TOTP enrollment.
+--
+-- Credentials (LOCAL DEV ONLY — these are publicly visible in this seed
+-- script and the Playwright auth helper):
+--   id:            00000000-0000-0000-0000-000000000fab
+--   email:         platform-ops@dev.fabt.org
+--   password:      admin123  (matches every other dev seed user — bcrypt hash same)
+--   mfa_secret:    JBSWY3DPEHPK3PXP  (RFC 4648 base32; standard MFA test secret)
+--   mfa_enabled:   true   (skips first-login forced enrollment)
+--   account_locked: false
+--
+-- NEVER run this seed against any environment other than dev/test. Production
+-- operators must use the fabt-cli hash-password tool + a real TOTP enrollment.
+-- The runtime guard for prod is the dev-start.sh wrapper + Spring profile
+-- gating; this script is invoked only from dev-start.sh and CI test setup.
+UPDATE platform_user
+SET email          = 'platform-ops@dev.fabt.org',
+    password_hash  = '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+    mfa_secret     = 'JBSWY3DPEHPK3PXP',
+    mfa_enabled    = true,
+    account_locked = false
+WHERE id = '00000000-0000-0000-0000-000000000fab';

--- a/infra/scripts/seed-data.sql
+++ b/infra/scripts/seed-data.sql
@@ -1,5 +1,46 @@
 -- Seed data for local development
 -- Run after Flyway migrations: psql -U fabt -d fabt -f seed-data.sql
+--
+-- Phase G-4.4 §5.13 prereq (warroom Pre-spec 3 Marcus HIGH): runtime guard.
+-- This script seeds dev-only credentials (password=admin123, well-known
+-- bcrypt hashes, the RFC 4648 §10 test TOTP secret JBSWY3DPEHPK3PXP for
+-- the bootstrap platform_user). Running it against any non-dev/test
+-- database would leak those credentials into a real environment. The
+-- guard below halts execution if the database name does NOT contain
+-- 'dev' or 'test'.
+--
+-- This belongs in the script itself rather than wrapper bash because
+-- (a) operators can invoke psql -f directly without going through
+-- dev-start.sh, and (b) the same script is reused by CI test fixtures
+-- via dockerized test databases — both contexts naming their DB
+-- 'fabt_dev' / 'fabt_test' / 'fabt'. Production DBs use 'fabt_prod'
+-- (or similar) and would trip the guard.
+--
+-- To seed against a custom-named dev DB (e.g. a contributor's local
+-- sandbox), rename it to include 'dev' or 'test', OR set the GUC
+-- override: PGOPTIONS='-c fabt.seed_force=1' psql -d <dbname> -f seed-data.sql
+\set ON_ERROR_STOP on
+DO $$
+DECLARE
+    db_name TEXT := current_database();
+    forced  TEXT := NULLIF(current_setting('fabt.seed_force', true), '');
+BEGIN
+    IF forced = '1' THEN
+        RAISE NOTICE 'seed-data.sql: fabt.seed_force=1 — bypassing dev/test name check on database "%"', db_name;
+        RETURN;
+    END IF;
+    IF lower(db_name) NOT LIKE '%dev%'
+       AND lower(db_name) NOT LIKE '%test%'
+       AND lower(db_name) <> 'fabt' THEN
+        RAISE EXCEPTION
+            'seed-data.sql REFUSES to run against database "%": name does not contain ''dev'' or ''test'' (and is not the dockerized dev default ''fabt''). '
+            'This script seeds dev-only credentials (admin123 password, RFC 4648 test TOTP secret JBSWY3DPEHPK3PXP) and '
+            'is intended ONLY for local dev or CI test fixtures. To override (NOT for production), set the GUC: '
+            'PGOPTIONS=''-c fabt.seed_force=1'' psql -d <dbname> -f seed-data.sql',
+            db_name;
+    END IF;
+END
+$$;
 
 -- Default tenant
 INSERT INTO tenant (id, name, slug, config, created_at, updated_at)

--- a/infra/scripts/seed-data.sql
+++ b/infra/scripts/seed-data.sql
@@ -810,6 +810,38 @@ SET email          = 'platform-ops@dev.fabt.org',
 WHERE id = '00000000-0000-0000-0000-000000000fab';
 
 -- ============================================================================
+-- PHASE G-4.4 §5.13: Smoke-spec platform_user (parallel-safe canary isolation)
+-- ============================================================================
+--
+-- The platform-operator-smoke.spec.ts canary does a real /login + /mfa-verify
+-- round-trip on every CI run. V88's TOTP replay protection (last_totp_code,
+-- 89s window) means a successful login "consumes" the current TOTP code for
+-- 89 seconds. If the smoke spec shared the bootstrap row (0fab) with the
+-- access-log spec's beforeAll login, the second login within the same 30s
+-- TOTP window would mint the same code and trip the replay rejection.
+--
+-- Solution: a dedicated platform_user at id 0fa1 for the smoke spec. The
+-- access-log spec keeps using the bootstrap row (single beforeAll login per
+-- run); the lockout spec uses 0fa2 (independent counter); the smoke spec
+-- uses 0fa1. Each spec has its own last_totp_code state. F17 (per-call
+-- UUIDs for full N-way isolation) remains deferred to G-4.5.
+INSERT INTO platform_user (id, email, password_hash, mfa_secret, mfa_enabled, account_locked, created_at)
+VALUES (
+    '00000000-0000-0000-0000-000000000fa1',
+    'platform-smoke@dev.fabt.org',
+    '$2b$10$D0ZKzFrhx0qdM0mQy9iZQeLYJPX8/eeEfrJi4TsO5D2o62Q/Fwhva',
+    'JBSWY3DPEHPK3PXP',
+    true,
+    false,
+    NOW()
+) ON CONFLICT (id) DO UPDATE SET
+    email          = EXCLUDED.email,
+    password_hash  = EXCLUDED.password_hash,
+    mfa_secret     = EXCLUDED.mfa_secret,
+    mfa_enabled    = EXCLUDED.mfa_enabled,
+    account_locked = EXCLUDED.account_locked;
+
+-- ============================================================================
 -- PHASE G-4.4 §5.13: Lockout-target platform_user (parallel-safe Spec 2 isolation)
 -- ============================================================================
 --


### PR DESCRIPTION
## Summary

Phase G-4 of the FABT v0.53 release — splits platform-admin authority from tenant-admin authority into a separate `platform_user` identity backed by its own JWT issuer, mandatory TOTP, and a per-action `platform_admin_access_log` audit table. The deprecated `PLATFORM_ADMIN` role is preserved for backwards-compatibility during the deprecation window; the V87 backfill grants `COC_ADMIN` to every existing `PLATFORM_ADMIN`-bearing app_user so existing operator accounts continue to work for tenant-scoped admin tasks.

13 commits across G-4.1 through G-4.4 close-out. Backend `1246/1246` mvn green; Playwright `387/387` chromium green via `dev-start.sh --nginx`; both runtime-verified at HEAD `381968f`.

## What changed

- **New schema (V87/V88/V89):** platform_user + lockout columns + platform_admin_access_log
- **New auth flow:** POST `/api/v1/auth/platform/login` + MFA-verify; iss=`fabt-platform` JWT; MFA_VERIFIED authority binding
- **New aspect:** `@PlatformAdminOnly` AOP wrapper — rejects without MFA_VERIFIED, requires `X-Platform-Justification` header (≥10 ASCII chars), commits PAL+AE rows BEFORE controller runs (Decision 11)
- **Endpoint migration:** ~30 controller methods migrated. See **[role-migration-table.md](https://github.com/ccradle/findABed/blob/main/openspec/changes/platform-admin-split-and-access-log/role-migration-table.md)** for the per-endpoint OLD→NEW + AuditEventType breakdown (M-S1 reviewer sign-off table)
- **F16 mitigation:** HMIS push reverted to COC_ADMIN with confirm-header gate + per-tenant `HMIS_EXPORT_TRIGGERED` audit_event row
- **3 new ArchUnit rules** prevent regression: no controller `@PreAuthorize` references PLATFORM_ADMIN; every Test*Controller is profile-gated; @PlatformAdminOnly always pairs with @PreAuthorize PLATFORM_OPERATOR
- **2 new E2E specs + 1 smoke** + a dedicated `platform_user` seed for each spec (parallel-safe across V88's TOTP replay protection)

## Reviewer required reading (sign-off endpoint-by-endpoint per M-S1)

→ **[openspec/changes/platform-admin-split-and-access-log/role-migration-table.md](https://github.com/ccradle/findABed/blob/main/openspec/changes/platform-admin-split-and-access-log/role-migration-table.md)**

That table is the M-S1 contract. ArchUnit catches "PLATFORM_ADMIN still appears" but not misclassification (wrong cohort, wrong AuditEventType, accidental role widening) — your endpoint-by-endpoint review closes that gap.

## Customer-facing changes (C-S1)

Verbatim text for the operator-of-record email in [oracle-update-notes-v0.53.0.md §3](finding-a-bed-tonight/docs/oracle-update-notes-v0.53.0.md). **Send ≥24h before deploy + read-receipt confirm before opening §4 deploy gates.** Highlights:
- Existing operator accounts continue to work (V87 backfill)
- Platform-wide actions move to `auth/platform/login` with mandatory TOTP
- HMIS push now requires `X-Confirm-HMIS-Push: CONFIRM` header + writes a tenant audit row
- F16 disclosure: COC_ADMIN-only operators (no historical PLATFORM_ADMIN) are now authorized to trigger HMIS pushes

## Deferred follow-ups (in design.md F1-F20)

- **F14** — Cross-tenant operator-driven HMIS push endpoint (post-v0.53)
- **F17** — Playwright fixture caching (G-4.5 CI runtime)
- **F18** — Prometheus alert on per-operator tenant-update rate (G-4.5)
- **F19** — Platform-operator observability config persistence IT (G-4.5)
- **F20** — Audit gaps on platform-scoped reads + cross-tenant batch metadata reads (deliberate v0.53 decision documented in design.md)

## Test plan

- [x] Backend full mvn test green at `381968f` (1246/1246) — `logs/g-4.4-mvn-test-post-f16.log` + targeted re-run `logs/g-4.4-post-warroom-fix.log` (146/146 affected classes)
- [x] Playwright full suite green via dev-start + nginx (387 passed, 35.9 min) — `logs/g-4.4-playwright-post-f16.log` with `--trace on`
- [x] 3 new specs runtime-verified: smoke (3/3), platform-admin-access-log (5/5), platform-totp-lockout (4/4)
- [x] Two warroom rounds passed: spec design (Phase 1+2 + Spec 1+2 code) + M-S1 role table + oracle-update-notes-v0.53.0
- [ ] Reviewer signs off on role-migration-table.md endpoint-by-endpoint
- [ ] Reviewer confirms CHANGELOG `[Unreleased]` entry covers the listed changes
- [ ] Reviewer confirms oracle-update-notes-v0.53.0.md matches deploy operator's mental model

## Deploy

Tag `v0.53.0` from main HEAD post-merge. Deploy runbook in [docs/oracle-update-notes-v0.53.0.md](finding-a-bed-tonight/docs/oracle-update-notes-v0.53.0.md):
- 5-file compose chain (same as v0.52, no new override)
- §5.10 NEW: bootstrap platform_user activation procedure for prod (V87 ships LOCKED; seed-data.sql refuses prod DB names; operator activates via fabt-cli + manual UPDATE + first-login MFA)
- Customer-comms ≥24h pre-deploy + read-receipt gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)