### PR TITLE
v0.55.1 followup: T1+T2+O1+D2+H2 (CI hygiene + HMIS contract test + i18n)

### DIFF
--- a/backend/src/test/java/org/fabt/hmis/HmisPushContractTest.java
+++ b/backend/src/test/java/org/fabt/hmis/HmisPushContractTest.java
@@ -1,0 +1,315 @@
+package org.fabt.hmis;
+
+import java.lang.reflect.RecordComponent;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.fabt.BaseIntegrationTest;
+import org.fabt.TestAuthHelper;
+import org.fabt.hmis.domain.HmisInventoryRecord;
+import org.fabt.hmis.service.HmisTransformer;
+import org.fabt.shared.web.TenantContext;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.jdbc.core.JdbcTemplate;
+
+import tools.jackson.databind.ObjectMapper;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * v0.55.1-O1: contract test asserting hold-attribution PII NEVER leaks into HMIS push payloads.
+ *
+ * <p>Doc claim ({@code hmisindex.html} post-§12 + AsyncAPI scope sentence per §3.1) says HMIS
+ * push carries no client PII. This test grounds that claim in code so a future projection-layer
+ * regression that adds an inappropriate JOIN or selects a PII column gets caught by CI rather
+ * than by an audit.
+ *
+ * <p>Per warroom B2 + Q4 (thorough form), the assertion is multi-layered:
+ *
+ * <ol>
+ *   <li><b>Schema-absent at projection record</b>: {@link HmisInventoryRecord} has no fields
+ *       matching hold-attribution PII patterns (verified via reflection on record components).</li>
+ *   <li><b>Schema-absent at outbox table</b>: {@code hmis_outbox} table has no PII columns
+ *       (verified via {@code information_schema.columns} query).</li>
+ *   <li><b>Serialized-payload absent</b>: with PII seeded on a reservation, the transformer's
+ *       output for that tenant — when serialized exactly as the push pipeline serializes it
+ *       (via {@link ObjectMapper#writeValueAsString}) — contains no trace of the seeded PII
+ *       values (substring search). Sanity-controlled by asserting the seeded reservation row
+ *       still has the encrypted PII (without that control, a silent seed failure would also
+ *       pass).</li>
+ *   <li><b>Both reentryMode states</b>: parameterized via {@code @ValueSource} to prove the
+ *       gate is unconditional regardless of tenant flag. Different forms across reentryMode
+ *       states would itself be a regression (the projection layer doesn't read the flag).</li>
+ * </ol>
+ *
+ * <p><b>Scope:</b> this test covers the canonical {@code hmis-push} projection layer
+ * ({@link HmisTransformer#buildInventory}). Tenant-specific custom adapters (per the
+ * {@code hmis-vendor-adapters} capability) are out of scope; if a tenant ever configures a
+ * custom adapter that touches the {@code reservation} table directly, that adapter gets its
+ * own contract test.
+ *
+ * <p>The thorough assertion shape (raw {@link JdbcTemplate} reads on the reservation sanity
+ * check + reflection on the record class + {@code information_schema} on the outbox table) is
+ * per v0.55.1 warroom B2: a single {@code assertThat(value).isNull()} would let a projection
+ * regression emitting empty strings or a renamed column slip through. This test doesn't go
+ * through any DTO that might {@code @JsonInclude(Include.NON_NULL)}-coerce nulls or hide
+ * present-but-blank values.
+ */
+class HmisPushContractTest extends BaseIntegrationTest {
+
+    @Autowired
+    private TestAuthHelper authHelper;
+
+    @Autowired
+    private JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    private HmisTransformer transformer;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    private HttpHeaders adminHeaders;
+    private HttpHeaders outreachHeaders;
+    private UUID tenantId;
+    private UUID shelterId;
+
+    /**
+     * Hold-attribution PII column names (pulled from V90 / `reservation` migration).
+     * Used by the schema-absence assertions to prove the projection table lacks them.
+     */
+    private static final List<String> PII_COLUMN_NAMES = List.of(
+            "held_for_client_name_encrypted",
+            "held_for_client_dob_encrypted",
+            "hold_notes_encrypted"
+    );
+
+    /**
+     * Lower-case substrings that PII-flavored field names would contain. Used by the
+     * record-component reflection assertion (catches any future field added to the
+     * projection record that carries PII semantics).
+     */
+    private static final List<String> PII_FIELD_NAME_PATTERNS = List.of(
+            "heldforclient",
+            "clientname",
+            "clientdob",
+            "holdnotes"
+    );
+
+    @BeforeEach
+    void setUp() {
+        authHelper.setupTestTenant();
+        authHelper.setupAdminUser();
+        authHelper.setupOutreachWorkerUser();
+
+        var dvAdmin = authHelper.setupUserWithDvAccess(
+                "dvadmin-hmis-contract@test.fabt.org", "DV Admin HMIS Contract",
+                new String[]{"PLATFORM_ADMIN", "COC_ADMIN"});
+        adminHeaders = authHelper.headersForUser(dvAdmin);
+        outreachHeaders = authHelper.outreachWorkerHeaders();
+
+        tenantId = authHelper.getTestTenantId();
+        TenantContext.runWithContext(tenantId, true, () -> {
+            shelterId = createNonDvShelter("HMIS Contract Test Shelter");
+        });
+    }
+
+    @Test
+    @DisplayName("Schema-absent at projection record: HmisInventoryRecord has no PII-flavored fields")
+    void hmisInventoryRecord_hasNoPiiFlavoredFields() {
+        RecordComponent[] components = HmisInventoryRecord.class.getRecordComponents();
+        assertThat(components)
+                .as("HmisInventoryRecord must remain a record (this assertion structure depends on it)")
+                .isNotEmpty();
+
+        for (RecordComponent component : components) {
+            String lower = component.getName().toLowerCase();
+            for (String pattern : PII_FIELD_NAME_PATTERNS) {
+                assertThat(lower)
+                        .as("HmisInventoryRecord field '%s' contains PII-flavored substring '%s' — "
+                                + "possible leak path; review whether this field is required for HMIS"
+                                + " export and consider renaming or removing.",
+                                component.getName(), pattern)
+                        .doesNotContain(pattern);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("Schema-absent at outbox table: hmis_outbox has no PII columns")
+    void hmisOutboxEntryTable_hasNoPiiColumns() {
+        List<String> columns = jdbcTemplate.queryForList(
+                "SELECT column_name FROM information_schema.columns "
+                + "WHERE table_name = 'hmis_outbox' AND table_schema = 'public'",
+                String.class);
+
+        assertThat(columns)
+                .as("hmis_outbox must exist and have columns (test prerequisite)")
+                .isNotEmpty();
+
+        for (String column : columns) {
+            String lower = column.toLowerCase();
+            assertThat(PII_COLUMN_NAMES)
+                    .as("Column '%s' in hmis_outbox matches a known PII column name — "
+                            + "the outbox table must be projection-only, not a join target for "
+                            + "reservation PII.", column)
+                    .noneMatch(piiName -> lower.equals(piiName));
+        }
+    }
+
+    @ParameterizedTest
+    @ValueSource(booleans = {true, false})
+    @DisplayName("Serialized-payload absent: HMIS transformer output (the canonical pipeline payload) "
+            + "carries no trace of seeded hold-attribution PII regardless of reentryMode")
+    void holdAttributionPii_absentFromTransformerSerializedPayload(boolean reentryMode) throws Exception {
+        // ---- Seed reservation with PII via the existing API (uses the encryption pipeline) ----
+        String clientName = "Probe-Person-" + UUID.randomUUID();
+        String clientDob = "1985-06-15";
+        String holdNotes = "Probe-Notes-" + UUID.randomUUID() + "-must-not-leak";
+
+        UUID reservationId = postHoldWithPii(clientName, clientDob, holdNotes);
+
+        // ---- Sanity: the encrypted PII landed in reservation. Without this control, a silent
+        // seed failure (e.g., the API rejected the body) would also pass the leak-test.
+        Map<String, Object> reservationRow = jdbcTemplate.queryForMap(
+                "SELECT held_for_client_name_encrypted, held_for_client_dob_encrypted, "
+                + "hold_notes_encrypted FROM reservation WHERE id = ?", reservationId);
+        assertThat(reservationRow.get("held_for_client_name_encrypted"))
+                .as("Sanity: encrypted PII must be present on reservation row to make the leak-test "
+                        + "meaningful (reentryMode=%s)", reentryMode)
+                .isNotNull();
+
+        // ---- Flip reentryMode flag for this branch of the parameterized test ----
+        jdbcTemplate.update(
+                "UPDATE tenant SET config = jsonb_set(config, '{features,reentryMode}', ?::jsonb, true) "
+                + "WHERE id = ?",
+                String.valueOf(reentryMode), tenantId);
+
+        // ---- Run the canonical projection layer ----
+        List<HmisInventoryRecord> records = transformer.buildInventory(tenantId);
+        assertThat(records)
+                .as("Transformer should produce at least one inventory record for the seeded shelter "
+                        + "(reentryMode=%s)", reentryMode)
+                .isNotEmpty();
+
+        // ---- Serialize exactly as HmisPushService.createOutboxEntriesForTenant does ----
+        String payload = objectMapper.writeValueAsString(records);
+
+        // ---- Thorough payload-absence: substring-search the JSON for the seeded PII. Any hit
+        // means the projection layer somehow pulled reservation-row PII into the inventory. ----
+        assertThat(payload)
+                .as("HMIS push payload must not contain seeded client name (reentryMode=%s)", reentryMode)
+                .doesNotContain(clientName);
+        assertThat(payload)
+                .as("HMIS push payload must not contain seeded DOB (reentryMode=%s)", reentryMode)
+                .doesNotContain(clientDob);
+        assertThat(payload)
+                .as("HMIS push payload must not contain seeded hold notes (reentryMode=%s)", reentryMode)
+                .doesNotContain(holdNotes);
+
+        // ---- Defense-in-depth: the encrypted blob itself must also not appear (would catch a
+        // serializer that pulled the encrypted column rather than decrypting + re-encrypting) ----
+        String nameEnc = (String) reservationRow.get("held_for_client_name_encrypted");
+        if (nameEnc != null && !nameEnc.isEmpty()) {
+            assertThat(payload)
+                    .as("HMIS push payload must not contain encrypted client-name blob "
+                            + "(reentryMode=%s)", reentryMode)
+                    .doesNotContain(nameEnc);
+        }
+
+        // ---- Defense-in-depth: payload must not contain any of the PII column names as JSON
+        // keys (would catch a future projection that includes the column name even with null
+        // values, e.g., from a `SELECT *`) ----
+        for (String piiCol : PII_COLUMN_NAMES) {
+            assertThat(payload.toLowerCase())
+                    .as("HMIS push payload must not mention PII column name '%s' (reentryMode=%s)",
+                            piiCol, reentryMode)
+                    .doesNotContain(piiCol);
+            // Also check camelCase variant (Jackson default field-naming for record components)
+            String camelCase = toCamelCase(piiCol);
+            assertThat(payload)
+                    .as("HMIS push payload must not mention PII field name '%s' (reentryMode=%s)",
+                            camelCase, reentryMode)
+                    .doesNotContain(camelCase);
+        }
+    }
+
+    // -------------------- helpers --------------------
+
+    /**
+     * Convert snake_case to camelCase. {@code held_for_client_name_encrypted} →
+     * {@code heldForClientNameEncrypted}.
+     */
+    private static String toCamelCase(String snake) {
+        StringBuilder sb = new StringBuilder();
+        boolean upper = false;
+        for (char c : snake.toCharArray()) {
+            if (c == '_') {
+                upper = true;
+            } else if (upper) {
+                sb.append(Character.toUpperCase(c));
+                upper = false;
+            } else {
+                sb.append(c);
+            }
+        }
+        return sb.toString();
+    }
+
+    private UUID createNonDvShelter(String name) {
+        String body = String.format("""
+                {
+                  "name": "%s",
+                  "addressStreet": "100 HMIS Contract Test St",
+                  "addressCity": "Raleigh",
+                  "addressState": "NC",
+                  "addressZip": "27601",
+                  "dvShelter": false,
+                  "constraints": { "populationTypesServed": ["SINGLE_ADULT"] },
+                  "capacities": [{"populationType": "SINGLE_ADULT", "bedsTotal": 10}]
+                }
+                """, name);
+        ResponseEntity<Map> resp = restTemplate.exchange(
+                "/api/v1/shelters", HttpMethod.POST,
+                new HttpEntity<>(body, adminHeaders), Map.class);
+        if (resp.getStatusCode() != HttpStatus.CREATED) {
+            throw new AssertionError(
+                    "POST /shelters returned " + resp.getStatusCode() + " — body: " + resp.getBody());
+        }
+        return UUID.fromString((String) resp.getBody().get("id"));
+    }
+
+    private UUID postHoldWithPii(String name, String dob, String notes) {
+        String body = String.format("""
+                {
+                  "shelterId": "%s",
+                  "populationType": "SINGLE_ADULT",
+                  "notes": "operator-side notes",
+                  "heldForClientName": "%s",
+                  "heldForClientDob": "%s",
+                  "holdNotes": "%s"
+                }
+                """, shelterId, name, dob, notes);
+        ResponseEntity<Map> resp = restTemplate.exchange(
+                "/api/v1/reservations", HttpMethod.POST,
+                new HttpEntity<>(body, outreachHeaders), Map.class);
+        if (resp.getStatusCode() != HttpStatus.CREATED) {
+            throw new AssertionError(
+                    "POST /reservations returned " + resp.getStatusCode()
+                    + " — body: " + resp.getBody());
+        }
+        return UUID.fromString((String) resp.getBody().get("id"));
+    }
+}

--- a/backend/src/test/java/org/fabt/hmis/HmisPushContractTest.java
+++ b/backend/src/test/java/org/fabt/hmis/HmisPushContractTest.java
@@ -126,6 +126,24 @@ class HmisPushContractTest extends BaseIntegrationTest {
         });
     }
 
+    /**
+     * Scope of this assertion: catches a future regression that adds a field to
+     * {@link HmisInventoryRecord} whose name matches the v0.55.0-introduced
+     * hold-attribution PII patterns ({@code held_for_client_*}, {@code client_name},
+     * {@code client_dob}, {@code hold_notes}).
+     *
+     * <p><b>Known limitation:</b> this reflection check is structurally blind to
+     * <em>new</em> PII categories. A field named {@code requesterIdentity},
+     * {@code applicantSsn}, or {@code guestEmail} would NOT match the pattern
+     * list and would NOT fail here. The actual leak gate for broader PII
+     * categories is the {@code hmisOutboxEntryTable_hasNoPiiColumns} check
+     * (schema-absent at the outbox table) plus the
+     * {@code holdAttributionPii_absentFromTransformerSerializedPayload} check
+     * (substring-payload search of seeded values). When adding a new PII
+     * category to the {@code reservation} table or any other source table,
+     * extend {@link #PII_FIELD_NAME_PATTERNS} <em>and</em> seed the new value
+     * into the substring-payload test.
+     */
     @Test
     @DisplayName("Schema-absent at projection record: HmisInventoryRecord has no PII-flavored fields")
     void hmisInventoryRecord_hasNoPiiFlavoredFields() {

--- a/e2e/playwright/tests/screen-reader.spec.ts
+++ b/e2e/playwright/tests/screen-reader.spec.ts
@@ -67,18 +67,22 @@ test.describe('Virtual Screen Reader Tests', () => {
     await outreachPage.waitForTimeout(3000);
 
     const doc = await getPageDOM(outreachPage);
-    const main = doc.querySelector('main') || doc.body;
+    // v0.55.1-T1: scope the screen-reader probe to the search-results region
+    // landmark, NOT the entire <main>. Slice 4 §8/§9 added shelter-type chips,
+    // county dropdown, advanced-filters group, and accepts-felonies toggle to
+    // the filter bar, pushing the freshness badges past the prior 100-step
+    // probe window. Scoping to the results region (where the badges actually
+    // live, on shelter cards) is also closer to how AT users navigate — by
+    // landmark, not sequentially through filters.
+    const resultsRegion =
+      doc.querySelector('[data-testid="search-results-region"]') ||
+      doc.querySelector('[role="region"][aria-label]') ||
+      doc.querySelector('main') ||
+      doc.body;
 
-    await virtual.start({ container: main as unknown as HTMLElement });
+    await virtual.start({ container: resultsRegion as unknown as HTMLElement });
 
-    // Navigate through all elements
-    // Slice 4 §8/§9 added shelter-type chips + county dropdown +
-    // accepts-felonies toggle to the advanced-filters section, which
-    // pushes the freshness badges past index 50 in the tab order.
-    // Bumped to 100 to keep the test forward-compatible if more filters
-    // land. If this still fails, scope `getPageDOM` to the results
-    // region (the badges live on the shelter cards, not in the filter
-    // bar).
+    // Navigate through elements within the results region.
     const phrases: string[] = [];
     for (let i = 0; i < 100; i++) {
       await virtual.next();
@@ -88,10 +92,17 @@ test.describe('Virtual Screen Reader Tests', () => {
 
     await virtual.stop();
 
-    const allSpoken = phrases.join(' ');
-
-    // Freshness badges should announce "Fresh" or "Stale" text (WCAG 1.4.1)
-    expect(allSpoken).toMatch(/Fresh|Stale|Unknown/);
+    // Freshness badges should announce "Fresh" or "Stale" text (WCAG 1.4.1).
+    // v0.55.1-T1 + warroom M4: assert at least 3 distinct freshness-badge
+    // announcements (≥50% of seeded shelters in the default search). A single
+    // match would be too lenient — a regression that surfaces only the very
+    // first shelter card's badge would still pass.
+    const freshnessMatches = phrases.filter((p) => /Fresh|Stale|Unknown/.test(p));
+    expect(
+      freshnessMatches.length,
+      `Expected ≥3 freshness-badge announcements in the results region; ` +
+        `found ${freshnessMatches.length}: ${freshnessMatches.join(', ')}`,
+    ).toBeGreaterThanOrEqual(3);
   });
 
   test('admin panel: tab bar has correct ARIA roles', async ({ adminPage }) => {

--- a/e2e/playwright/tests/wcag-vpat-verification.spec.ts
+++ b/e2e/playwright/tests/wcag-vpat-verification.spec.ts
@@ -184,30 +184,29 @@ test.describe('WCAG 1.4.1 Use of Color', () => {
 
 test.describe('WCAG 1.4.3 Contrast (Light + Dark)', () => {
 
-  test('light mode: zero contrast violations across all pages', async ({ outreachPage, adminPage, coordinatorPage }) => {
-    // Search page
-    await outreachPage.goto('/outreach');
-    await outreachPage.waitForTimeout(2000);
-    const searchResults = await new AxeBuilder({ page: outreachPage })
+  // v0.55.1-T2: split into per-page tests (was a single 3-page test that
+  // timed out post-§10 outreach expansion). Each test gets its own 30s
+  // budget; failure attribution names the offending page directly.
+  // Dark-mode test below stays as a single test (only covers outreach).
+  async function assertColorContrastForPage(page: any, pagePath: string) {
+    await page.goto(pagePath);
+    await page.waitForTimeout(2000);
+    const results = await new AxeBuilder({ page })
       .withRules(['color-contrast'])
       .analyze();
-    expect(searchResults.violations, formatViolations(searchResults.violations)).toEqual([]);
+    expect(results.violations, formatViolations(results.violations)).toEqual([]);
+  }
 
-    // Admin page
-    await adminPage.goto('/admin');
-    await adminPage.waitForTimeout(2000);
-    const adminResults = await new AxeBuilder({ page: adminPage })
-      .withRules(['color-contrast'])
-      .analyze();
-    expect(adminResults.violations, formatViolations(adminResults.violations)).toEqual([]);
+  test('light mode: outreach page has zero contrast violations', async ({ outreachPage }) => {
+    await assertColorContrastForPage(outreachPage, '/outreach');
+  });
 
-    // Coordinator page
-    await coordinatorPage.goto('/coordinator');
-    await coordinatorPage.waitForTimeout(2000);
-    const coordResults = await new AxeBuilder({ page: coordinatorPage })
-      .withRules(['color-contrast'])
-      .analyze();
-    expect(coordResults.violations, formatViolations(coordResults.violations)).toEqual([]);
+  test('light mode: admin page has zero contrast violations', async ({ adminPage }) => {
+    await assertColorContrastForPage(adminPage, '/admin');
+  });
+
+  test('light mode: coordinator page has zero contrast violations', async ({ coordinatorPage }) => {
+    await assertColorContrastForPage(coordinatorPage, '/coordinator');
   });
 
   test('dark mode: zero contrast violations on key pages', async ({ browser }) => {

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -123,6 +123,7 @@
   "search.resultCount": "{count, plural, one {# shelter found} other {# shelters found}}",
   "search.noResults": "No shelters match your filters",
   "search.tryDifferent": "Try adjusting your search criteria",
+  "search.resultsRegion": "Search results",
   "search.allTypes": "All Population Types",
   "search.singleAdult": "Single Adults",
   "search.family": "Families with Children",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -123,6 +123,7 @@
   "search.resultCount": "{count, plural, one {# refugio encontrado} other {# refugios encontrados}}",
   "search.noResults": "Ningún refugio coincide con sus filtros",
   "search.tryDifferent": "Intente ajustar sus criterios de búsqueda",
+  "search.resultsRegion": "Resultados de búsqueda",
   "search.allTypes": "Todos los Tipos",
   "search.singleAdult": "Adultos Solteros",
   "search.family": "Familias con Niños",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -723,9 +723,9 @@
   "hold.notes": "Nota para el coordinador del refugio",
   "hold.clientAttributionPrivacyNote": "El nombre, la fecha de nacimiento y las notas del cliente se almacenan cifrados. Se borran a más tardar 25 horas después de que esta reserva expire, sea confirmada, o sea cancelada. Use estos campos únicamente para la coordinación del registro en el refugio.",
   "hold.help.clientName": "Opcional. El coordinador del refugio verá esto para saber a quién esperar en el registro. Se borra automáticamente a más tardar 25 horas después de que la reserva termine.",
-  "hold.help.clientDob": "Opcional. El refugio lo usa solo para confirmar a la persona correcta en el registro. Se borra automáticamente a más tardar 25 horas después de que la reserva termine.",
-  "hold.help.notes": "Opcional. Nota de coordinación de texto libre para el refugio — por ejemplo, un número de teléfono del navegador o detalles de la ventana de llegada. Se borra automáticamente a más tardar 25 horas después de que la reserva termine. Evite identificadores sensibles que no quiera que el coordinador vea.",
-  "shelter.eligibility.notes.help": "Texto libre que se muestra a los trabajadores de extensión que reservan camas. No pegue información específica del cliente aquí — este campo describe la política de ingreso del refugio, no a una persona en particular.",
+  "hold.help.clientDob": "Opcional. El refugio lo usa únicamente para confirmar a la persona correcta en el registro. Se borra automáticamente a más tardar 25 horas después de que la reserva termine.",
+  "hold.help.notes": "Opcional. Nota de coordinación de texto libre para el refugio — por ejemplo, un número de teléfono del navegador de servicios o detalles de la ventana de llegada. Se borra automáticamente a más tardar 25 horas después de que la reserva termine. Evite identificadores sensibles que no quiera que el coordinador vea.",
+  "shelter.eligibility.notes.help": "Texto libre que se muestra a los trabajadores de alcance comunitario que reservan camas. No pegue información específica del cliente aquí — este campo describe la política de ingreso del refugio, no a una persona en particular.",
 
   "admin.holdDurationMinutes": "Duración de la reserva (minutos)",
   "admin.eligibilityCriteria": "Criterios de elegibilidad",

--- a/frontend/src/pages/OutreachSearch.tsx
+++ b/frontend/src/pages/OutreachSearch.tsx
@@ -995,7 +995,12 @@ export function OutreachSearch() {
         </div>
       )}
 
-      {/* Results */}
+      {/* Results region — wraps result cards + empty-state. v0.55.1-T1: gives screen-reader probes a stable landmark to scope to (the freshness badges live on the cards within this region). */}
+      <div
+        role="region"
+        aria-label={intl.formatMessage({ id: 'search.resultsRegion' })}
+        data-testid="search-results-region"
+      >
       {!loading && filtered.map((r) => {
         const avail = totalBedsAvailable(r);
         const isFull = avail === 0;
@@ -1196,6 +1201,7 @@ export function OutreachSearch() {
           <div style={{ fontSize: text.base, marginTop: 6 }}><FormattedMessage id="search.tryDifferent" /></div>
         </div>
       )}
+      </div>
 
       {/* Detail modal */}
       {selectedShelter && (


### PR DESCRIPTION
## Summary

Code-repo half of v0.55.1 — paired with `feature/v0-55-1-followup` in `findABed` (docs). Implements the warroom-accepted carryover items from `project_v055_1_backlog.md`. **Validation: 1444/1444 backend tests green, full Playwright suite 470/470 (6 pre-existing flakes match documented long-tail; no regressions from this slice).**

### What landed

- **T1 — `screen-reader.spec.ts:65` scope fix.** Added `<div role="region" aria-label={search.resultsRegion}>` wrap around the OutreachSearch results map (real a11y landmark addition + Spanish day-one i18n key). Test now scopes to the region via `[data-testid="search-results-region"]` (locale-independent per `feedback_data_testid`). Sanity-assertion bumped from `>= 1` to `>= 3` distinct freshness-badge matches (warroom M4).
- **T2 — `wcag-vpat-verification.spec.ts:187` split.** Refactored single 3-page contrast probe into 3 per-page tests (outreach + admin + coordinator) via extracted `assertColorContrastForPage` helper. Each test runs under default 30s budget; failure attribution names the offending page directly. All 29 wcag-vpat tests green (~4m).
- **O1 — HMIS hold-attribution PII contract test.** New `HmisPushContractTest` with multi-layered assertion (warroom B2 thorough form): (1) reflection on `HmisInventoryRecord` confirms no PII-flavored fields; (2) `information_schema.columns` confirms `hmis_outbox` table has no PII columns; (3) substring-payload search confirms seeded reservation PII never appears in transformer output. Parameterized on `reentryMode={true,false}` to prove the gate is unconditional. 4/4 pass.
- **H2 — Javadoc tightening on the reflection check.** Documents the known false-negative class (catches *renamed* hold-attribution PII fields, structurally blind to *new* PII categories — those are caught by the schema-absent + payload-substring layers). No logic change.
- **D2 — AI-synthetic Spanish revisions.** 3 of 5 v0.55.0 reentry es.json keys revised after the AI-synthetic linguistic review (per-key 8-dimension analysis; full audit doc + native-reviewer flag in docs PR):
  - `hold.help.clientDob`: `solo` → `únicamente` (register-consistency with privacy-note key)
  - `hold.help.notes`: `del navegador` → `del navegador de servicios` (anglicism disambiguation; **flagged for future-real-native-reviewer** per implementation-warroom web research surfacing stronger alternatives `navegador de pacientes`/`enlace comunitario`/`asesor`)
  - `shelter.eligibility.notes.help`: `trabajadores de extensión` → `trabajadores de alcance comunitario` (pan-Latin neutral, vs the agricultural-extension calque)

  i18n-coverage tests 3/3 pass (en/es key parity).

### Truthfulness disclosure (per `feedback_truthfulness_above_all`)

The Spanish translation review on the 5 v0.55.0 reentry keys was performed by AI (Claude playing the Maria persona, with web-search-grounded linguistic research and per-key citations), NOT by a native speaker. Disclosure is verbose at every surface (commit messages, audit doc, archive marker, this PR description). A real-native-reviewer pass remains a future option; the citations make a future review faster.

## Test plan

- [x] `mvn clean test` — 1444/1444 pass, 0 failures, 0 errors. BUILD SUCCESS in 7m 19s.
- [x] `npm run build` — clean (1.55s + PWA build clean).
- [x] `vitest src/i18n/i18n-coverage.test.ts` — 3/3 pass (key parity en/es).
- [x] Full Playwright suite vs `BASE_URL=http://localhost:8081` (dev-start --nginx --observability) — 470 pass, 6 pre-existing flakes, 2 skipped, 57.7m. Pre-existing flakes documented in `project_v055_1_backlog.md`; not regressions.
- [x] T1 spec re-run: 6/6 screen-reader tests green.
- [x] T2 spec re-run: 29/29 wcag-vpat tests green.
- [x] O1 spec re-run: 4/4 HmisPushContractTest green.

## Paired PR

`feature/v0-55-1-followup` in `findABed` (docs) carries the docs half (S2 semantic markup + S1 dark-mode re-captures + D3 capture.sh + D2 audit doc + audit-trail warrooms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)