### PR TITLE
ci: ci-runbook-consulted-check (v0.57.3 ops discipline)

### DIFF
--- a/.github/workflows/runbook-consulted-check.yml
+++ b/.github/workflows/runbook-consulted-check.yml
@@ -1,0 +1,40 @@
+name: Runbook consulted-memories check
+
+on:
+  pull_request:
+    branches:
+      - main
+      - 'release/**'
+    paths:
+      - 'docs/oracle-update-notes-v*.md'
+
+permissions:
+  contents: read
+
+jobs:
+  consulted-check:
+    name: ci-runbook-consulted-check
+    runs-on: ubuntu-latest
+    # Path-filtered guard from the ci-runbook-consulted-check OpenSpec change.
+    # Enforces docs/runbook-template.md §1 'consulted:' convention. Companion
+    # to the /opsx-runbook-draft skill (which pre-populates the block) — this
+    # CI check raises the ceiling so even operators who skip the skill must
+    # satisfy three structural assertions before merge:
+    #   1. consulted: block present in the runbook
+    #   2. no leftover [!WARNING] draft callout from the skill
+    #   3. any newly-added feedback_*.md memory in the same PR must be cited
+    #
+    # Escape hatch: PR title contains [skip-runbook-check] — emergency only.
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # Need full history so git diff origin/main...HEAD works; the
+          # default fetch-depth=1 is shallow and can't compute the PR diff.
+          fetch-depth: 0
+
+      - name: Run consulted-memories check
+        env:
+          # Surface PR title to the script so the [skip-runbook-check]
+          # escape hatch works.
+          GITHUB_PR_TITLE: ${{ github.event.pull_request.title }}
+        run: bash scripts/ci/check-runbook-consulted-memories.sh

--- a/scripts/ci/check-runbook-consulted-memories.sh
+++ b/scripts/ci/check-runbook-consulted-memories.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+#
+# check-runbook-consulted-memories.sh — ci-runbook-consulted-check guard.
+#
+# Enforces the `consulted:` frontmatter convention defined by
+# `runbook-template-v1` (see docs/runbook-template.md §1). The companion
+# skill `opsx-runbook-draft` pre-populates the block; this CI check raises
+# the ceiling so even operators who skip the skill must satisfy three
+# structural assertions before merge.
+#
+# Failure modes this catches:
+#   1. Operator hand-authors a runbook without a `consulted:` block.
+#   2. Operator commits a draft that still contains the
+#      `> [!WARNING] generated draft` self-disclosure callout from the skill.
+#   3. Operator adds a new feedback_*.md memory in the same PR but forgets
+#      to cite it in the runbook's `consulted:` block. (No-op for projects
+#      that don't commit memories to git; harmless when memories are
+#      operator-laptop-only.)
+#
+# Usage (CI):
+#   bash scripts/ci/check-runbook-consulted-memories.sh
+#   Triggered by .github/workflows/runbook-consulted-check.yml on PRs that
+#   touch docs/oracle-update-notes-v*.md.
+#
+# Usage (local pre-commit):
+#   bash scripts/ci/check-runbook-consulted-memories.sh
+#   Run from repo root before pushing a runbook PR. Same exit codes.
+#
+# Escape hatch:
+#   PR title contains the literal substring `[skip-runbook-check]`.
+#   Use ONLY for emergency hotfixes; abuse will be reviewed quarterly.
+#
+# Exit codes:
+#   0 = no runbook touched, or all assertions pass, or skip token present
+#   1 = at least one assertion failed
+#   2 = environmental failure (git missing, repo state unexpected)
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# ── Helpers ─────────────────────────────────────────────────────────────
+
+# Marker text the opsx-runbook-draft skill emits in its [!WARNING] callout.
+# Must stay in sync with .claude/skills/opsx-runbook-draft/SKILL.md.
+readonly DRAFT_WARNING_MARKER='This draft is generated'
+
+# Detect changed files. In CI use diff against origin/main; locally fall back
+# to staged + unstaged + untracked so the check works pre-push.
+detect_changed_files() {
+    if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+        # GitHub Actions PR — diff base..HEAD
+        git diff --name-only "origin/${GITHUB_BASE_REF}...HEAD" 2>/dev/null || true
+    elif git rev-parse origin/main &>/dev/null; then
+        git diff --name-only "origin/main...HEAD" 2>/dev/null || true
+    else
+        # Fallback: staged + unstaged + untracked (local pre-commit usage)
+        {
+            git diff --name-only HEAD 2>/dev/null
+            git diff --name-only --cached 2>/dev/null
+            git ls-files --others --exclude-standard 2>/dev/null
+        } | sort -u
+    fi
+}
+
+# Detect newly-ADDED files only (for assertion 3 — uncited new memory).
+detect_added_files() {
+    if [[ -n "${GITHUB_BASE_REF:-}" ]]; then
+        git diff --name-only --diff-filter=A "origin/${GITHUB_BASE_REF}...HEAD" 2>/dev/null || true
+    elif git rev-parse origin/main &>/dev/null; then
+        git diff --name-only --diff-filter=A "origin/main...HEAD" 2>/dev/null || true
+    else
+        git diff --name-only --diff-filter=A HEAD 2>/dev/null || true
+        git diff --name-only --diff-filter=A --cached 2>/dev/null || true
+        git ls-files --others --exclude-standard 2>/dev/null || true
+    fi
+}
+
+pr_title_contains_skip_token() {
+    local title="${GITHUB_PR_TITLE:-}"
+    [[ "$title" == *"[skip-runbook-check]"* ]]
+}
+
+# ── Assertions ──────────────────────────────────────────────────────────
+
+# Assertion 1: each touched runbook contains a `consulted:` block.
+# Per template v1: the block is YAML-fenced and the `consulted:` key
+# appears at column 0 within that fence.
+check_consulted_block_present() {
+    local runbook="$1"
+    if ! grep -qE '^consulted:' "$runbook"; then
+        echo "FAIL: $runbook is missing the 'consulted:' frontmatter block" >&2
+        echo "      Per docs/runbook-template.md §1 (runbook-template-v1)," >&2
+        echo "      every release runbook MUST list every memory file the author" >&2
+        echo "      reviewed in a YAML-fenced 'consulted:' block." >&2
+        echo "      Run /opsx-runbook-draft to auto-populate, then refine." >&2
+        return 1
+    fi
+    return 0
+}
+
+# Assertion 2: no leftover [!WARNING] draft callout from the skill.
+check_no_leftover_warning() {
+    local runbook="$1"
+    if grep -qF "$DRAFT_WARNING_MARKER" "$runbook"; then
+        echo "FAIL: $runbook still contains the opsx-runbook-draft warning callout" >&2
+        echo "      The 'This draft is generated' callout means the runbook is" >&2
+        echo "      half-baked. Refine every citation + every gate, then" >&2
+        echo "      remove the [!WARNING] block before merge." >&2
+        return 1
+    fi
+    return 0
+}
+
+# Assertion 3: any newly-added feedback_*.md memory committed in this PR
+# must be referenced in at least one touched runbook's body. No-op when
+# memories are operator-laptop-only (typical for FABT today).
+check_new_memories_cited() {
+    local runbook="$1"
+    local fail=0
+    while IFS= read -r added; do
+        [[ -z "$added" ]] && continue
+        local basename
+        basename="$(basename "$added")"
+        # Match the memory's filename (with or without .md) inside the runbook
+        if ! grep -qE "${basename%.md}|${basename}" "$runbook"; then
+            echo "FAIL: new memory $added is not cited in $runbook" >&2
+            echo "      A PR that adds a new feedback memory AND touches a runbook" >&2
+            echo "      must cite the new memory in the runbook's 'consulted:' block" >&2
+            echo "      (or 'not-applicable:' with a reason). Otherwise the lesson" >&2
+            echo "      lands in memory but never enters a runbook — defeating the" >&2
+            echo "      runbook-template-v1 purpose." >&2
+            fail=1
+        fi
+    done < <(detect_added_files | grep -E '^.*memory/.*feedback_.*\.md$' || true)
+    return $fail
+}
+
+# ── Main flow ───────────────────────────────────────────────────────────
+
+CHANGED=$(detect_changed_files)
+RUNBOOKS=$(echo "$CHANGED" | grep -E '^docs/oracle-update-notes-v[0-9]+\.[0-9]+\.[0-9]+\.md$' || true)
+
+if [[ -z "$RUNBOOKS" ]]; then
+    echo "ok: no runbook touched in this changeset; check is a no-op"
+    exit 0
+fi
+
+if pr_title_contains_skip_token; then
+    echo "WARN: PR title contains [skip-runbook-check] — skipping consulted-memory assertions"
+    echo "      Affected runbooks: $RUNBOOKS"
+    echo "      Use of this escape hatch is reviewed quarterly."
+    exit 0
+fi
+
+FAIL=0
+COUNT=0
+while IFS= read -r runbook; do
+    [[ -z "$runbook" ]] && continue
+    COUNT=$((COUNT + 1))
+
+    check_consulted_block_present "$runbook" || FAIL=1
+    check_no_leftover_warning "$runbook" || FAIL=1
+    check_new_memories_cited "$runbook" || FAIL=1
+done <<< "$RUNBOOKS"
+
+if [[ $FAIL -eq 0 ]]; then
+    echo "ok: all $COUNT touched runbook(s) satisfy runbook-template-v1 'consulted:' convention"
+    exit 0
+else
+    echo ""
+    echo "FAIL: at least one runbook assertion failed; see messages above" >&2
+    echo "      Reference: docs/runbook-template.md §1" >&2
+    echo "      Skill:     /opsx-runbook-draft (pre-populates the block)" >&2
+    echo "      Skip:      add [skip-runbook-check] to PR title (emergency only)" >&2
+    exit 1
+fi


### PR DESCRIPTION
## Summary

Implements the **ci-runbook-consulted-check** OpenSpec change. Path-filtered GitHub Actions workflow + bash check script that lints PRs touching `docs/oracle-update-notes-v*.md` against three structural assertions:

1. `consulted:` block present in the runbook (per `docs/runbook-template.md` §1)
2. No leftover `[!WARNING] This draft is generated` callout from the companion `/opsx-runbook-draft` skill (operator forgot to remove)
3. Any newly-added `feedback_*.md` memory in the same PR is cited in the runbook (no-op for projects that don't commit memories — safe default)

Companion PR in docs repo: https://github.com/ccradle/findABed/pull/new/feature/v0.57.3-ops-discipline (the `/opsx-runbook-draft` skill itself). The skill raises the FLOOR by pre-populating the `consulted:` block; this CI check raises the CEILING so even operators who skip the skill cannot merge a runbook missing the convention.

## Why TICKET-not-DEPLOY

Tooling-only change. No backend code, no Flyway, no env vars, no compose changes. Lands directly on main; no v0.57.3 tag required (the v0.57.X numbering in the OpenSpec was nominal — this is operational tooling that benefits the *next* release runbook, not a deploy itself).

## Files

- `scripts/ci/check-runbook-consulted-memories.sh` (134 lines bash, `set -euo pipefail`, mirrors style of `verify-release-gate-pins.sh`)
- `.github/workflows/runbook-consulted-check.yml` (37 lines, path-filtered to `docs/oracle-update-notes-v*.md`, `fetch-depth: 0` so the diff against `origin/main` works)

## Verification

- [x] `bash -n scripts/ci/check-runbook-consulted-memories.sh` — syntax clean
- [x] Run on current main: `ok: no runbook touched in this changeset; check is a no-op` (correct)
- [x] Spot-check against the v0.57.2 runbook: `consulted:` present, no `[!WARNING]` draft callout, no uncited memories
- [ ] CI on this PR — workflow itself is path-filtered to `docs/oracle-update-notes-v*.md` so it WON'T trigger on this PR (no runbook touched). Will trigger on the next PR that touches a runbook.

## Marker text contract

`DRAFT_WARNING_MARKER='This draft is generated'` in the script MUST stay in sync with `.claude/skills/opsx-runbook-draft/SKILL.md` (companion PR, docs repo). The marker is what the CI check detects to refuse merge of runbooks where the operator forgot to remove the draft callout.

## Escape hatch

PR title contains `[skip-runbook-check]` — emergency hotfixes only; abuse reviewed quarterly. Documented in script header.

## Deferred

OpenSpec task 6.1 ("Add to 'Pre-tag rehearsal' subsection of `FOR-DEVELOPERS.md`") references a subsection that doesn't exist in current main. Deferred to a follow-up edit when that section is authored.

## OpenSpec reference

`openspec/changes/ci-runbook-consulted-check/proposal.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)