### PR TITLE
release(v0.56.0): pom bump + CHANGELOG + runbook + docs prep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,17 +5,11 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased] — v0.56.0 in progress
+## [v0.56.0] — 2026-05-03 — DV-policy tenant flag + platform-observability split
 
-This section drafts the v0.56.0 entry as the bundle assembles. Per the post-v0.55 prioritization warroom, v0.56.0 will bundle:
+Two openspec changes ship in this release: `dv-policy-tenant-flag` (tenant-scoped acknowledgement that gates per-shelter DV writes) and `platform-observability-split` (move tenant-agnostic observability config from /admin to platform tier). Backend rebuild + frontend rebuild + two new Flyway migrations (V97, V98). The originally-planned `info-email-contact` + GH #67 items did not make this bundle and are deferred to a later release.
 
-- `dv-policy-tenant-flag` — captured below; backend feature complete, frontend complete, deploy pending
-- `info-email-contact` Slice B+ — paused on dv-policy-tenant-flag; resumes after this lands
-- GH #67 (in-app issue reporting) — depends on info-email-contact's `useContactInfo()` hook
-
-The Unreleased section is renamed to `[v0.56.0] — YYYY-MM-DD — <bundle theme>` at tag time once all three are merged and deployed.
-
-### dv-policy-tenant-flag (in progress)
+### dv-policy-tenant-flag
 
 - **New tenant config key `dv_policy_enabled`** (boolean, default `false` on absent). Gates per-shelter `dv_shelter=true` writes via service-layer invariant in `ShelterService.create / update / activate`. Mirrors the v0.55 `features.reentryMode` JSONB-config pattern.
 - **Flyway V97 backfill** (`V97__backfill_dv_policy_enabled.sql`): sets `dv_policy_enabled=true` on every tenant that already has at least one shelter with `dv_shelter=true` at migration time. Idempotent; safe to re-run. The 3 demo tenants all backfill (each seeds at least one DV shelter). `seed-data.sql` defensively also sets the key on `--fresh` reseeds.
@@ -27,6 +21,24 @@ The Unreleased section is renamed to `[v0.56.0] — YYYY-MM-DD — <bundle theme
 - **`ShelterImportService` 211 CSV import path**: per-row reject is preserved by the existing `try/catch` infrastructure — DV rows on flag-off tenants are reported per-row rather than failing the whole batch. Behavior locked in by a dedicated IT.
 - **Tests**: 1489+ backend + 210+ Vitest, all green. Plus new dv-policy-specific coverage: 16 unit tests on the helper / service-write, 6 V97 migration IT scenarios (Riley's 4-tenant multi-state fixture), 10 controller IT scenarios (cross-tenant no-leak, audit-row content assertion, dvAccess gate), 10 ShelterService invariant scenarios, 3 211 import IT scenarios. Existing tests across 16+ classes were updated to enable the flag on test tenants — `TestAuthHelper.setupTestTenant` and `setupSecondaryTenant` default the flag to `true` (test fixtures represent operational CoCs; the flag-off case is exercised by raw-JDBC test setup in dedicated specs).
 - **Deploy notes**: see `openspec/changes/dv-policy-tenant-flag/runbook-fragments.md` (in the docs repo) for the v0.56 oracle-update-notes input — pre-deploy backfill scope query, Flyway HWM transition (V96 → V97), `--fresh` behavior clarification, onboarding sequence for fresh CoCs, rollback policy.
+
+### platform-observability-split
+
+- **New `platform_config` singleton table** (`V98__platform_config.sql`). Houses 6 tenant-agnostic observability fields (prometheus_enabled, tracing_enabled, tracing_endpoint, monitor_stale_interval_minutes, monitor_dv_canary_interval_minutes, monitor_temperature_interval_minutes). Single-row invariant enforced by `platform_config_singleton` CHECK on a canonical UUID. Seeds default values matching the prior `@Scheduled` literal cadences (5/15/60 minutes) so behavior is identical immediately after migration.
+- **`GET /api/v1/platform/observability`** (PLATFORM_OPERATOR + `@PlatformAdminOnly`) reads the platform config; **`PUT /api/v1/platform/observability`** (same + `X-Platform-Justification` header) writes a partial-merge update. Per-field audit emission (`PLATFORM_OBSERVABILITY_UPDATED` AuditEventType) with `field`, `old_value`, `new_value`, `value_changed`, `outcome=applied` payload. `SELECT … FOR UPDATE` row lock on the singleton row prevents lost updates under concurrent operator writes.
+- **`PUT /api/v1/tenants/{id}/surge-threshold`** (COC_ADMIN, no platform-justification header). Replaces the broken-since-G-4.4 `PUT /api/v1/tenants/{id}/observability` for the one tenant-specific field (Fahrenheit threshold for surge activation). Validation `-50 ≤ threshold ≤ 150` with `tenant.surgeThreshold.outOfRange` error code; emits `TENANT_CONFIG_UPDATED` audit. Read-modify-write preserves sibling JSONB keys.
+- **`OperationalMonitorService` rewired** (`SchedulingConfigurer` + `TaskScheduler` + dynamic `ScheduledFuture`). Replaces the literal `@Scheduled(fixedRate=…)` annotations so platform-operator interval changes take effect on the next reschedule cycle without a backend restart. Mirrors the existing `BatchJobScheduler` pattern.
+- **`OperationalMonitorService.rescheduleFromConfig()`** is invoked from `PlatformObservabilityController` on every successful PUT that touches an interval field; non-interval fields skip the reschedule.
+- **Removed**: `/admin#observability` tab. **Moved**: temperature threshold to `/admin#surge` (operator suggestion 2026-05-02 — surge thresholds belong alongside surge activation controls).
+- **Frontend**: new `frontend/src/pages/admin/components/SurgeTemperatureSettings.tsx` (modal + inline-edit form for the threshold; mirrors the dv-policy parseTemperatureError extracted-helper pattern). Platform Operator Dashboard gains a new `'observability'` ActionCategory with 6 inline-edit cards via the new `frontend/src/pages/platform/components/ObservabilityActionCard.tsx` (toggle / number / url field types per W3C ARIA APG; bounded number inputs; URL inputs with placeholder hints; current-value display row; 2-step destructive confirm with operator justification textarea).
+- **Accessibility**: PlatformActionCard switched from native `disabled` attribute to `aria-disabled="true"` + click guard. Per W3C ARIA APG (https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#focusabilityofdisabledcontrols), keeping the button focusable lets a keyboard-only operator land on it and discover the disabled-state tooltip via screen reader; native `disabled` removes it from tab order entirely.
+- **Tenant-list View card** wired to an inline TenantListPanel via `platformFetch` (carries the JWT). Replaces the prior `window.open` flow that stripped the JWT in a new tab.
+- **Structured error code registry** extended: `platform.observability.intervalOutOfRange`, `platform.observability.tracingEndpointMalformed`, `platform.observability.fieldTypeMismatch`, `platform.observability.unknownField`, `tenant.surgeThreshold.outOfRange`. `parseObservabilityError` extracted helper covered by 10 Vitest cases.
+- **i18n**: 4 new EN keys (`admin.observability.thresholdDescription`, `admin.observability.thresholdError`, `admin.observability.confirmTitle`, `admin.observability.confirmBody`) + 4 ES keys. ES additions are AI-synthetic (Claude with web-citation grounding, NOT a native speaker) per `feedback_truthfulness_above_all`; tracked at `reference_es_json_ai_synthetic_reviewed.md`.
+- **Frontend bug fix**: `observability.spec.ts` cleanup-logic bug where `if (wasEnabled) PUT true` skipped the restore branch when `wasEnabled === false`, polluting dev DB on first run. Fixed to unconditional `PUT { tracing_enabled: wasEnabled }`.
+- **Tests**: 1538/1538 backend (13 new `PlatformObservabilityControllerTest` IT scenarios + 10 new `TemperatureThresholdControllerTest` scenarios incl. COORDINATOR/OUTREACH forbidden, audit row content assertion, sibling-key preservation; updated `PlatformConfigServiceIntegrationTest` for new error codes; `TenantPathGuardIntegrationTest` expects 404 for cross-tenant `/surge-threshold`); 228/228 Vitest (10 new `ObservabilityActionCard.test.ts` + 8 new `SurgeTemperatureSettings.test.ts`); 32/32 Playwright (16 dashboard / inline-edit + 16 regression — `platform-dashboard-inline-flows.spec.ts` is new; existing `platform-ui-dashboard.spec.ts`, `platform-training-walkthrough.spec.ts`, `observability.spec.ts` updated for `aria-disabled` and the new endpoint surface).
+- **BREAKING (operator-facing)**: COC_ADMINs lose write access to the 6 platform-wide observability fields. They never reliably had write access (G-4.4 broke it; the UI was visible but every save 400'd), but the surfaced UI is gone now and the endpoint stays PLATFORM_OPERATOR-only. Operators looking for "where do I configure tracing?" should use the Platform Operator Dashboard (requires platform login + justification).
+- **Deploy notes**: V98 is additive (singleton table seeded with prior literal defaults). The pre-existing per-tenant `tenant.config.observability.*` JSONB keys remain readable for one release cycle (design D3 backward-read); a v0.58+ Flyway migration drops them once prod observability confirms zero reads. Service rollback (revert the JAR) is fully safe — old code reads from per-tenant config which still exists.
 
 ---
 

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -13,7 +13,7 @@
 
     <groupId>org.fabt</groupId>
     <artifactId>finding-a-bed-tonight</artifactId>
-    <version>0.55.0</version>
+    <version>0.56.0</version>
     <name>Finding A Bed Tonight</name>
     <description>Open-source shelter bed availability platform</description>
 

--- a/docs/operations/platform-operator-user-guide.md
+++ b/docs/operations/platform-operator-user-guide.md
@@ -295,6 +295,96 @@ exposes credentials over the wrong channel.
 
 ---
 
+## 9. Configuring observability
+
+> **v0.56 status:** the dashboard's **Observability** section is the
+> only operator surface that can flip Prometheus metrics on/off,
+> toggle the OpenTelemetry exporter, change the OTLP endpoint, and
+> tune the three monitor cadences (stale-shelter detection, DV-canary
+> probe, NOAA temperature fetch). Pre-v0.56 these fields lived on the
+> CoC admin **Observability** tab and reliably 400'd on every save
+> (the G-4.4 endpoint role split moved them under
+> `@PlatformAdminOnly` but the UI never carried the
+> `X-Platform-Justification` header). The CoC tab is gone in v0.56;
+> the platform dashboard is the single source of truth.
+
+The Observability cards are **inline-edit cards** — the input lives
+on the card itself, not in a popup. Three field types render
+differently:
+
+- **Toggles** (Prometheus Metrics, OpenTelemetry Tracing) — switch
+  control, label state-stable ("Enabled" / "Disabled" reflects the
+  *current* value, not the proposed new one). Aligns with the W3C
+  ARIA APG Switch Pattern.
+- **Bounded numbers** (Stale Shelter Cadence, DV Canary Cadence,
+  Temperature Cadence) — narrow numeric input + "minutes" suffix,
+  bounded `1..1440`. Out-of-range values are caught client-side and
+  the backend re-validates with `platform.observability.intervalOutOfRange`.
+- **URL** (OTLP Endpoint) — wide text input + placeholder hint.
+  Backend validates parseability with
+  `platform.observability.tracingEndpointMalformed`.
+
+Each card displays the **current persisted value** above the editor
+— you can see the existing setting before deciding to change it.
+
+### Saving a change
+
+When you click **Edit**, the input becomes active and the **Save**
+button enables only after you type a value that differs from the
+current one. The Save button color reflects the card's danger level:
+
+- **Safe** (Prometheus toggle, Tracing toggle, Stale Shelter Cadence)
+  — green button, single-confirm modal asking only for the
+  justification text (≥10 chars).
+- **Destructive** (OTLP Endpoint, DV Canary Cadence, Temperature
+  Cadence) — red button, **two-step confirmation**: a confirmation
+  modal with the justification field, then the actual PUT after you
+  click Confirm. Bad OTLP endpoints blackhole spans; lengthening the
+  DV canary weakens the platform's leak-detection posture; floors
+  on the temperature cadence are reserved by NOAA's rate-limit.
+
+Every successful PUT writes one `audit_events` row per changed field
+(`event_type='PLATFORM_OBSERVABILITY_UPDATED'`) carrying `field`,
+`old_value`, `new_value`, `value_changed`, and your operator id.
+Monitor-interval changes additionally trigger
+`OperationalMonitorService.rescheduleFromConfig()` so the new
+cadence takes effect on the next scheduler cycle without a backend
+restart. Toggles and the OTLP endpoint do not trigger reschedule —
+they take effect on the next scrape / span export.
+
+### Where the temperature threshold lives now
+
+The one tenant-specific observability field — the Fahrenheit
+threshold for surge activation recommendations — has moved from the
+old `/admin#observability` tab to `/admin#surge`. CoC admins set
+it via the **SurgeTemperatureSettings** panel embedded in the
+Surge tab. The backend endpoint is `PUT /api/v1/tenants/{id}/surge-threshold`
+and does NOT require a platform-justification header — it is
+COC_ADMIN-scoped and operator-readable. Validation is `-50 ≤ value ≤ 150`
+with `tenant.surgeThreshold.outOfRange` on rejection.
+
+### Common situations
+
+| What you want to do | Where | Notes |
+|---|---|---|
+| Turn Prometheus metrics off temporarily | Platform dashboard → Observability → Prometheus Metrics → Edit → toggle Off → Save | Justification mandatory. Takes effect on next scrape. |
+| Point the OTLP exporter at a new collector | Platform dashboard → Observability → OTLP Endpoint → Edit → paste URL → Confirm twice | A bad URL blackholes spans silently — verify the collector first. |
+| Lengthen the stale-shelter detection cycle from 5 min to 10 min | Platform dashboard → Observability → Stale Shelter Cadence → Edit → 10 → Save | Safe action; takes effect on next reschedule. |
+| Tighten the DV canary probe (shorten the cadence) | Platform dashboard → Observability → DV Canary Cadence → Edit → smaller number → Confirm twice | Tightening is destructive-flagged because lowering increases load on the security path; lengthening is destructive because it weakens posture. The dashboard treats both directions as destructive on this field. |
+| Change a CoC's surge-activation temperature threshold | Admin → Surge → SurgeTemperatureSettings → enter new °F → Save | CoC-admin scope; no platform login required. Uses the new `/surge-threshold` endpoint. |
+
+### When something goes wrong
+
+| Symptom | Likely cause | Self-serve action |
+|---|---|---|
+| Save returns "Out of range" | Number outside `1..1440` (intervals) or `-50..150` (threshold) | Re-enter within bounds. |
+| Save returns "Tracing endpoint malformed" | URL not parseable (no scheme, bad host) | Re-enter as `http://collector:4318/v1/traces` or similar. |
+| Save returns "Justification required" | You hit the endpoint via curl without `X-Platform-Justification` | Use the dashboard, which adds the header automatically. |
+| Toggle visually flipped but the next scrape still misses metrics | OTel exporter wraps the Prometheus toggle at startup — toggling at runtime requires a brief settle time | Wait one full scrape interval (15s default), recheck. |
+| Card shows "Could not load current value" | Backend `GET /api/v1/platform/observability` returned non-200 | Reload the page; if persistent, escalate. |
+
+---
+
 ## See also
 
 - [`oracle-update-notes-v0.54.0.md`](../oracle-update-notes-v0.54.0.md)

--- a/docs/oracle-update-notes-v0.56.0.md
+++ b/docs/oracle-update-notes-v0.56.0.md
@@ -116,9 +116,9 @@ consulted:
   - file: feedback_legal_scan_in_comments.md
     # why-cited: legal-language scan applies to JSDoc + JavaDoc, not
     # just user-facing copy. Already cleared by the round-7 `2d337b2`
-    # commit on the platform-obs feature branch (4 "compliant" + 1 "no
-    # way to" rephrased to "follows the W3C ARIA APG Switch Pattern" /
-    # "could not").
+    # commit on the platform-obs feature branch (4 overclaim words + 1
+    # impossibility phrase rephrased to "follows the W3C ARIA APG
+    # Switch Pattern" / "could not").
   - file: feedback_check_ports_before_assuming.md
     # why-cited: post-deploy frontend smoke uses port 8081 (nginx) in
     # local rehearsal and the public URL via Cloudflare for prod smoke.

--- a/docs/oracle-update-notes-v0.56.0.md
+++ b/docs/oracle-update-notes-v0.56.0.md
@@ -1,0 +1,577 @@
+# Oracle Deploy Notes — v0.56.0 (dv-policy-tenant-flag + platform-observability-split)
+
+**Status:** draft pending CI green + tag.
+**Template version:** v1 (per `docs/runbook-template.md`).
+**OpenSpec changes:** `dv-policy-tenant-flag` + `platform-observability-split` (both in the docs repo).
+
+---
+
+## What's new in v0.56.0 (one-paragraph summary)
+
+v0.56 ships two openspec changes together: `dv-policy-tenant-flag`
+introduces a tenant-scoped acknowledgement (`tenant.config.dv_policy_enabled`)
+that gates per-shelter `dv_shelter=true` writes via a `ShelterService`
+invariant, with a dedicated `PATCH /api/v1/admin/tenants/{id}/dv-policy`
+COC_ADMIN endpoint, an admin Settings panel with extra-confirm modal, and
+a forward-only V97 backfill that flips the flag on tenants that already
+operate DV shelters. `platform-observability-split` splits the broken-
+since-G-4.4 `/admin#observability` tab into three pieces: a new V98
+`platform_config` singleton table for the 6 tenant-agnostic fields
+(prometheus, tracing, three monitor cadences) flipped via `PUT
+/api/v1/platform/observability` (PLATFORM_OPERATOR + `@PlatformAdminOnly`)
+on the Platform Operator Dashboard, the surviving tenant-specific
+temperature threshold moved to `/admin#surge` with a new
+`PUT /api/v1/tenants/{id}/surge-threshold` COC_ADMIN endpoint, and the
+`OperationalMonitorService` rewired from literal `@Scheduled` rates to a
+`SchedulingConfigurer` + `TaskScheduler` + dynamic `ScheduledFuture`
+pattern so platform-operator interval changes take effect on the next
+reschedule cycle without a restart. The deploy is **single-stage** with
+a backend rebuild + frontend rebuild and two new Flyway migrations
+(V97, V98). Backend full mvn test 1538/1538, Vitest 228/228, Playwright
+32/32. The originally-planned `info-email-contact` + GH #67 items did
+NOT make this bundle and are deferred.
+
+---
+
+## 1. Consulted Memories
+
+```yaml
+consulted:
+  - file: feedback_runbook_groundtruth_vm.md
+    # why-cited: every container name, JAR path, port, and image tag in
+    # this runbook ground-truthed against project_live_deployment_status
+    # (current state v0.55.1, Flyway V96, fabt-pgaudit:v0.45.0,
+    # 5-file compose chain). v0.56 introduces no new compose override.
+  - file: feedback_runbook_compose_chain.md
+    # why-cited: prod uses a 5-FILE compose chain (UNCHANGED from v0.55).
+    # Missing any one file breaks deploy (postgres crash loop on v0.50).
+  - file: feedback_prod_docker_build_pattern.md
+    # why-cited: explicit `docker build --no-cache` BEFORE
+    # `compose up --force-recreate` for both backend + frontend.
+  - file: feedback_deploy_old_jars.md
+    # why-cited: `mvn clean` mandatory before backend `docker build` —
+    # old JARs in `backend/target/` cause Docker to embed stale bytecode.
+  - file: feedback_deploy_checklist_v031.md
+    # why-cited: clean build, single-JAR verify, no-cache image, actuator
+    # on 9091, post-deploy class verification.
+  - file: feedback_runbook_template_v1.md
+    # why-cited: this runbook follows the v1 template structure.
+  - file: feedback_release_after_scans.md
+    # why-cited: tag + GitHub release published only after CI scans green
+    # (CodeQL + npm audit + dependency-check + E2E + Performance).
+  - file: feedback_smoke_spec_default_target.md
+    # why-cited: post-deploy Playwright smoke uses FABT_BASE_URL +
+    # `--config=deploy/playwright.config.ts` + `post-deploy-smoke`
+    # positional. The smoke spec defaults to localhost without that
+    # override.
+  - file: feedback_never_print_rendered_secrets.md
+    # why-cited: never cat/grep `~/fabt-secrets/.env.prod` or any
+    # rendered alertmanager.yml during deploy. Use structural checks
+    # only.
+  - file: feedback_no_ssh_tunnels.md
+    # why-cited: this runbook shares SSH commands the operator runs.
+    # The platform-operator login (now needed to drive the new
+    # observability cards on the Platform Operator Dashboard) requires
+    # an SSH tunnel; details surfaced in chat at deploy time per
+    # `feedback_platform_login_via_ssh_tunnel.md`, NOT committed here.
+  - file: feedback_bind_mount_inode_pitfall.md
+    # why-cited: no compose-file edit in v0.56 and no new files in
+    # mounted config directories, so prometheus does NOT need
+    # force-recreate this release.
+  - file: feedback_verify_doc_facts_against_source.md
+    # why-cited: every command path, container name, and image tag below
+    # ground-truthed against the V97 + V98 migration files, the
+    # PlatformObservabilityController + DvPolicyController source, and
+    # the live VM state from project_live_deployment_status.md.
+  - file: feedback_stale_sw_on_deploy.md
+    # why-cited: post-deploy frontend testing must be incognito or
+    # site-data-cleared — old service worker will serve cached JS.
+  - file: feedback_periodic_resume_save.md
+    # why-cited: post-deploy memory updates per §8.
+  - file: feedback_platform_login_via_ssh_tunnel.md
+    # why-cited: v0.56 SURFACES new platform-operator paths — the
+    # observability inline-edit cards on the Platform Operator
+    # Dashboard. The SSH tunnel command for hitting the platform UI in
+    # prod is shared in chat at deploy time, NEVER committed here
+    # (op-sec).
+  - file: project_live_deployment_status.md
+    # why-cited: ground-truth source. v0.55.1 currently live; Flyway HWM
+    # V96; 5-file compose chain; `fabt-pgaudit:v0.45.0` postgres image;
+    # JAR at `/app/app.jar`; container_name conventions (fabt-backend,
+    # fabt-frontend, finding-a-bed-tonight-postgres-1).
+  - file: project_dv_policy_tenant_flag_decisions.md
+    # why-cited: 2026-05-01 warroom decisions for dv-policy-tenant-flag
+    # (COC_ADMIN + extra-confirm; "no DV shelters without flag"
+    # invariant; disable-path forbidden while DV shelters exist).
+  - file: feedback_truthfulness_above_all.md
+    # why-cited: AI-synthetic Spanish review disclosure for the 4 new
+    # platform-obs Spanish keys (admin.observability.threshold*,
+    # confirm*) — same convention as the v0.55.1 D2 disclosure.
+  - file: feedback_persona_transparency.md
+    # why-cited: marker text in commits + this runbook never says
+    # "Maria-reviewed" — always "AI-synthetic-linguistic-review".
+  - file: reference_es_json_ai_synthetic_reviewed.md
+    # why-cited: AI-synthetic Spanish review pointer + disclosure
+    # conventions used here for the v0.56 platform-obs key additions.
+  - file: feedback_legal_scan_in_comments.md
+    # why-cited: legal-language scan applies to JSDoc + JavaDoc, not
+    # just user-facing copy. Already cleared by the round-7 `2d337b2`
+    # commit on the platform-obs feature branch (4 "compliant" + 1 "no
+    # way to" rephrased to "follows the W3C ARIA APG Switch Pattern" /
+    # "could not").
+  - file: feedback_check_ports_before_assuming.md
+    # why-cited: post-deploy frontend smoke uses port 8081 (nginx) in
+    # local rehearsal and the public URL via Cloudflare for prod smoke.
+```
+
+---
+
+## 2. Scope & Non-Scope
+
+**Deploying:** v0.56.0 — `dv-policy-tenant-flag` + `platform-observability-split` openspec changes bundled.
+
+**From:** `v0.55.1` live at `findabed.org` (frontend bundle on top of v0.55.0 backend JAR). Confirm current via:
+
+```bash
+curl -s https://findabed.org/api/v1/version
+# Expected pre-deploy: {"version":"0.55"}
+# (VersionController strips the patch version — v0.55.0 backend JAR
+# under v0.55.1 frontend reports "0.55", and v0.56.0 will report "0.56".)
+```
+
+**To:** `v0.56.0` — backend JAR `0.55.0 → 0.56.0` (rebuilt; pom.xml bumped), Flyway HWM `V96 → V98`, frontend bundle gains the dv-policy admin panel + the new SurgeTemperatureSettings + the 6 inline-edit Observability action cards on the Platform Operator Dashboard.
+
+**Migrations in this deploy:**
+
+- **V97** — `V97__backfill_dv_policy_enabled.sql`. Backfills `tenant.config.dv_policy_enabled = true` on every tenant that already has at least one shelter with `dv_shelter = true` at migration time. Idempotent. Tenants with zero DV shelters are not modified (helper defaults to `false` on absent key). Performance: uses the existing `shelter(tenant_id)` index; fast at 10K-shelter scale (Sam's review, warroom 2026-05-02).
+- **V98** — `V98__platform_config.sql`. Creates the `platform_config` singleton table (one canonical UUID, enforced by CHECK constraint). Seeds the initial row with defaults that match the prior `@Scheduled` literal cadences (5/15/60 minutes for stale/dv-canary/temperature) plus `prometheus_enabled=true`, `tracing_enabled=false`, `tracing_endpoint='http://localhost:4318/v1/traces'`. Behavior is identical immediately after migration; operators flip via the new platform endpoint.
+
+**New endpoints:**
+
+- `PATCH /api/v1/admin/tenants/{tenantId}/dv-policy` — COC_ADMIN, requires `dvAccess=true` JWT claim. Tenant-scoping check fires before any DV-shelter inventory query so cross-tenant probes do not leak inventory state via timing or response data. Disable path (`true → false`) forbidden while active DV shelters exist; rejection emits a `TENANT_CONFIG_UPDATED` audit row with `outcome: "rejected"`. Cross-tenant probe also emits `rejection_code: "tenant.crossTenantAccess"`.
+- `GET /api/v1/platform/observability` — PLATFORM_OPERATOR + `@PlatformAdminOnly`. Returns the 6 platform-wide config fields.
+- `PUT /api/v1/platform/observability` — same role + `X-Platform-Justification` header. Partial-merge update with `SELECT … FOR UPDATE` row lock. Per-field audit emission (`PLATFORM_OBSERVABILITY_UPDATED` AuditEventType). Triggers `OperationalMonitorService.rescheduleFromConfig()` on any monitor-interval change.
+- `PUT /api/v1/tenants/{id}/surge-threshold` — COC_ADMIN, no platform-justification header. Replaces the broken-since-G-4.4 `/observability` PUT for the temperature threshold. Validation `-50 ≤ threshold ≤ 150`; `tenant.surgeThreshold.outOfRange` error code. Emits `TENANT_CONFIG_UPDATED`.
+
+**Removed endpoint:** `PUT /api/v1/tenants/{id}/observability` — the 6 platform-wide fields move to the platform endpoint; the 1 tenant-specific field moves to `/surge-threshold`. The `GET /api/v1/tenants/{id}/observability` is kept (backward-read per design D3) — `SurgeTemperatureSettings` reads the threshold via this GET.
+
+**New AuditEventType enum value:** `PLATFORM_OBSERVABILITY_UPDATED` (one row per changed field with `field`, `old_value`, `new_value`, `value_changed`, `outcome=applied` payload).
+
+**Frontend bug fix bundled:** `ApiError` class now captures the backend `context` field (was reading `details` previously, but the backend always sent `context`; the field-name mismatch silently dropped structured error payloads for ALL 400 responses across the codebase, not just the new dv-policy / platform-obs endpoints). This is a code-hygiene side-effect of the dv-policy work; behavior change is "structured error UX appears where it was supposed to."
+
+**Accessibility change bundled:** PlatformActionCard switched from native `disabled` attribute to `aria-disabled="true"` + click guard (W3C ARIA APG keyboard-discoverability). Existing Playwright assertions migrated from `toBeDisabled()` to `toHaveAttribute('aria-disabled', 'true')`.
+
+**What does NOT change in this deploy:**
+
+- Tenant JWT issuer + claims, FORCE RLS posture, Postgres / pgaudit (`fabt-pgaudit:v0.45.0` continues unchanged).
+- Compose file chain — same 5 files; no new override.
+- Prometheus rule files + alertmanager templates — unchanged.
+- Container names — unchanged from v0.55.
+- Reentry-mode UI (V91-V96 surface) — no change.
+- Public demo HTML / PNG screenshots — no v0.56-specific surface needs new captures (operator dashboard is not on the public demo site; admin temperature panel is a cosmetic move only).
+
+**Out of scope (deferred):**
+
+- `info-email-contact` Slice B+ — not yet implemented (only proposal/design phase).
+- GH #67 (in-app issue reporting) — depends on info-email-contact.
+- Drop of the obsoleted per-tenant `tenant.config.observability.{prometheus_enabled, tracing_enabled, tracing_endpoint, monitor_*_interval_minutes}` JSONB keys — kept for backward-read per design D3; v0.58+ Flyway migration drops them after one release cycle of observed-zero-reads in prod.
+- Cross-authenticator MFA QA matrix completion (still tracked at `docs/operations/platform-operator-mfa-compatibility.md`).
+
+---
+
+## 3. Service-Recreate Matrix
+
+| Service (prod container_name) | What triggers recreate | Changed? | Recreate required? |
+|---|---|---|---|
+| `fabt-backend` | New JAR (0.56.0) + new V97-V98 migrations + new endpoints | Yes | Yes |
+| `fabt-frontend` | New bundle (DvPolicySettings + SurgeTemperatureSettings + ObservabilityActionCard + ApiError fix) | Yes | Yes |
+| `finding-a-bed-tonight-postgres-1` | `fabt-pgaudit:v0.45.0` image unchanged; pgaudit.conf unchanged | No | No |
+| `finding-a-bed-tonight-prometheus-1` | No new rules file in `deploy/prometheus/`; no compose-file edit; no inode change | No | No |
+| `finding-a-bed-tonight-alertmanager-1` | No new template; no rendered-secret change | No | No |
+| `finding-a-bed-tonight-{grafana,jaeger,otel-collector}-1` | No dashboard / collector / image change | No | No |
+| Host `nginx` | No `/etc/nginx/sites-available/fabt` edit | No | No |
+
+> **Container-name rule:** `fabt-backend` and `fabt-frontend` carry custom `container_name:` directives in `~/fabt-secrets/docker-compose.prod.yml` (out-of-repo). Postgres and the observability stack use default `<project>-<service>-<replica>` naming. Verified via `docker ps` on the live VM 2026-04-30 (post-v0.55.0 deploy, unchanged in v0.55.1).
+
+---
+
+## 4. Pre-Deploy Gates
+
+- [ ] **pom.xml version bumped** — `cd backend && grep -nE "<version>0\." pom.xml | head -1` should report **0.56.0** at line 16. If still 0.55.0, edit `backend/pom.xml` line 16, commit on the release branch, and re-run `mvn -B -DskipTests clean package -q` to confirm the JAR filename is now `*0.56.0*.jar`. The Spring Boot Maven plugin writes the version into `META-INF/build-info.properties` at package time, which is what `/api/v1/version` reads at runtime.
+- [ ] **Backend tests green** — `cd backend && mvn -B test -q` — expect 1538/1538 passing locally (1414 pre-v0.56 + ~124 new tests across `PlatformObservabilityControllerTest`, `TemperatureThresholdControllerTest`, `PlatformConfigServiceIntegrationTest`, `V97MigrationIntegrationTest`, `DvPolicyControllerTest`, `ShelterServiceDvPolicyInvariantTest`, `TenantPathGuardIntegrationTest`).
+- [ ] **Frontend tests green** — `cd frontend && npm run test:run` — expect 228/228 Vitest (10 new `ObservabilityActionCard.test.ts` + 8 new `SurgeTemperatureSettings.test.ts` covering parseObservabilityError + parseTemperatureError).
+- [ ] **Mocked Playwright suite green locally** — `cd e2e/playwright && BASE_URL=http://localhost:8081 npx playwright test platform-dashboard-inline-flows.spec.ts platform-ui-dashboard.spec.ts platform-training-walkthrough.spec.ts observability.spec.ts --reporter=list` — expect 32/32 against `./dev-start.sh --nginx`. Run through nginx, NOT bare Vite (per `feedback_check_ports_before_assuming.md`).
+- [ ] **Pre-deploy DV-policy backfill scope query** (run on prod DB before deploy):
+
+  ```bash
+  docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -c "
+  SELECT t.slug,
+         COUNT(s.id) FILTER (WHERE s.dv_shelter = true) AS dv_shelter_count,
+         (t.config -> 'dv_policy_enabled')::text AS current_dv_policy_value
+  FROM tenant t
+  LEFT JOIN shelter s ON s.tenant_id = t.id
+  GROUP BY t.id, t.slug, t.config
+  ORDER BY t.slug;"
+  ```
+
+  Use the `fabt` owner role (per `feedback_rls_hides_dv_data` — `fabt_app` would have RLS hide DV shelters from the count). Expected: each of the 3 prod tenants (`dev-coc`, `blueridge`, `mountain` per `project_live_demo_seed_inventory`) shows ≥1 DV shelter and `current_dv_policy_value = NULL` (V97 will set it to `true` for each).
+
+- [ ] **Pre-deploy platform_config check** — confirm the singleton table does not pre-exist:
+
+  ```bash
+  docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc \
+      "SELECT 1 FROM information_schema.tables WHERE table_name='platform_config';"
+  # Expected pre-deploy: empty (V98 has not run yet).
+  ```
+
+- [ ] **CI green** — `gh run list --branch main --limit 5` — all runs green (CodeQL, CI, E2E, Performance, DV Access Control Canary). Already verified `2026-05-03T22:20:45Z` run 25292474449 — RUN_DONE: success.
+- [ ] **Env-var trailing-space lint** — `grep -nE "^FABT_[A-Z_]*= " ~/fabt-secrets/.env.prod` returns NO output. (v0.49 issue #1.)
+- [ ] **Container UID vs perms** — no new bind-mounted files in this deploy; `git checkout v0.56.0` does not introduce new bind-mount paths.
+- [ ] **Compose dry-render (5-file chain)** — see Section 5 for the canonical chain. Run:
+
+  ```bash
+  COMPOSE_CHAIN=(
+      -f docker-compose.yml
+      -f /home/ubuntu/fabt-secrets/docker-compose.prod.yml
+      -f /home/ubuntu/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml
+      -f /home/ubuntu/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml
+      -f /home/ubuntu/fabt-secrets/docker-compose.prod-v0.52-oci-anchor.yml
+  )
+  docker compose "${COMPOSE_CHAIN[@]}" --env-file ~/fabt-secrets/.env.prod \
+      config > /tmp/v0.56.0-config.rendered.yml
+  ```
+
+  **Expected delta from compose-config: ZERO.** No compose file changed in v0.56; the only filesystem changes are inside the backend JAR and the frontend bundle. A non-empty diff against the v0.55 render means a compose file changed unexpectedly.
+
+- [ ] **OCI key path mounted on the VM** — backend env has `FABT_OCI_AUDIT_ANCHOR_PRIVATE_KEY_PATH=/etc/fabt/oci/audit-anchor.pem`. Confirm via `docker inspect fabt-backend | grep -i oci_audit_anchor`.
+- [ ] **pg_dump backup** — `docker exec finding-a-bed-tonight-postgres-1 pg_dump -U fabt -d fabt -Fc > ~/fabt-backups/fabt-pre-v0.56.0-$(date -u +%Y%m%d-%H%M%S).dump`. Restore via `pg_restore`, NOT `psql`.
+- [ ] **Git tag + GitHub release published** — `git tag v0.56.0 && git push origin v0.56.0`, then `gh release create v0.56.0 --generate-notes`. Verify with `gh release view v0.56.0`. The deploy MUST checkout the tag, not main HEAD.
+- [ ] **SSH access confirmed** — open an SSH session to the VM before starting (`ssh -i ~/.ssh/fabt-oracle ubuntu@${FABT_VM_IP}`).
+- [ ] **Local rehearsal PASS** — run `make rehearse-deploy` (or equivalent local sequence) on this branch before tagging. The rehearsal harness exercises the V97 + V98 migrations against a clean DB plus the post-deploy smoke gate.
+
+---
+
+## 5. Deploy Steps
+
+> **Canonical 5-file compose chain** (per memory `project_live_deployment_status.md`, ground-truthed 2026-04-30 via `docker compose ls`). EVERY `docker compose ... up -d` invocation MUST include all five `-f` flags. Missing any one breaks deploy (per `feedback_runbook_compose_chain.md`):
+>
+> ```bash
+> # Define once at the top of the operator session.
+> COMPOSE_CHAIN=(
+>     -f docker-compose.yml
+>     -f /home/ubuntu/fabt-secrets/docker-compose.prod.yml
+>     -f /home/ubuntu/fabt-secrets/docker-compose.prod-v0.43-flyway-ooo.yml
+>     -f /home/ubuntu/fabt-secrets/docker-compose.prod-v0.44-pgaudit.yml
+>     -f /home/ubuntu/fabt-secrets/docker-compose.prod-v0.52-oci-anchor.yml
+> )
+> # Use as `docker compose "${COMPOSE_CHAIN[@]}" ...`
+> ```
+
+> **No static-content scp this release.** v0.56 ships no demo HTML or PNG churn — the new dv-policy and platform-obs surfaces are operator-facing only and do not appear on the public demo site. Skip the `/var/www/findabed-docs/` deploy step entirely.
+
+### 1. Preserve last-good image tags
+
+```bash
+docker tag fabt-backend:latest fabt-backend:v0.55.0-lastgood
+docker tag fabt-frontend:latest fabt-frontend:v0.55.1-lastgood
+docker images | grep -E "fabt-(backend|frontend)"
+# Expected: latest + v0.55.x-lastgood both present (same IMAGE ID, two tags).
+# Note: backend lastgood is v0.55.0 (last backend-rebuild release);
+# frontend lastgood is v0.55.1 (last frontend-rebuild release).
+# These are the rollback-target images for §7.
+```
+
+### 2. Checkout the release tag on the VM
+
+```bash
+cd ~/finding-a-bed-tonight
+git fetch origin --tags
+git checkout v0.56.0
+git log --oneline -1
+# Expected: HEAD on the v0.56.0 tagged commit (detached HEAD is correct).
+```
+
+> **Do NOT `git pull origin main`.** Deployed commit must equal the tag for audit traceability.
+
+### 3. Verify Dockerfile + migration paths landed
+
+```bash
+ls -1 infra/docker/Dockerfile.backend infra/docker/Dockerfile.frontend
+# Expected: both present.
+
+ls -1 backend/src/main/resources/db/migration/V9{7,8}__*.sql
+# Expected:
+#   V97__backfill_dv_policy_enabled.sql
+#   V98__platform_config.sql
+```
+
+### 4. Backend rebuild (clean + no-cache)
+
+```bash
+cd ~/finding-a-bed-tonight/backend
+mvn -B -DskipTests clean package -q
+ls -1 target/*.jar | head -3
+# Expected: exactly one *0.56.0*.jar (fat JAR) plus the .original side-car.
+# More than one fat JAR means `mvn clean` did not run — abort and re-run.
+
+cd ~/finding-a-bed-tonight
+docker build --no-cache \
+    -f infra/docker/Dockerfile.backend \
+    -t fabt-backend:v0.56.0 \
+    -t fabt-backend:latest .
+```
+
+### 5. Frontend rebuild (clean + no-cache)
+
+```bash
+cd ~/finding-a-bed-tonight/frontend
+npm ci
+npm run build
+cd ~/finding-a-bed-tonight
+
+docker build --no-cache \
+    -f infra/docker/Dockerfile.frontend \
+    -t fabt-frontend:v0.56.0 \
+    -t fabt-frontend:latest .
+```
+
+### 6. Bring up backend + frontend
+
+```bash
+docker compose "${COMPOSE_CHAIN[@]}" \
+    --env-file ~/fabt-secrets/.env.prod \
+    up -d --force-recreate backend frontend
+# Postgres + observability stack stay up — they are NOT recreated.
+# `--force-recreate` is required for backend (new JAR) and frontend
+# (new bundle); per `feedback_prod_docker_build_pattern.md` simply
+# rebuilding without recreate leaves the old container running.
+```
+
+### 7. Wait for backend readiness + Flyway forward-progress
+
+```bash
+# Internal management port — actuator binds to 9091 localhost-only.
+TIMEOUT=120
+for i in $(seq 1 $((TIMEOUT/3))); do
+    if curl -fsS http://localhost:9091/actuator/health 2>/dev/null | grep -q '"status":"UP"'; then
+        echo "backend is UP after ${i}x3s"; break
+    fi
+    echo "waiting for backend ($i)..."; sleep 3
+done
+
+# If timeout: dump container logs and ABORT to §7 rollback.
+# docker logs fabt-backend --tail 200
+
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc \
+    "SELECT version, description, success FROM flyway_schema_history ORDER BY installed_rank DESC LIMIT 4;"
+# Expected top 2 rows in descending order:
+#   V98 | platform config                    | t
+#   V97 | backfill dv policy enabled         | t
+# (Description text comes from the migration filename underscore-split.)
+```
+
+> **If the backend does not become UP within 120s**, stop here. Pull `docker logs fabt-backend --tail 200`, look for Flyway errors first. Go to §7 Rollback Matrix.
+
+---
+
+## 6. Post-Deploy Gates
+
+### Mandatory smoke gate
+
+```bash
+cd ~/finding-a-bed-tonight/e2e/playwright && \
+  FABT_BASE_URL=https://findabed.org npx playwright test \
+    --config=deploy/playwright.config.ts --project=chromium \
+    --reporter=list --trace on --retries=1 post-deploy-smoke \
+    2>&1 | tee ../../logs/post-deploy-smoke-v0.56.0.log
+```
+
+> **Do NOT skip this gate.** Smoke is the only test that exercises the full Cloudflare → host nginx → frontend → backend chain. `--retries=1` defends against the rate-limit flake on test 13/14 per `feedback_smoke_config_on_prod.md`.
+
+Expected: 13/15 GREEN, 2 SKIPPED (forgot-password demo branch + 211-import-edit; both dev-only).
+
+### Version check
+
+```bash
+curl -s https://findabed.org/api/v1/version
+# Expected: {"version":"0.56"}
+# NOT "0.56.0" — VersionController strips the patch.
+```
+
+### Flyway HWM
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc \
+    "SELECT max(version::int) FROM flyway_schema_history WHERE success=true;"
+# Expected: 98
+```
+
+### V97 — DV-policy backfill verification
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -c "
+SELECT t.slug,
+       COUNT(s.id) FILTER (WHERE s.dv_shelter = true) AS dv_shelter_count,
+       (t.config -> 'dv_policy_enabled')::text AS dv_policy_value
+FROM tenant t
+LEFT JOIN shelter s ON s.tenant_id = t.id
+GROUP BY t.id, t.slug, t.config
+ORDER BY t.slug;"
+# Expected: every prod tenant with dv_shelter_count >= 1 now shows
+# dv_policy_value = 'true'. Tenants with dv_shelter_count = 0 (if any)
+# show dv_policy_value = NULL (helper defaults to false on absent).
+```
+
+### V98 — platform_config singleton present + seeded
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -c "
+SELECT id, config, updated_by IS NULL AS is_initial_seed
+FROM platform_config;"
+# Expected: exactly 1 row.
+#   id = 00000000-0000-0000-0000-000000000001
+#   config = {
+#     prometheus_enabled: true,
+#     tracing_enabled: false,
+#     tracing_endpoint: 'http://localhost:4318/v1/traces',
+#     monitor_stale_interval_minutes: 5,
+#     monitor_dv_canary_interval_minutes: 15,
+#     monitor_temperature_interval_minutes: 60
+#   }
+#   is_initial_seed = t (no operator has flipped anything yet)
+```
+
+### dv-policy endpoint smoke (login required)
+
+```bash
+# Login as cocadmin@blueridge.fabt.org / dev-coc-west / admin123 (out-of-band token mint), then:
+curl -sS -o /dev/null -w "GET own /tenants/{id}/config: %{http_code}\n" \
+    -H "Authorization: Bearer ${COC_ADMIN_JWT}" \
+    https://findabed.org/api/v1/tenants/${TENANT_ID}/config
+# Expected: 200 (G-4.4 fix from v0.55 still holds).
+
+curl -sS -X PATCH -H "Authorization: Bearer ${COC_ADMIN_JWT}" \
+    -H "Content-Type: application/json" \
+    -d '{"dvPolicyEnabled": true}' \
+    https://findabed.org/api/v1/admin/tenants/${TENANT_ID}/dv-policy
+# Expected: 204 (already true after V97 backfill — idempotent re-set).
+```
+
+### platform-observability endpoint smoke (SSH tunnel + platform login required)
+
+> **SSH tunnel command + platform-operator credentials are shared in chat at deploy time, NOT committed here** (per `feedback_platform_login_via_ssh_tunnel.md`).
+
+```bash
+# After establishing the platform-operator JWT via the SSH tunnel + MFA flow:
+curl -sS -H "Authorization: Bearer ${PLATFORM_JWT}" \
+    https://findabed.org/api/v1/platform/observability
+# Expected: 200 + JSON body matching the V98 seed defaults.
+
+# Verify justification is REQUIRED on writes:
+curl -sS -o /dev/null -w "PUT without justification: %{http_code}\n" \
+    -X PUT -H "Authorization: Bearer ${PLATFORM_JWT}" \
+    -H "Content-Type: application/json" \
+    -d '{"prometheus_enabled": true}' \
+    https://findabed.org/api/v1/platform/observability
+# Expected: 400 (missing X-Platform-Justification — bad_request from
+# JustificationValidationFilter; structured errorCode missing_justification).
+```
+
+### Audit row landed for any platform-obs write performed during gates
+
+```bash
+docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -tAc "
+SELECT event_type, count(*)
+FROM audit_events
+WHERE event_type = 'PLATFORM_OBSERVABILITY_UPDATED'
+  AND timestamp > NOW() - INTERVAL '1 hour'
+GROUP BY event_type;"
+# Expected: 0 if no operator PUT was performed during the gate window;
+# >= 1 if the gate above included a write. Schema confirms the new
+# enum value is registered.
+```
+
+### OperationalMonitorService scheduled tasks loaded
+
+```bash
+docker logs fabt-backend --since 5m 2>&1 | grep -E "OperationalMonitor|configureTasks|stale_interval" | head -10
+# Expected: at least one log line confirming the SchedulingConfigurer
+# bean wired its 3 tasks at startup. The actuator/scheduledtasks
+# endpoint is NOT exposed in the default v0.56 management config; use
+# log-grep as the verification path.
+```
+
+### Stale-SW reminder
+
+If anyone tests the new admin/platform UI from a browser that was logged in pre-deploy, **use incognito or clear site data** (per `feedback_stale_sw_on_deploy.md`).
+
+---
+
+## 7. Rollback Matrix
+
+| Symptom | Action | Time to recover |
+|---|---|---|
+| Backend won't start (Flyway validate error) | Read `docker logs fabt-backend --tail 200` for Flyway specifics first. If a migration broke partway, full DB rollback is the safe path: `docker exec -i finding-a-bed-tonight-postgres-1 pg_restore -U fabt -d fabt --clean --if-exists < ~/fabt-backups/fabt-pre-v0.56.0-<TIMESTAMP>.dump`, then `docker tag fabt-backend:v0.55.0-lastgood fabt-backend:latest && docker compose "${COMPOSE_CHAIN[@]}" up -d --force-recreate backend`. | ~15 min |
+| Backend JAR fails for non-Flyway reasons (NPE on boot, bean wiring) | Image-only rollback. V97-V98 stay applied — both are forward-compatible (V97 sets a JSONB key the v0.55.x backend ignores; V98 creates a new table the v0.55.x backend never reads). `docker tag fabt-backend:v0.55.0-lastgood fabt-backend:latest && docker compose "${COMPOSE_CHAIN[@]}" up -d --force-recreate backend`. | ~5 min |
+| New endpoints return 5xx in steady state | Image-only rollback per row above. The new endpoints disappear; existing tenant flow is unaffected. | ~5 min |
+| Frontend admin/platform surface broken or visually wrong | Frontend image-only rollback: `docker tag fabt-frontend:v0.55.1-lastgood fabt-frontend:latest && docker compose "${COMPOSE_CHAIN[@]}" up -d --force-recreate frontend`. The backend keeps running with the new JAR; new UI surfaces are inaccessible until you rebuild the v0.56 frontend. | ~3 min |
+| Host nginx 502 after backend recreate | Frontend docker-network is stale — recreate frontend too. (Standard remediation per template.) | ~3 min |
+| Frontend serving stale JS post-deploy | Old service worker cached the bundle. Use incognito or clear site data. | <1 min |
+| Operator flipped dv-policy to FALSE on a tenant + needs revert | The flag is a JSONB key — operator can re-flip via the admin UI (or via `psql` UPDATE if the backend is down). The forward-only V97 backfill does not need to be re-run; it only initialized rows with NO existing key. | <1 min |
+| Operator broke the OTel exporter via a bad `tracing_endpoint` URL | Same flow — operator (or DBA) reverts via the platform endpoint or `psql UPDATE platform_config SET config = jsonb_set(config, '{tracing_endpoint}', '"http://localhost:4318/v1/traces"'::jsonb)`. `OperationalMonitorService` does not reschedule on tracing-endpoint change (only on monitor-interval change), so revert takes effect on next OTel export. | <1 min |
+| Full rollback to v0.55.1 | `docker tag fabt-backend:v0.55.0-lastgood fabt-backend:latest && docker tag fabt-frontend:v0.55.1-lastgood fabt-frontend:latest && docker compose "${COMPOSE_CHAIN[@]}" up -d --force-recreate backend frontend`. **V97-V98 are NOT rolled back** — they are additive and forward-compatible with v0.55.x backend. | ~6 min |
+
+> **V97-V98 are one-way migrations.** V97 is a JSONB key write that the v0.55.x backend ignores; V98 is a new table the v0.55.x backend never references. Rolling back the JAR rolls back the calls, not the schema. Full DB rollback via `pg_restore` is the path only when a migration itself fails partway — both v0.56 migrations are simple enough that this is unlikely.
+
+---
+
+## 8. Post-Deploy Housekeeping
+
+> **Run after the deploy succeeds.** A rolled-back deploy means
+> memory should reflect that explicitly (e.g. `v0.56-rolled-back` in
+> the resume-point note) — do NOT pre-record version/Flyway updates
+> below.
+
+- [ ] Update `project_live_deployment_status.md` memory: version `v0.55.1 → v0.56.0`, Flyway HWM `V96 → V98`, new controllers (`DvPolicyController`, `PlatformObservabilityController`, `TemperatureThresholdController`), `/api/v1/version` reports `"0.56"`.
+- [ ] Update `project_resume_point.md` memory per `feedback_periodic_resume_save.md`: dv-policy + platform-obs shipped; remaining backlog items (info-email-contact, GH #67) unblocked for next-cycle.
+- [ ] Tag the just-deployed images for the next release's rollback path: `docker tag fabt-backend:v0.56.0 fabt-backend:v0.56.0-lastgood && docker tag fabt-frontend:v0.56.0 fabt-frontend:v0.56.0-lastgood`.
+- [ ] Update `CHANGELOG.md`: confirm `[v0.56.0] — 2026-MM-DD` date is the actual deploy date.
+- [ ] Archive both spent OpenSpec changes: `/opsx:archive dv-policy-tenant-flag` + `/opsx:archive platform-observability-split`. Sync delta specs into main specs first.
+- [ ] Manual demo walkthrough as cocadmin: admin Settings → DV Shelter Operations panel → toggle (with extra-confirm modal) → save → verify audit row. Confirm the disable-rejection error renders the count + link to filtered Shelters tab when the tenant has active DV shelters.
+- [ ] Manual smoke as platform operator (via SSH tunnel): `/platform` dashboard → Observability category → toggle a Prometheus value or change a monitor interval → confirm the 2-step destructive-confirm modal + per-field audit row + monitor reschedule (interval changes only).
+- [ ] Verify Prometheus rule count is unchanged from pre-deploy:
+  ```bash
+  docker exec finding-a-bed-tonight-prometheus-1 wget -qO- http://localhost:9090/api/v1/rules \
+      | python3 -m json.tool | grep -cE '"name":'
+  ```
+  Expected: same count as pre-deploy. v0.56 does not add rules.
+- [ ] Confirm alert names are unchanged (alertmanager template chain is unmodified in v0.56).
+- [ ] Append the v0.56 platform-obs Spanish keys (`admin.observability.thresholdDescription`, `thresholdError`, `confirmTitle`, `confirmBody`) to `reference_es_json_ai_synthetic_reviewed.md` memory — AI-synthetic review, not a native speaker. Same disclosure conventions as v0.55.1 D2.
+- [ ] Delete or expire any test alerts fired during deploy verification.
+
+---
+
+## Related artifacts
+
+- OpenSpec changes:
+  - `openspec/changes/dv-policy-tenant-flag/` (in the docs repo — full proposal, design, tasks, runbook-fragments)
+  - `openspec/changes/platform-observability-split/` (in the docs repo — full proposal, design, tasks)
+- Operator user guide updates: `docs/operations/platform-operator-user-guide.md` Observability configuration section (NEW)
+- CHANGELOG: `CHANGELOG.md` `[v0.56.0]` section (both changes)
+- Backend migrations:
+  - `backend/src/main/resources/db/migration/V97__backfill_dv_policy_enabled.sql`
+  - `backend/src/main/resources/db/migration/V98__platform_config.sql`
+- New backend controllers:
+  - `backend/src/main/java/org/fabt/tenant/api/DvPolicyController.java`
+  - `backend/src/main/java/org/fabt/observability/api/PlatformObservabilityController.java`
+  - `backend/src/main/java/org/fabt/tenant/api/TemperatureThresholdController.java`
+- New frontend components:
+  - `frontend/src/pages/admin/components/DvPolicySettings.tsx`
+  - `frontend/src/pages/admin/components/SurgeTemperatureSettings.tsx`
+  - `frontend/src/pages/platform/components/ObservabilityActionCard.tsx`
+- New Playwright spec: `e2e/playwright/tests/platform-dashboard-inline-flows.spec.ts`
+- Pull requests: code repo PR #173 (dv-policy) + PR #174 (platform-obs); docs repo PR #10 + PR #11
+
+---
+
+*FABT Deploy Runbook v0.56.0 — follows template v1 (`docs/runbook-template.md`)*

--- a/docs/schema.dbml
+++ b/docs/schema.dbml
@@ -1,8 +1,8 @@
 // ============================================================================
 // Finding A Bed Tonight (FABT) — Database Schema
-// Source: live PostgreSQL @ Flyway HWM V95 (transitional-reentry-support
-//         + reentry-release-readiness)
-// Last synced: 2026-04-30 (regenerated via pg_dump + sql2dbml + curated
+// Source: live PostgreSQL @ Flyway HWM V98 (dv-policy-tenant-flag +
+//         platform-observability-split)
+// Last synced: 2026-05-03 (regenerated via pg_dump + sql2dbml + curated
 //         enum/Project preservation per `feedback_update_docs_with_code`)
 // ============================================================================
 
@@ -461,6 +461,15 @@ Table "platform_admin_access_log" {
     (platform_user_id, timestamp) [type: btree, name: "platform_admin_access_log_user_time"]
   }
   Note: 'Phase G-4.3 platform-admin audit ledger. Append-only via REVOKE UPDATE/DELETE + BEFORE-mutate trigger. Written by the @PlatformAdminOnly AOP aspect alongside an audit_events row in a single REQUIRES_NEW transaction. Compliance queries: see docs/runbook.md. WARNING: an audit row indicates the action was ATTEMPTED, not necessarily completed — for actual completion correlate via audit_event_id against application logs at the same correlation window.'
+}
+
+Table "platform_config" {
+  "id" uuid [pk, not null, default: `'00000000-0000-0000-0000-000000000001'::uuid`, note: 'Singleton row id enforced by platform_config_singleton CHECK constraint.']
+  "config" jsonb [not null, default: `'{}'::jsonb`, note: 'Platform-wide observability + scheduler config. Schema (informally enforced by PlatformConfig record + endpoint validation): prometheus_enabled (bool), tracing_enabled (bool), tracing_endpoint (string URL), monitor_stale_interval_minutes (int 1..1440), monitor_dv_canary_interval_minutes (int 1..1440), monitor_temperature_interval_minutes (int 1..1440). Bounds enforced by the controller, not at the DB layer (design D4).']
+  "updated_at" timestamp [not null, default: `now()`]
+  "updated_by" uuid [note: 'platform_user.id of the operator who last applied a change, or NULL for the initial-seed row. Cross-references the audit_events row for each PLATFORM_OBSERVABILITY_UPDATED emission.']
+
+  Note: 'Platform-wide observability + scheduler config (V98, platform-observability-split, 2026-05). Single-row table enforced by the platform_config_singleton CHECK constraint. Read by PlatformConfigService at startup + on every monitor reschedule; written by PUT /api/v1/platform/observability (PLATFORM_OPERATOR + @PlatformAdminOnly + X-Platform-Justification header). Houses the 6 tenant-agnostic fields the /admin#observability tab used to (incorrectly) store per-tenant — temperature_threshold_f stays per-tenant via /admin#surge.'
 }
 
 Table "platform_key_material" {


### PR DESCRIPTION
## Summary

Documentation prep for the v0.56.0 deploy bundling **dv-policy-tenant-flag** + **platform-observability-split** (both already merged to main).

- `backend/pom.xml`: 0.55.0 → 0.56.0 (drives JAR filename + `/api/v1/version` reporting `"0.56"`)
- `CHANGELOG.md`: rename Unreleased → `[v0.56.0] — 2026-05-03`; add `### platform-observability-split` section alongside the existing dv-policy section; drop the stale info-email-contact + GH #67 bundle line (deferred)
- `docs/oracle-update-notes-v0.56.0.md`: NEW deploy runbook per template v1, sourced from `runbook-fragments.md` (V97 backfill SQL + onboarding sequence + rollback policy) + V98 migration body (singleton CHECK + seed defaults) + `project_live_deployment_status` ground-truth (5-file compose chain, container names, image tags)
- `docs/schema.dbml`: add `platform_config` singleton table; bump HWM comment V95 → V98
- `docs/operations/platform-operator-user-guide.md`: NEW section 9 covering the new inline-edit Observability cards on the Platform Operator Dashboard (toggle / number / url field types per W3C ARIA APG, danger-level handling, where the temperature threshold lives now)

Backend `mvn clean package -DskipTests` produces `finding-a-bed-tonight-0.56.0.jar` — pom bump verified.

## Test plan

- [ ] CI green on this branch (CodeQL, CI, E2E, Performance, DV Access Control Canary)
- [ ] Local rehearsal `make rehearse-deploy` against this branch — exercises V97 + V98 against a clean DB
- [ ] After CI green: tag v0.56.0 on this branch, push tag, `gh release create v0.56.0 --generate-notes`
- [ ] Then VM deploy per the new runbook; smoke gate Playwright vs findabed.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)