### PR TITLE
chore(rehearsal): version-match + env-passthrough gates (v0.57.2)

### DIFF
--- a/deploy/rehearsal-prod-overlay.yml
+++ b/deploy/rehearsal-prod-overlay.yml
@@ -54,6 +54,10 @@ services:
       FABT_WEBHOOK_CONNECT_TIMEOUT_SECONDS: ${FABT_WEBHOOK_CONNECT_TIMEOUT_SECONDS}
       FABT_WEBHOOK_READ_TIMEOUT_SECONDS: ${FABT_WEBHOOK_READ_TIMEOUT_SECONDS}
       FABT_PANIC_ALERT_WEBHOOK: ${FABT_PANIC_ALERT_WEBHOOK:-}
+      # info-email-contact (v0.57): mirrors the prod compose `environment:`
+      # block. v0.57.0 deploy aborted because this mapping was missing in prod;
+      # rehearsal now enforces parity via Step 8.7 env-passthrough assertion.
+      FABT_PLATFORM_CONTACT_EMAIL: ${FABT_PLATFORM_CONTACT_EMAIL}
     depends_on:
       postgres:
         condition: service_healthy

--- a/deploy/rehearsal.env.example
+++ b/deploy/rehearsal.env.example
@@ -38,6 +38,14 @@ FABT_CORS_ALLOWED_ORIGINS=http://localhost:18081
 # ── Deployment tier ───────────────────────────────────────────────────────────
 FABT_DEPLOYMENT_TIER=lite
 
+# ── Platform contact email (info-email-contact, v0.57) ────────────────────────
+# Surfaces in the public footer + login-page CTA. application.yml has an empty
+# default, but the prod compose chain MUST map this var explicitly so the
+# container sees it (the v0.57.0 deploy abort happened because .env.prod was
+# updated but the prod compose `environment:` block was not — the rehearsal
+# env-passthrough gate now catches that drift).
+FABT_PLATFORM_CONTACT_EMAIL=rehearsal-contact@example.test
+
 # ── NOAA weather (optional — defaults to Raleigh-Durham coords if unset) ──────
 FABT_NOAA_LAT=35.8776
 FABT_NOAA_LON=-78.7875

--- a/scripts/deploy-rehearsal.sh
+++ b/scripts/deploy-rehearsal.sh
@@ -317,6 +317,79 @@ done
 
 [[ $FAIL -eq 1 ]] && { echo -e "${RED}REHEARSAL FAIL — DO NOT TAG${NC} (gate: $FAIL_GATE) — artifacts: $ARTIFACT_DIR" >&2; exit 1; }
 
+# ── Step 8.6: Version match (catches v0.57.0 issue: pom not bumped on tag) ────
+# /api/v1/version returns major.minor (VersionController strips patch). The
+# value comes from BuildProperties → META-INF/build-info.properties → pom.xml
+# at mvn-package time. If the operator forgets to bump pom.xml on a release
+# tag, the JAR ships with the prior version baked in and prod silently runs
+# the wrong version. Rehearsal MUST refuse to greenlight that state.
+log "=== Step 8.6: Version-match assertion (pom.xml vs /api/v1/version) ==="
+EXPECTED_MAJOR_MINOR=$(grep -m1 -E '^    <version>' "$REPO_ROOT/backend/pom.xml" \
+    | sed -E 's|.*<version>([0-9]+\.[0-9]+).*|\1|')
+if [[ -z "$EXPECTED_MAJOR_MINOR" || ! "$EXPECTED_MAJOR_MINOR" =~ ^[0-9]+\.[0-9]+$ ]]; then
+    fail "VERSION_PARSE" "Could not parse major.minor from backend/pom.xml <version> line"
+else
+    ACTUAL_VERSION=$(curl -sf "http://localhost:18080/api/v1/version" 2>/dev/null \
+        | jq -r '.version // empty' 2>/dev/null || true)
+    if [[ -z "$ACTUAL_VERSION" ]]; then
+        fail "VERSION_FETCH" "/api/v1/version returned empty/missing version field"
+    elif [[ "$ACTUAL_VERSION" != "$EXPECTED_MAJOR_MINOR" ]]; then
+        fail "VERSION_MISMATCH" \
+            "/api/v1/version returned '${ACTUAL_VERSION}' but pom.xml says '${EXPECTED_MAJOR_MINOR}' — pom not bumped before tag (v0.57.0 abort cause #1)"
+    else
+        ok "Version endpoint matches pom.xml ($ACTUAL_VERSION)"
+    fi
+fi
+
+[[ $FAIL -eq 1 ]] && { echo -e "${RED}REHEARSAL FAIL — DO NOT TAG${NC} (gate: $FAIL_GATE) — artifacts: $ARTIFACT_DIR" >&2; exit 1; }
+
+# ── Step 8.7: Env-var passthrough (catches v0.57.0 issue: missing env mapping) ─
+# .env.rehearsal sets a value, the prod-overlay's `environment:` block maps it
+# into the container, and `docker exec env` proves it reached the JVM. The
+# v0.57.0 abort happened because FABT_PLATFORM_CONTACT_EMAIL was added to
+# .env.prod but NOT to the prod compose's environment: block — the container
+# never saw it (compose --env-file controls INTERPOLATION, not container env).
+# Rehearsal now derives the required-set from the rehearsal compose itself,
+# so any drift between "configured" and "passed through" trips this gate.
+log "=== Step 8.7: Env-passthrough assertion (compose env block → container env) ==="
+BACKEND_CONTAINER="$(docker ps --filter "name=fabt-rehearsal-backend" --format '{{.Names}}' | head -1)"
+if [[ -z "$BACKEND_CONTAINER" ]]; then
+    fail "ENV_PASSTHROUGH_NO_CONTAINER" "Could not find rehearsal backend container"
+else
+    # Extract FABT_* keys from the rehearsal compose's backend env block.
+    # Pattern: lines indented 6 spaces under `services.backend.environment:`,
+    # form `FABT_X: ${...}`. Stop at next service or top-level key.
+    REHEARSAL_FABT_KEYS=$(awk '
+        /^  backend:/ {in_backend=1; next}
+        in_backend && /^  [a-z]/ {in_backend=0; in_env=0}
+        in_backend && /^    environment:/ {in_env=1; next}
+        in_backend && in_env && /^    [a-z]/ {in_env=0}
+        in_env && /^      FABT_[A-Z_]+:/ {match($0, /FABT_[A-Z_]+/); print substr($0, RSTART, RLENGTH)}
+    ' "$REPO_ROOT/deploy/rehearsal-prod-overlay.yml" | sort -u)
+    if [[ -z "$REHEARSAL_FABT_KEYS" ]]; then
+        fail "ENV_PASSTHROUGH_PARSE" "Could not extract FABT_* keys from rehearsal-prod-overlay.yml backend env block"
+    else
+        log "  Asserting $(echo "$REHEARSAL_FABT_KEYS" | wc -l | tr -d ' ') FABT_* vars reach the container..."
+        CONTAINER_ENV=$(docker exec "$BACKEND_CONTAINER" env 2>>"$LOG" | grep '^FABT_' | sort)
+        echo "$CONTAINER_ENV" > "$ARTIFACT_DIR/container-env.txt"
+        MISSING_VARS=""
+        while IFS= read -r key; do
+            [[ -z "$key" ]] && continue
+            if ! echo "$CONTAINER_ENV" | grep -q "^${key}="; then
+                MISSING_VARS="${MISSING_VARS}${key} "
+            fi
+        done <<< "$REHEARSAL_FABT_KEYS"
+        if [[ -n "$MISSING_VARS" ]]; then
+            fail "ENV_PASSTHROUGH_MISSING" \
+                "Vars in rehearsal compose env block but absent from backend container: $MISSING_VARS — fix rehearsal compose mapping AND prod compose chain (v0.57.0 abort cause #2)"
+        else
+            ok "All FABT_* env vars from rehearsal compose reach the container"
+        fi
+    fi
+fi
+
+[[ $FAIL -eq 1 ]] && { echo -e "${RED}REHEARSAL FAIL — DO NOT TAG${NC} (gate: $FAIL_GATE) — artifacts: $ARTIFACT_DIR" >&2; exit 1; }
+
 # ── Step 8.5: Load dev seed data (mirrors dev-start.sh behavior) ─────────────
 # seed-data.sql creates the dev-coc tenant + @dev.fabt.org users with admin123.
 # These are NOT in Flyway migrations (they're dev/demo-only seed data loaded

--- a/scripts/deploy-rehearsal.sh
+++ b/scripts/deploy-rehearsal.sh
@@ -317,13 +317,13 @@ done
 
 [[ $FAIL -eq 1 ]] && { echo -e "${RED}REHEARSAL FAIL — DO NOT TAG${NC} (gate: $FAIL_GATE) — artifacts: $ARTIFACT_DIR" >&2; exit 1; }
 
-# ── Step 8.6: Version match (catches v0.57.0 issue: pom not bumped on tag) ────
+# ── Step 8.1: Version match (catches v0.57.0 issue: pom not bumped on tag) ────
 # /api/v1/version returns major.minor (VersionController strips patch). The
 # value comes from BuildProperties → META-INF/build-info.properties → pom.xml
 # at mvn-package time. If the operator forgets to bump pom.xml on a release
 # tag, the JAR ships with the prior version baked in and prod silently runs
 # the wrong version. Rehearsal MUST refuse to greenlight that state.
-log "=== Step 8.6: Version-match assertion (pom.xml vs /api/v1/version) ==="
+log "=== Step 8.1: Version-match assertion (pom.xml vs /api/v1/version) ==="
 EXPECTED_MAJOR_MINOR=$(grep -m1 -E '^    <version>' "$REPO_ROOT/backend/pom.xml" \
     | sed -E 's|.*<version>([0-9]+\.[0-9]+).*|\1|')
 if [[ -z "$EXPECTED_MAJOR_MINOR" || ! "$EXPECTED_MAJOR_MINOR" =~ ^[0-9]+\.[0-9]+$ ]]; then
@@ -343,7 +343,7 @@ fi
 
 [[ $FAIL -eq 1 ]] && { echo -e "${RED}REHEARSAL FAIL — DO NOT TAG${NC} (gate: $FAIL_GATE) — artifacts: $ARTIFACT_DIR" >&2; exit 1; }
 
-# ── Step 8.7: Env-var passthrough (catches v0.57.0 issue: missing env mapping) ─
+# ── Step 8.2: Env-var passthrough (catches v0.57.0 issue: missing env mapping) ─
 # .env.rehearsal sets a value, the prod-overlay's `environment:` block maps it
 # into the container, and `docker exec env` proves it reached the JVM. The
 # v0.57.0 abort happened because FABT_PLATFORM_CONTACT_EMAIL was added to
@@ -351,7 +351,7 @@ fi
 # never saw it (compose --env-file controls INTERPOLATION, not container env).
 # Rehearsal now derives the required-set from the rehearsal compose itself,
 # so any drift between "configured" and "passed through" trips this gate.
-log "=== Step 8.7: Env-passthrough assertion (compose env block → container env) ==="
+log "=== Step 8.2: Env-passthrough assertion (compose env block → container env) ==="
 BACKEND_CONTAINER="$(docker ps --filter "name=fabt-rehearsal-backend" --format '{{.Names}}' | head -1)"
 if [[ -z "$BACKEND_CONTAINER" ]]; then
     fail "ENV_PASSTHROUGH_NO_CONTAINER" "Could not find rehearsal backend container"


### PR DESCRIPTION
## Summary

Closes the gap from the v0.57.0 deploy abort: rehearsal returned PASS while prod was missing both a pom version bump and a new env-var mapping. Two new gates in `scripts/deploy-rehearsal.sh` + backfill of the `FABT_PLATFORM_CONTACT_EMAIL` plumbing that was already missing in rehearsal.

Per `feedback_rehearsal_must_test_new_env_vars.md` (memory captured the day of the v0.57.0 abort).

## Verification — full rehearsal run completed

`make rehearse-deploy` ran end-to-end on this branch with **REHEARSAL PASS** (artifacts: `/tmp/deploy-rehearsal-20260510-140105`):

```
=== Step 8.1: Version-match assertion (pom.xml vs /api/v1/version) ===
✓ Version endpoint matches pom.xml (0.57)

=== Step 8.2: Env-passthrough assertion (compose env block → container env) ===
  Asserting 14 FABT_* vars reach the container...
✓ All FABT_* env vars from rehearsal compose reach the container
```

All 10 steps green + Playwright smoke 13/15 (2 expected demo-tier skips). Both new gates exercised against a real container.

## New gates

### Step 8.1 — `assert_version_match` (v0.57.0 abort cause #1)

```bash
EXPECTED_MAJOR_MINOR=$(grep -m1 -E '^    <version>' backend/pom.xml | sed -E 's|.*<version>([0-9]+\.[0-9]+).*|\1|')
ACTUAL_VERSION=$(curl -sf http://localhost:18080/api/v1/version | jq -r .version)
[ "$ACTUAL_VERSION" = "$EXPECTED_MAJOR_MINOR" ] || fail "VERSION_MISMATCH" "..."
```

`/api/v1/version` returns the major.minor that `VersionController` computes from `BuildProperties` (`META-INF/build-info.properties` baked at `mvn package` time). If pom is not bumped on a release tag, the JAR ships with the prior version baked into MANIFEST.MF and the version endpoint silently lies. The v0.57.0 deploy hit this exactly: pom was at `0.56.0`, endpoint reported `0.56`, deploy aborted at §5.7 verification.

### Step 8.2 — `assert_env_passthrough` (v0.57.0 abort cause #2)

```bash
# Parse FABT_* keys from rehearsal compose's backend env block
REHEARSAL_FABT_KEYS=$(awk '
    /^  backend:/ {in_backend=1; next}
    in_backend && /^  [a-z]/ {in_backend=0; in_env=0}
    in_backend && /^    environment:/ {in_env=1; next}
    in_backend && in_env && /^    [a-z]/ {in_env=0}
    in_env && /^      FABT_[A-Z_]+:/ {match($0, /FABT_[A-Z_]+/); print substr($0, RSTART, RLENGTH)}
' deploy/rehearsal-prod-overlay.yml | sort -u)

# Assert each one reaches the running container
CONTAINER_ENV=$(docker exec fabt-rehearsal-backend env | grep ^FABT_)
for key in $REHEARSAL_FABT_KEYS; do
    echo "$CONTAINER_ENV" | grep -q "^${key}=" || MISSING="$MISSING $key"
done
```

Catches the exact v0.57.0 shape: a new env var added to `.env.prod` but missing from the prod compose's `environment:` block — `compose --env-file` controls **interpolation**, not container env. The container never sees the var; the application logs `absent`; deploy aborts at §5.7. Now rehearsal would fail at Step 8.2 BEFORE the operator tags.

Container env dump preserved at `$ARTIFACT_DIR/container-env.txt` for forensic review when the gate trips.

## Backfill — info-email-contact plumbing missing in rehearsal

Discovered while writing the gate: `FABT_PLATFORM_CONTACT_EMAIL` is in `application.yml` (with empty default, so the JVM starts) but was **never added** to `deploy/rehearsal-prod-overlay.yml` or `deploy/rehearsal.env.example`. The pre-fix rehearsal was rubber-stamping a build that didn't actually plumb the var either.

- `deploy/rehearsal-prod-overlay.yml`: add `FABT_PLATFORM_CONTACT_EMAIL: ${FABT_PLATFORM_CONTACT_EMAIL}` to backend env block
- `deploy/rehearsal.env.example`: add the var with explanatory comment pointing at the v0.57.0 lesson

## Step ordering

Renumbered the new gates to 8.1 / 8.2 (originally drafted as 8.6 / 8.7) so lexical numbering matches execution order: `8 → 8.1 → 8.2 → 8.5 → 9 → 10`. New gates fail-fast BEFORE seed-data load — no point seeding into a build that's already wrong.

## Bundled into v0.57.2 with PRs #178 + #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)