### PR TITLE
fix(sse): value-conditional emitter cleanup (sseCatchup flake)

### DIFF
--- a/backend/src/main/java/org/fabt/notification/service/NotificationService.java
+++ b/backend/src/main/java/org/fabt/notification/service/NotificationService.java
@@ -96,38 +96,28 @@ public class NotificationService {
         }
 
         SseEmitter emitter = new SseEmitter(EMITTER_TIMEOUT_MS);
+        EmitterEntry myEntry = new EmitterEntry(emitter, userId, tenantId, roles, dvAccess);
 
-        // Idempotent cleanup — Spring may fire onCompletion after onTimeout/onError,
-        // so cleanup can be called multiple times per emitter. Only decrement the gauge once.
-        Runnable cleanup = () -> {
-            if (emitters.remove(userId) != null) {
-                activeConnections.decrementAndGet();
-                log.debug("SSE emitter removed for user {}", userId);
-            }
-        };
-
-        // Spring #33421/#33340: register all three callbacks to prevent deadlock and leaks.
-        // Callbacks must be idempotent — heartbeat/sendEvent may have already removed the
-        // emitter from the map before these callbacks fire asynchronously (Design D5).
-        emitter.onCompletion(() -> {
-            if (emitters.containsKey(userId)) {
-                cleanup.run();
-            }
-        });
+        // Spring #33421/#33340: register all three callbacks to prevent deadlock and
+        // leaks. Each callback dispatches into removeEmitterIfMatches(userId, myEntry),
+        // which uses ConcurrentHashMap.remove(key, value) so a STALE callback (firing
+        // after a newer emitter has been registered for the same userId on reconnect)
+        // is a no-op rather than evicting the newer entry. This was the root cause of
+        // the SseCatchupDeliversUnreadNotifications flake: emitter1.complete()
+        // scheduled onCompletion async; before it fired, register() re-entered and
+        // put emitter2 under the same key; emitter1's stale callback then removed
+        // emitter2 by key, breaking catch-up delivery.
+        emitter.onCompletion(() -> removeEmitterIfMatches(userId, myEntry));
         emitter.onTimeout(() -> {
             log.warn("SSE emitter timed out for user {}", userId);
-            if (emitters.containsKey(userId)) {
-                cleanup.run();
-            }
+            removeEmitterIfMatches(userId, myEntry);
         });
         emitter.onError(e -> {
             log.warn("SSE emitter error for user {}: {}", userId, e.getClass().getSimpleName());
-            if (emitters.containsKey(userId)) {
-                cleanup.run();
-            }
+            removeEmitterIfMatches(userId, myEntry);
         });
 
-        emitters.put(userId, new EmitterEntry(emitter, userId, tenantId, roles, dvAccess));
+        emitters.put(userId, myEntry);
         activeConnections.incrementAndGet();
 
         // Send initial connection event with retry field and monotonic id
@@ -148,6 +138,30 @@ public class NotificationService {
 
         log.debug("SSE emitter registered for user {} (tenant {})", userId, tenantId);
         return emitter;
+    }
+
+    /**
+     * Value-conditional cleanup. Removes the emitter entry for {@code userId}
+     * iff the currently-registered entry equals {@code expectedEntry}. A stale
+     * callback (e.g. emitter1.onCompletion firing after register() has put
+     * emitter2 under the same key) is a no-op. Idempotent: if multiple
+     * lifecycle callbacks (onCompletion + onTimeout + onError) fire for the
+     * same emitter, only the first decrements the active-connections gauge.
+     *
+     * <p>Public for {@link org.fabt.notification.SseStabilityTest} (sibling
+     * package) to exercise the stale-callback path deterministically without
+     * depending on Spring's async DeferredResult callback scheduling. Not
+     * intended for any production caller — production code reaches this only
+     * via the lifecycle callbacks wired in {@link #register}.</p>
+     */
+    public boolean removeEmitterIfMatches(UUID userId, EmitterEntry expectedEntry) {
+        if (emitters.remove(userId, expectedEntry)) {
+            activeConnections.decrementAndGet();
+            log.debug("SSE emitter removed for user {}", userId);
+            return true;
+        }
+        log.debug("Stale SSE cleanup for user {} ignored — newer emitter is registered", userId);
+        return false;
     }
 
     /**

--- a/backend/src/test/java/org/fabt/notification/SseStabilityTest.java
+++ b/backend/src/test/java/org/fabt/notification/SseStabilityTest.java
@@ -1,5 +1,6 @@
 package org.fabt.notification;
 
+import java.util.Map;
 import java.util.UUID;
 
 import io.micrometer.core.instrument.MeterRegistry;
@@ -10,6 +11,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -75,5 +77,74 @@ class SseStabilityTest extends BaseIntegrationTest {
         assertThat(meterRegistry.find("fabt.sse.connections.active").gauge()).isNotNull();
         assertThat(meterRegistry.find("sse.send.failures.total").counter()).isNotNull();
         assertThat(meterRegistry.find("sse.event.delivery.duration").timer()).isNotNull();
+    }
+
+    /**
+     * Regression guard for the SseCatchupDeliversUnreadNotifications flake.
+     *
+     * <p>Pre-fix shape of the bug: each {@code register()} captured a {@code Runnable
+     * cleanup} closure that called {@code emitters.remove(userId)} (by KEY only). When
+     * a user reconnected, the previous emitter's {@code complete()} scheduled its
+     * onCompletion callback to fire async via Spring's DeferredResult lifecycle. If
+     * the new {@code register()} put a new entry under the same key BEFORE that stale
+     * callback fired, the callback would still {@code remove(userId)} — evicting the
+     * newer entry. The next {@code pushNotification(userId, ...)} then silently
+     * no-op'd (entry == null path), the catch-up never delivered, and the latch in
+     * {@code SseNotificationIntegrationTest.sseCatchupDeliversUnreadNotifications}
+     * timed out at exactly 5.020s.
+     *
+     * <p>The fix routes all three lifecycle callbacks through
+     * {@link NotificationService#removeEmitterIfMatches(UUID, NotificationService.EmitterEntry)},
+     * which uses {@code ConcurrentHashMap.remove(key, value)}. This test invokes the
+     * stale-callback path directly — no async timing required.
+     */
+    @Test
+    @DisplayName("Stale lifecycle callback for retired emitter does not evict the current entry (GH SSE flake fix)")
+    void test_staleCleanupCallback_doesNotEvictNewerEmitter() {
+        UUID userId = UUID.randomUUID();
+        UUID tenantId = authHelper.getTestTenantId();
+        String[] roles = new String[]{"COORDINATOR"};
+
+        // First register — emitter1 + entry1 land in the map
+        notificationService.register(userId, tenantId, roles, false, null);
+        @SuppressWarnings("unchecked")
+        Map<UUID, NotificationService.EmitterEntry> emitters =
+                (Map<UUID, NotificationService.EmitterEntry>)
+                        ReflectionTestUtils.getField(notificationService, "emitters");
+        assertThat(emitters).isNotNull();
+        NotificationService.EmitterEntry entry1 = emitters.get(userId);
+        assertThat(entry1).as("entry1 must be in the map after first register").isNotNull();
+
+        // Second register — emitter2 + entry2 replace entry1
+        notificationService.register(userId, tenantId, roles, false, null);
+        NotificationService.EmitterEntry entry2 = emitters.get(userId);
+        assertThat(entry2).as("entry2 must be in the map after second register").isNotNull();
+        assertThat(entry2)
+                .as("second register must produce a distinct EmitterEntry — equals() compares all record components incl. SseEmitter identity")
+                .isNotEqualTo(entry1);
+
+        // Simulate emitter1's stale lifecycle callback firing AFTER emitter2 is registered.
+        // This is the bug shape: pre-fix, this would call emitters.remove(userId) by KEY
+        // and evict entry2. Post-fix, it's a no-op because entry1 != current value.
+        boolean removed = notificationService.removeEmitterIfMatches(userId, entry1);
+        assertThat(removed)
+                .as("stale callback for retired entry1 must NOT remove anything — it is value-conditional now")
+                .isFalse();
+
+        // The newer entry MUST still be the current one. Pre-fix this assertion would
+        // fail with entry2 evicted from the map.
+        NotificationService.EmitterEntry afterStale = emitters.get(userId);
+        assertThat(afterStale)
+                .as("entry2 must survive a stale callback fired by emitter1's lifecycle (was the GH SSE flake root cause)")
+                .isEqualTo(entry2);
+
+        // The legitimate cleanup (callback fired by emitter2's own lifecycle) is still wired.
+        boolean removedLive = notificationService.removeEmitterIfMatches(userId, entry2);
+        assertThat(removedLive)
+                .as("legitimate callback for live entry2 MUST remove it")
+                .isTrue();
+        assertThat(emitters.get(userId))
+                .as("after live callback fires, the entry is gone")
+                .isNull();
     }
 }


### PR DESCRIPTION
## Summary

Fixes the intermittent `SseNotificationIntegrationTest.sseCatchupDeliversUnreadNotifications` flake (CI run 25373703706 — 5.020s timeout at line 428). The original memory-based hypothesis ("close-race in a DIFFERENT test, fix with bounded-read + IOException suppression") was wrong; this PR is grounded in the actual surefire output.

## Root cause

`NotificationService.register` (`backend/src/main/java/org/fabt/notification/service/NotificationService.java`) captured a `Runnable cleanup` closure that called `emitters.remove(userId)` **by KEY only**. When a user reconnected:

1. Test A (or real prod reconnect) leaves emitter1 in the map; test/teardown calls `emitter1.complete()`, scheduling its `onCompletion` callback to fire async via Spring's `DeferredResult` lifecycle.
2. Test B re-enters `register(coordinatorId, ...)` (idempotent `setupTestTenant("sse-test")` + `setupCoordinatorUser()` produce the same `userId` across tests), removing emitter1's entry and putting **emitter2** under the same key. Sends "connected" event.
3. Catch-up virtual thread starts: `findUnreadForCatchup` → `pushNotification`.
4. **Meanwhile**, emitter1's stale `onCompletion` finally fires. The closure's `emitters.remove(userId)` evicts **emitter2** (the wrong entry).
5. `pushNotification` looks up the user's emitter → null → silent `return` at line 462-463.
6. Latch never trips → exactly 5.020s timeout → assertion fails.

Intermittent because the bug fires only when emitter1's onCompletion lands AFTER emitter2's catch-up runs — JVM thread scheduling determines that.

The IOException stack trace from the same CI log (`sseCatchupDeliversInSeverityOrder:464`) was misleading — that came from a DIFFERENT, *passing* test emitting noisy stderr during teardown close. Decoupled from the actual failure.

## Fix

Route all three lifecycle callbacks (`onCompletion` / `onTimeout` / `onError`) through `removeEmitterIfMatches(userId, expectedEntry)`, which uses `ConcurrentHashMap.remove(key, value)`. Stale callbacks for retired `EmitterEntry` instances are now no-ops — they cannot evict the current entry.

```java
// BEFORE — KEY-only remove, race-prone
Runnable cleanup = () -> {
    if (emitters.remove(userId) != null) { activeConnections.decrementAndGet(); }
};
emitter.onCompletion(() -> { if (emitters.containsKey(userId)) cleanup.run(); });

// AFTER — value-conditional, atomic, race-safe
EmitterEntry myEntry = new EmitterEntry(emitter, userId, tenantId, roles, dvAccess);
emitter.onCompletion(() -> removeEmitterIfMatches(userId, myEntry));
emitter.onTimeout(() -> { log.warn(...); removeEmitterIfMatches(userId, myEntry); });
emitter.onError(e -> { log.warn(...); removeEmitterIfMatches(userId, myEntry); });

public boolean removeEmitterIfMatches(UUID userId, EmitterEntry expectedEntry) {
    if (emitters.remove(userId, expectedEntry)) {
        activeConnections.decrementAndGet();
        return true;
    }
    return false;  // stale — newer entry is live
}
```

## Regression test

`SseStabilityTest#test_staleCleanupCallback_doesNotEvictNewerEmitter` exercises the bug shape deterministically — no async timing required:

1. `register(userId)` → entry1 in map
2. `register(userId)` → entry2 replaces entry1
3. Directly invoke `removeEmitterIfMatches(userId, entry1)` — simulates the stale callback firing AFTER the new emitter was registered
4. Assert entry2 still in map (the bug: entry2 was evicted)
5. Assert legitimate cleanup for entry2 still works

**Sanity-checked**: temporarily reverted the value-conditional remove and confirmed the test FAILS with entry2 evicted from the map. With the fix in place, all 5 SseStabilityTest tests + 67 tests across notification/sse/reservation packages pass.

## Test plan

- [x] `mvn test -Dtest='SseStabilityTest#test_staleCleanupCallback_doesNotEvictNewerEmitter'` green with fix, RED with bug-state revert
- [x] `mvn test -Dtest='*Notification*,*Sse*,*Reservation*Test'` — 67 tests, 0 failures, 0 errors
- [ ] Full backend suite via CI on this PR
- [ ] `sseCatchupDeliversUnreadNotifications` no longer flakes — watch CI for 3+ runs without it failing

## Notes

The memory entry `project_sse_catchup_severity_order_flake.md` has the wrong test name + wrong root-cause hypothesis. Will be rewritten post-merge with corrected ground truth.

Bundling alongside #178 for v0.57.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)