### PR TITLE
fix(audit): bind SYSTEM_TENANT_ID in scheduled hold-attribution purge (#177)

### DIFF
--- a/backend/src/main/java/org/fabt/referral/service/ReferralTokenPurgeService.java
+++ b/backend/src/main/java/org/fabt/referral/service/ReferralTokenPurgeService.java
@@ -92,23 +92,33 @@ public class ReferralTokenPurgeService {
      *       overlap by construction.</li>
      * </ol>
      *
-     * <p>Same TenantContext binding pattern as the DV referral purge above
-     * (system context + dvAccess=true) — the reservation table has FORCE
-     * RLS that joins through shelter, so dvAccess is required to cover
-     * both DV and non-DV reservations cross-tenant. The repository's SQL
-     * is no-op on rows whose ciphertext is already null, so re-runs cost
-     * nothing on already-purged rows.
+     * <p>The reservation table has FORCE RLS that joins through shelter, so
+     * dvAccess=true is required to cover both DV and non-DV reservations
+     * cross-tenant. The repository's SQL is no-op on rows whose ciphertext
+     * is already null, so re-runs cost nothing on already-purged rows.
      *
      * <p>Null-safe on pre-V93 databases: the SQL references the new
      * {@code _encrypted} columns by name, so a pre-V93 DB will fail with
      * a column-not-found error rather than silently no-op. In practice
      * this is fine — V91-V94 ship together in slice-1 of reentry-spec,
      * so any prod DB running v0.55+ has the columns.
+     *
+     * <p><b>v0.57.2 GH #177:</b> binds {@link TenantContext#SYSTEM_TENANT_ID}
+     * explicitly. The downstream {@code RESERVATION_PII_PURGED} audit row
+     * (emitted by {@code ReservationService.purgeExpiredHoldAttribution})
+     * needs a non-null tenant context so the FORCE-RLS INSERT on
+     * {@code audit_events} succeeds via the explicit-bind path rather than
+     * the SYSTEM_TENANT_ID fallback in {@code AuditEventService.onAuditEvent}.
+     * The fallback path increments {@code fabt.audit.system_insert.count}
+     * which trips the {@code FabtPhaseBSystemTenantFallback} alert
+     * (Phase B silent-audit-write runbook). The action is legitimately
+     * platform-scope (one summary row per scheduled invocation), so
+     * SYSTEM_TENANT_ID is the correct binding.
      */
     @TenantUnscoped("15-minute retention purge — platform-wide by hold-attribution PII retention design (v0.55 §13.C.1)")
     @Scheduled(fixedDelay = 900_000)
     public void purgeExpiredHoldAttribution() {
-        TenantContext.runWithContext(TenantContext.getTenantId(), true, () -> {
+        TenantContext.runWithContext(TenantContext.SYSTEM_TENANT_ID, true, () -> {
             Instant cutoff = Instant.now().minus(PURGE_AGE);
             // v0.55 §13.A.4 — service-layer call now emits the
             // RESERVATION_PII_PURGED audit row internally regardless of

--- a/backend/src/test/java/org/fabt/reservation/HoldAttributionIntegrationTest.java
+++ b/backend/src/test/java/org/fabt/reservation/HoldAttributionIntegrationTest.java
@@ -12,6 +12,8 @@ import java.util.UUID;
 
 import org.fabt.BaseIntegrationTest;
 import org.fabt.TestAuthHelper;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.search.Search;
 import org.fabt.referral.service.ReferralTokenPurgeService;
 import org.fabt.reservation.repository.ReservationRepository;
 import org.fabt.reservation.service.ReservationService;
@@ -19,6 +21,7 @@ import org.fabt.shared.security.CrossTenantCiphertextException;
 import org.fabt.shared.security.EncryptionEnvelope;
 import org.fabt.shared.security.KeyPurpose;
 import org.fabt.shared.security.SecretEncryptionService;
+import org.fabt.shared.web.TenantContext;
 import org.fabt.shelter.api.ShelterResponse;
 import org.fabt.testsupport.WithTenantContext;
 import org.junit.jupiter.api.BeforeEach;
@@ -71,6 +74,7 @@ class HoldAttributionIntegrationTest extends BaseIntegrationTest {
     @Autowired private ReservationService reservationService;
     @Autowired private ReferralTokenPurgeService referralTokenPurgeService;
     @Autowired private SecretEncryptionService encryptionService;
+    @Autowired private MeterRegistry meterRegistry;
 
     private UUID tenantId;
     private UUID shelterId;
@@ -784,6 +788,60 @@ class HoldAttributionIntegrationTest extends BaseIntegrationTest {
         assertThat(after.get("notes_enc"))
                 .as("@Scheduled entry must null notes ciphertext for an aged row")
                 .isNull();
+    }
+
+    @Test
+    @DisplayName("GH #177 @Scheduled purgeExpiredHoldAttribution binds SYSTEM_TENANT_ID explicitly "
+            + "(no fabt.audit.system_insert.count fallback)")
+    void scheduledEntryPoint_doesNotIncrementSystemFallbackCounter() {
+        // GH #177 regression guard. Pre-fix, ReferralTokenPurgeService:111
+        // wrapped in runWithContext(TenantContext.getTenantId(), ...) where
+        // getTenantId() is null on the scheduler thread → tenantId=null bound
+        // → downstream RESERVATION_PII_PURGED audit row hit the SYSTEM_TENANT_ID
+        // FALLBACK path in AuditEventService.onAuditEvent → counter
+        // fabt.audit.system_insert.count{action=RESERVATION_PII_PURGED}
+        // incremented on every invocation → FabtPhaseBSystemTenantFallback
+        // alert fired at ~1 event per 14.7 min on prod 2026-05-05.
+        //
+        // Fix binds TenantContext.SYSTEM_TENANT_ID explicitly; the audit row
+        // still lands under the SYSTEM tenant (legitimate platform-scope
+        // action) but via the explicit-bind path, so the counter stays flat.
+        // The counter is the canonical fallback signal — asserting on
+        // tenant_id alone is insufficient because both the bug state AND the
+        // fix state produce tenant_id=SYSTEM_TENANT_ID rows. Only the counter
+        // distinguishes them.
+        double counterBefore = systemInsertCounterValue("RESERVATION_PII_PURGED");
+
+        // Call the @Scheduled entry from outside any TenantContext — exactly
+        // what Spring's TaskScheduler does in production.
+        referralTokenPurgeService.purgeExpiredHoldAttribution();
+
+        double counterAfter = systemInsertCounterValue("RESERVATION_PII_PURGED");
+        assertThat(counterAfter - counterBefore)
+                .as("Scheduled purge MUST bind SYSTEM_TENANT_ID explicitly so the audit "
+                    + "row writes via the explicit-bind path, NOT the fallback path. If this "
+                    + "increments, the GH #177 regression is back and the FabtPhaseBSystemTenantFallback "
+                    + "alert will fire on prod within 30 min of next deploy.")
+                .isEqualTo(0.0);
+
+        // Defense-in-depth: the row IS expected to land with tenant_id=SYSTEM_TENANT_ID
+        // (the action is legitimately platform-scope), so confirm it landed there
+        // via the explicit-bind path the counter assertion just proved.
+        Integer matchingRows = WithTenantContext.readAsSystem(() -> jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM audit_events "
+                + "WHERE action = 'RESERVATION_PII_PURGED' AND tenant_id = ?::uuid",
+                Integer.class, TenantContext.SYSTEM_TENANT_ID));
+        assertThat(matchingRows)
+                .as("at least one RESERVATION_PII_PURGED row must exist under SYSTEM_TENANT_ID")
+                .isGreaterThanOrEqualTo(1);
+    }
+
+    private double systemInsertCounterValue(String action) {
+        Search search = meterRegistry.find("fabt.audit.system_insert.count").tag("action", action);
+        if (search.counter() == null) {
+            return 0.0;
+        }
+        return search.counter().count();
     }
 
     @Test


### PR DESCRIPTION
## Summary

Closes #177.

`ReferralTokenPurgeService.purgeExpiredHoldAttribution` was wrapping its body in `runWithContext(TenantContext.getTenantId(), ...)` from the `@Scheduled` thread, where `getTenantId()` is null. The downstream `RESERVATION_PII_PURGED` audit row hit the SYSTEM_TENANT_ID **fallback** path in `AuditEventService.onAuditEvent`, incrementing `fabt.audit.system_insert.count` and tripping the `FabtPhaseBSystemTenantFallback` warning alert on prod 2026-05-05 12:04 UTC.

Bind `TenantContext.SYSTEM_TENANT_ID` explicitly. The action is legitimately platform-scope (one summary row per scheduled invocation), so the row still lands under the SYSTEM tenant — but via the explicit-bind path, so the counter stays flat and the alert auto-resolves within 30 min of next deploy.

## Sweep verified

| Site | Audit emit? | Action |
|------|-------------|--------|
| `ReferralTokenService:110` (gauge) | NO — read-only `countAllPending` SELECT | skip |
| `ReferralTokenService:287` (`expireTokens`) | NO — Marcus M4 Javadoc documents intentional, only DomainEvents | skip |
| `ReferralTokenPurgeService:50` (`purgeTerminalTokens`) | NO — class Javadoc: "No audit trail of individual referrals survives — VAWA compliance" | skip |
| `ReferralTokenPurgeService:111` (`purgeExpiredHoldAttribution`) | YES — `RESERVATION_PII_PURGED` via `ReservationService` | **THIS FIX** |

## Regression test

`HoldAttributionIntegrationTest#scheduledEntryPoint_doesNotIncrementSystemFallbackCounter` asserts the canonical fallback signal — `fabt.audit.system_insert.count{action=RESERVATION_PII_PURGED}` counter delta equals 0 across the @Scheduled invocation — plus a defense-in-depth tenant_id assertion.

Sanity-checked locally: temporarily reverted the one-liner and confirmed the test FAILS with `expected: 0.0 but was: 1.0`. With the fix in place, it PASSES.

## Test plan

- [x] `mvn test -Dtest='HoldAttributionIntegrationTest#scheduledEntryPoint_doesNotIncrementSystemFallbackCounter'` — green with fix, RED with bug-state revert
- [x] `mvn test -Dtest='*Reservation*Test,*Referral*Test,*HoldAttribution*,*AuditEvent*Test'` — 211 tests, 0 failures, 0 errors
- [ ] Full backend suite via CI on this PR
- [ ] Post-deploy: `rate(fabt_audit_system_insert_count_total[15m])` for `RESERVATION_PII_PURGED` flatlines within 30 min
- [ ] Post-deploy: `FabtPhaseBSystemTenantFallback` alert auto-resolves

## Why TICKET-tier (not blocking hotfix)

Per `docs/security/phase-b-silent-audit-write-failures-runbook.md` page-vs-ticket decision tree:
- ✅ Audit rows landing (under sentinel via fallback, not lost — forensics intact)
- ✅ Action is scheduled-job (`RESERVATION_PII_PURGED`), not request-path
- ✅ Rate matches schedule cadence (~1 per 15 min)
- ✅ No `42501` RLS-rejection in logs

Bundling for v0.57.2 alongside SSE flake fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)