### PR TITLE
docs(ops): Oracle VM kernel-reboot runbook v3.1

### DIFF
--- a/docs/TESTING-GUIDE.md
+++ b/docs/TESTING-GUIDE.md
@@ -1,0 +1,539 @@
+# FABT Testing Guide
+
+**Audience:** Junior developers joining the FABT codebase, or anyone writing their first test in this repo.
+
+**Goal:** by the end of this guide you can (a) pick the right kind of test for the change you're making, (b) write it following the patterns the rest of the codebase uses, and (c) run it locally and in CI without surprises.
+
+This guide covers four kinds of tests we use in FABT:
+
+| Kind | What it tests | What's real | What's faked | Wall-clock |
+|---|---|---|---|---|
+| **Unit test** | One class, one method, one rule at a time | Just the class under test | Every collaborator (via Mockito) | ~milliseconds |
+| **Integration test with mock** | A request flowing through the whole Spring app, with one or two external boundaries stubbed | Full Spring context + real Postgres + real HTTP | One specific bean (e.g. an SSRF guard) or an outbound HTTP endpoint | ~seconds |
+| **Integration test with Testcontainer** | Same as above, but with *nothing* faked — real Postgres, real Flyway, real services end-to-end | Everything | Nothing | ~seconds |
+| **Karate API test** | The shipped REST API contract from a black-box client's point of view | Whatever's running at `baseUrl` | Nothing — Karate is a real HTTP client | ~seconds |
+
+The rest of this guide walks each kind end-to-end with a real exemplar from the codebase you can read and copy.
+
+---
+
+## Before you start: one-time setup
+
+You need these tools installed (the [`dev-start.sh`](../dev-start.sh) script will check for them and complain if any are missing):
+
+- **Java 25+** — backend builds and runs on Java 25.
+- **Maven 3.9+** — the build tool. We **never** use `gradle` (see [`feedback_maven_not_gradle.md`](https://github.com/anthropics/claude-code/) memory).
+- **Docker Desktop** — required for Testcontainers (real Postgres) and the dev stack.
+- **Node 20+** — for the frontend and the Karate runner.
+- **Git Bash** (Windows) or any POSIX shell (macOS/Linux).
+
+If you can run this, you're ready:
+
+```bash
+cd finding-a-bed-tonight
+mvn -version          # Maven + Java 25
+docker info           # Docker daemon reachable
+node --version        # v20+
+```
+
+Don't worry about installing JUnit, Mockito, Testcontainers, or Karate — Maven pulls them in from `backend/pom.xml` and `e2e/karate/pom.xml`.
+
+---
+
+## Where tests live
+
+```
+finding-a-bed-tonight/
+├── backend/
+│   └── src/
+│       └── test/
+│           └── java/
+│               ├── org/fabt/                          ← backend tests
+│               │   ├── shelter/service/
+│               │   │   └── ShelterServiceIsValidCountyTest.java     [unit]
+│               │   ├── subscription/
+│               │   │   └── WebhookTimeoutTest.java                  [integration + mock]
+│               │   └── ...
+│               └── db/migration/
+│                   └── V97MigrationIntegrationTest.java             [integration + testcontainer]
+└── e2e/
+    └── karate/
+        └── src/test/java/features/
+            └── dv-access/
+                └── dv-access-control.feature                        [karate API]
+```
+
+The rule of thumb:
+
+- A test for **one Java class** goes in `backend/src/test/java/<same package>/<ClassName>Test.java`.
+- A test that **boots Spring** goes in the same package and ends in `IntegrationTest.java` (Maven Surefire is configured to recognize this suffix).
+- A test for the **REST API contract from outside** goes in `e2e/karate/src/test/java/features/<area>/<thing>.feature`.
+
+---
+
+## 1. Unit tests
+
+### What a unit test is
+
+A unit test exercises **one class** in isolation. Every collaborator the class depends on is replaced by a Mockito mock so the test fails for exactly one reason: a bug in the class under test. No Spring. No database. No HTTP. No filesystem.
+
+If your test takes more than a few hundred milliseconds, it's almost certainly not a unit test anymore.
+
+### When to write one
+
+- You added a new method on a service class that branches on inputs.
+- You added a validator, a parser, or any pure function.
+- You changed a class's contract and want to pin the new behavior.
+- You're fixing a bug — write the failing unit test first, watch it fail, then fix the code.
+
+### Exemplar to read
+
+[`backend/src/test/java/org/fabt/shelter/service/ShelterServiceIsValidCountyTest.java`](../backend/src/test/java/org/fabt/shelter/service/ShelterServiceIsValidCountyTest.java)
+
+This test pins the 4-branch state machine inside `ShelterService.isValidCounty(...)`:
+
+1. `county == null` → always true (no constraint).
+2. `active_counties: []` configured → true (validation disabled).
+3. `active_counties: ["Wake"]` → match-or-miss.
+4. Key absent → fall back to a hard-coded NC county list.
+
+What makes it a good template:
+
+- **The class-level Javadoc enumerates every branch** so the next person knows where new cases slot in (lines 28–47).
+- **Each branch has both a positive and a negative test** (e.g. `countyInExplicitList_isValid` + `countyNotInExplicitList_isInvalid_evenIfInNcDefaults`). Without the negative test you don't know your code rejects what it should.
+- **`.as("...")` descriptions** on every AssertJ assertion explain *why* the rule exists, not what the code does — so when CI fails 6 months from now, you can read the failure message and understand the design intent (line 137: *"Wake is in NC defaults but excluded from this tenant's active_counties"*).
+- **The constructor passes `null` for every unused dependency** (lines 65–77). If a future change makes `isValidCounty` start calling, say, `reservationService`, this test will throw NPE and you'll know immediately. This is the cheapest way to detect a hidden coupling.
+- **Defensive cases live alongside the happy paths** — malformed JSON, null config, tenant-not-found. They're not in a separate file; they're right where the next reader will see them.
+
+### Skeleton
+
+```java
+package org.fabt.<area>.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Unit tests for {@link ThingService#doStuff(Input)}.
+ *
+ * <p>Branches under test:
+ * <ol>
+ *   <li>Input is null → throw IllegalArgumentException.</li>
+ *   <li>Input passes validation → returns transformed value.</li>
+ *   <li>Repository returns empty → returns default fallback.</li>
+ * </ol>
+ */
+@ExtendWith(MockitoExtension.class)
+class ThingServiceTest {
+
+    @Mock private ThingRepository repo;
+
+    @Test
+    void doStuff_validInput_returnsTransformedValue() {
+        // Arrange
+        when(repo.findFor("hello")).thenReturn(Optional.of(new Thing("HELLO")));
+        ThingService svc = new ThingService(repo);
+
+        // Act
+        String result = svc.doStuff(new Input("hello"));
+
+        // Assert
+        assertThat(result)
+            .as("uppercased Thing value should be returned verbatim")
+            .isEqualTo("HELLO");
+    }
+}
+```
+
+### How to run
+
+```bash
+# All backend tests (slow — boots Spring contexts for IT classes)
+cd finding-a-bed-tonight/backend
+mvn test
+
+# Just this one class (fast — pure unit, no Spring)
+mvn test -Dtest=ShelterServiceIsValidCountyTest
+
+# One test method
+mvn test -Dtest=ShelterServiceIsValidCountyTest#nullCounty_isAlwaysValid_andSkipsTenantLookup
+```
+
+### Common pitfalls
+
+- **Over-mocking.** If you find yourself mocking 10 dependencies to test one method, you've probably found a class that's doing too much. Consider splitting it before writing the test.
+- **Verifying every interaction.** `verify(mock, times(1)).somethingCalled()` for *every* call makes the test a re-implementation of the production code. Verify only the interactions that are part of the contract (e.g. "this method must NOT hit the DB when the input is null" is worth verifying).
+- **Adding `@SpringBootTest` for convenience.** That makes it an integration test, takes 30s to boot, and is no longer a unit test. If a class can't be unit-tested without Spring, that's design feedback — the class probably has too many responsibilities.
+- **Asserting on strings without `.as()`.** `assertThat(x).isEqualTo("HELLO")` tells you nothing when it fails. `assertThat(x).as("uppercased value").isEqualTo("HELLO")` tells you which rule broke.
+
+---
+
+## 2. Integration tests with mocks
+
+### What this is
+
+A Spring `@SpringBootTest` that boots the full backend application, talks to a real Testcontainers Postgres, and exercises a real HTTP request end-to-end — **but with one or two boundaries surgically replaced** by a Mockito mock or a WireMock stub.
+
+You use it when:
+
+- You need the full Spring wiring to be real (security filters, transaction boundaries, JSON serialization, JdbcTemplate, etc.).
+- *But* one external collaborator would otherwise make the test impossible — typically because it would refuse to talk to a test fixture (an SSRF guard rejecting `localhost`), or because the real collaborator is a network service you can't run in CI.
+
+### Exemplar to read
+
+[`backend/src/test/java/org/fabt/subscription/WebhookTimeoutTest.java`](../backend/src/test/java/org/fabt/subscription/WebhookTimeoutTest.java)
+
+This test verifies that an outbound webhook delivery fails fast when the subscriber takes too long to respond. The full Spring app runs. Postgres runs. The real `WebhookDeliveryService` runs against a real `RestClient`. Only **two** things are faked:
+
+1. The **outbound HTTP destination** — a real WireMock server bound to a random localhost port, configured to wait 3 seconds before replying (line 101).
+2. The **SSRF guard** — `@MockitoBean private SafeOutboundUrlValidator urlValidator;` (line 61). Without this, the production guard would (correctly) reject `http://localhost:<random>/webhook` and the test couldn't reach WireMock.
+
+What makes it a good template:
+
+- **The `@MockitoBean` is a *single* bean replacement, and there's a comment explaining why** (lines 58–60). Every other test in the suite keeps the SSRF guard armed — see [`BaseIntegrationTest.java:67-74`](../backend/src/test/java/org/fabt/BaseIntegrationTest.java).
+- **`@TestPropertySource` overrides config for the rule under test** (lines 49–52: `fabt.webhook.read-timeout-seconds=1`). The timeout logic is real; only the value is shrunk so the test runs in <2s instead of 30.
+- **Negative case + positive case in the same class** (lines 99 + 148). The negative test proves the timeout fires; the positive test proves a fast endpoint within the same configured timeout still succeeds. Without the positive case, a regression where *every* delivery fails would still pass the negative test.
+- **A wall-clock assertion proves the timeout actually fired** (line 137: `elapsedMs < 2500`). The upstream stub waits 3000ms. If your code waited for it anyway, the test would take >3s — the bound makes that visible.
+- **DB-side-effect verification** (line 140: `SELECT COUNT(*) FROM webhook_delivery_log`). The test asserts the failure was *recorded*, not silently dropped. A common bug class is "we report success to the caller but log a failure" — only a DB query catches it.
+- **Per-test WireMock lifecycle** (`@BeforeEach` starts it, `@AfterEach` stops it). No global state leaking between tests.
+
+### Skeleton
+
+```java
+@DisplayName("My Feature With An External Dependency")
+@TestPropertySource(properties = "fabt.my-feature.timeout-seconds=1")
+class MyFeatureIntegrationTest extends BaseIntegrationTest {
+
+    @Autowired private TestAuthHelper authHelper;
+    @Autowired private JdbcTemplate jdbc;
+
+    @MockitoBean private TheExternalGuardBean guard;  // documented: WHY?
+
+    private WireMockServer wireMock;
+
+    @BeforeEach
+    void setUp() {
+        wireMock = new WireMockServer(WireMockConfiguration.options().dynamicPort());
+        wireMock.start();
+        authHelper.setupTestTenant();
+        authHelper.setupAdminUser();
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (wireMock != null) wireMock.stop();
+    }
+
+    @Test
+    void positivePath_doesTheThing() { /* ... */ }
+
+    @Test
+    void negativePath_recordsFailureWhenUpstreamMisbehaves() { /* ... */ }
+}
+```
+
+### How to run
+
+Identical to unit tests — Maven Surefire picks it up from the `*Test.java` / `*IntegrationTest.java` suffix:
+
+```bash
+cd finding-a-bed-tonight/backend
+mvn test -Dtest=WebhookTimeoutTest
+```
+
+The first run downloads the Postgres Docker image (~150MB) — slow once, fast forever after.
+
+### Common pitfalls
+
+- **Mocking too many beans.** Each `@MockitoBean` is one boundary the test no longer verifies. Two is usually a smell; three is almost always wrong. If you find yourself reaching for a fourth, step back: maybe this should be a unit test against a smaller class, or a fully-real integration test against Testcontainers.
+- **Forgetting to document *why* a bean is mocked.** Future you will not remember. The comment is the whole point.
+- **`@MockBean` instead of `@MockitoBean`.** `@MockBean` is deprecated as of Spring Boot 3.4. Always use `@MockitoBean` from `org.springframework.test.context.bean.override.mockito`.
+- **WireMock at a fixed port.** Always use `WireMockConfiguration.options().dynamicPort()` — fixed ports collide when tests run in parallel.
+
+---
+
+## 3. Integration tests with Testcontainers
+
+### What this is
+
+A `@SpringBootTest` that runs against a **real Postgres** (via Testcontainers) and **real Flyway migrations** with **nothing mocked**. The most production-faithful kind of test we have. Slower than unit tests, but the test result is high-fidelity: if it passes here, it will almost certainly pass in prod.
+
+You use it when:
+
+- You're changing a SQL migration.
+- You're testing logic that involves transactions, RLS policies, or JSONB column manipulation that Hibernate / JdbcTemplate alone can't model in-memory.
+- You're testing security rules that have to flow through the real Spring Security filter chain.
+- You want the strongest possible regression guard for a change.
+
+### How the Postgres container works
+
+Every IT class in this repo extends [`BaseIntegrationTest`](../backend/src/test/java/org/fabt/BaseIntegrationTest.java). The base class starts **one** `postgres:16-alpine` container per JVM (static initializer at line 31), and every test class reuses it. This avoids the 5-second container-startup cost per class.
+
+The container's JDBC URL is injected into Spring's `DataSource` via `@DynamicPropertySource` at line 44. Flyway runs all migrations against this fresh DB once at boot. Subsequent tests use the same schema; per-test isolation comes from creating fresh tenants/users with random UUIDs (see exemplar below).
+
+### Exemplar to read
+
+[`backend/src/test/java/db/migration/V97MigrationIntegrationTest.java`](../backend/src/test/java/db/migration/V97MigrationIntegrationTest.java)
+
+This test pins three invariants of a Flyway migration that backfills `dv_policy_enabled = true` on tenants that own at least one DV shelter:
+
+1. **Backfill correctness** — affected tenants land on `true`.
+2. **No incorrect spread** — unaffected tenants don't get the key at all.
+3. **Idempotency** — re-running the migration produces identical state.
+
+What makes it a good template:
+
+- **The test loads the migration SQL from the classpath at runtime** (lines 80–93). It does not copy the SQL into a Java string. If the production migration file changes, this test runs the new SQL automatically — no drift possible.
+- **A 4-state fixture matrix** covers every meaningful migration input (lines 98–101): tenant with *active* DV shelters, tenant with *inactive-only* DV shelters, tenant with *non-DV* shelters only, tenant with *zero* shelters. The migration's WHERE clause is verified in every direction at once.
+- **Each test creates its own tenants with UUID-suffixed slugs** (lines 105–111). No reliance on the `dev-coc-*` seed tenants. Tests can be reordered, re-run, or run in parallel without interference. This is the [`feedback_isolated_test_data`](memory link) discipline.
+- **RLS context discipline is documented in the class Javadoc** (lines 46–61). FABT's `shelter` table has Row-Level Security; an INSERT outside a tenant context silently fails. The doc explains *which* setup code needs `TenantContext.runWithContext(tenantId, dvAccess=true, ...)` and *why*, with citations.
+- **An idempotency test AND a non-clobber test** (lines 178 + 188). These are the migration tests that are usually missing. The migration could be perfectly correct on first run and still clobber existing JSONB keys on second run, or vice versa. Both directions need pinning.
+- **Helpers are thin, named for intent, and have Javadoc** (lines 211–248: `runV97For`, `readDvPolicyKey`, `clearDvPolicyKey`).
+
+### Skeleton
+
+```java
+@DisplayName("V<N> <what the migration does>")
+@SpringBootTest(classes = Application.class,
+        webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+class V<N>MigrationIntegrationTest extends BaseIntegrationTest {
+
+    private static final String V<N>_SQL = loadMigrationSql();
+
+    private static String loadMigrationSql() {
+        try (var stream = V<N>MigrationIntegrationTest.class.getResourceAsStream(
+                "/db/migration/V<N>__<name>.sql")) {
+            if (stream == null) throw new IllegalStateException("not found");
+            return new String(stream.readAllBytes(), StandardCharsets.UTF_8);
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to load V<N> SQL", e);
+        }
+    }
+
+    @Autowired private JdbcTemplate jdbc;
+    @Autowired private TestAuthHelper authHelper;
+
+    private UUID tenantA;
+    private UUID tenantB;
+
+    @BeforeEach
+    void setUp() {
+        String suffix = UUID.randomUUID().toString().substring(0, 8);
+        tenantA = authHelper.setupSecondaryTenant("v<N>-a-" + suffix).getId();
+        tenantB = authHelper.setupSecondaryTenant("v<N>-b-" + suffix).getId();
+        // ...prime fixture state...
+    }
+
+    @Test
+    void affectedTenantBackfills() {
+        runMigrationFor(tenantA);
+        assertThat(readMigratedColumn(tenantA)).isEqualTo("expected-value");
+    }
+
+    @Test
+    void unaffectedTenantIsNotModified() {
+        runMigrationFor(tenantB);
+        assertThat(readMigratedColumn(tenantB)).isNull();
+    }
+
+    @Test
+    void migrationIsIdempotent() {
+        runMigrationFor(tenantA);
+        String first = readMigratedColumn(tenantA);
+        runMigrationFor(tenantA);
+        assertThat(readMigratedColumn(tenantA)).isEqualTo(first);
+    }
+
+    private void runMigrationFor(UUID tenantId) {
+        TenantContext.runWithContext(tenantId, true, () -> jdbc.execute(V<N>_SQL));
+    }
+    private String readMigratedColumn(UUID tenantId) { /* ... */ }
+}
+```
+
+### How to run
+
+Same Maven command — Surefire treats it as a normal test:
+
+```bash
+cd finding-a-bed-tonight/backend
+mvn test -Dtest=V97MigrationIntegrationTest
+```
+
+First run downloads `postgres:16-alpine` if you don't already have it (~150MB, ~30s on a typical home connection). Subsequent runs reuse the cached image.
+
+### Common pitfalls
+
+- **Forgetting RLS context.** If you `INSERT INTO shelter (...)` from a test without wrapping it in `TenantContext.runWithContext(...)`, the row goes in but is invisible to your assertions because RLS hides it. Use [`fabt` owner role rather than `fabt_app`](https://github.com/anthropics/claude-code/) when diagnosing — `fabt_app` is the RLS-restricted role.
+- **Depending on seed-data tenants.** The `dev-coc`, `dev-coc-west`, `dev-coc-east` tenants exist in test DBs but their state is shared across the whole test run. Mutating them in one test breaks another test that ran first. Always `setupSecondaryTenant("<unique-slug>")`.
+- **Copy-pasting migration SQL into a Java string.** The whole point of a migration IT is to test the actual migration file. Load it from the classpath.
+- **Asserting only the happy path of a migration.** Migrations need three assertions minimum: (1) it does the right thing, (2) it doesn't do the wrong thing, (3) running it twice is safe.
+- **Using `@Transactional` to "clean up" state.** Spring's `@Transactional` test rollback doesn't play well with how Flyway runs migrations. Prefer creating fresh-per-test fixtures.
+
+---
+
+## 4. Karate API tests
+
+### What this is
+
+A **black-box test of the running HTTP API**. Karate is a tiny domain-specific language for writing API contract tests in `.feature` files (Gherkin-flavored). It speaks real HTTP at a real server, asserts on real JSON responses, and knows nothing about Spring, Postgres, or Java classes.
+
+You use it when:
+
+- You added a new REST endpoint and want to pin its contract from the outside.
+- You changed an endpoint's response shape and want to be sure no client breaks.
+- You want a fast-fail "is the API up and behaving sanely?" check for CI.
+- You're defending a security invariant that lives at the API boundary (the `dv-access-control.feature` test halts the entire CI pipeline if any DV shelter ever appears in a public response).
+
+### Exemplar to read
+
+[`e2e/karate/src/test/java/features/dv-access/dv-access-control.feature`](../e2e/karate/src/test/java/features/dv-access/dv-access-control.feature)
+
+This is the canary that runs first in CI. If any of its scenarios fail, the entire E2E pipeline halts — a DV shelter appearing in a public query is a data-protection failure.
+
+What makes it a good template:
+
+- **The header comment says what's at stake** (lines 3–5). Anyone modifying this file knows they're touching a blocking gate.
+- **One invariant per scenario** — five scenarios, each verifying the *absence* of DV data on a different API surface (bed search, shelter list, direct GET, HSDS export, and a role-without-flag check). Five surfaces × one rule = the rule pinned everywhere.
+- **Asserts on absence with `karate.filter(...) == '#[0]'`** (line 18). This is the Karate idiom for "no element in this list matches the predicate." Both the UUID and the human-readable name are checked (lines 17 + 20) — defends against a regression that renames the shelter but keeps the UUID, and vice versa.
+- **"404 not 403" is a deliberate assertion** (lines 31–36 with the inline comment). `403 Forbidden` would confirm the resource exists, which is the leak being defended against. The comment names the rule so future readers don't "fix" it to 403.
+- **The last scenario builds its own test user inline** (lines 45–76) instead of trusting seed assumptions. The seed `cocadmin` user has `dvAccess=true` because the DV escalation queue needs it — this test creates a `COC_ADMIN` with `dvAccess=false` to prove that the role alone isn't the gate; the flag is.
+- **Per-run-unique email** (line 54: `'dv-canary-noaccess-' + java.util.UUID.randomUUID() + '@...'`) prevents the `(tenant_id, email)` UNIQUE constraint from biting on re-runs.
+
+### Skeleton
+
+```gherkin
+Feature: <What this API contract pins>
+
+  <One-sentence statement of what failure of this test means in production terms.>
+
+  Background:
+    * url baseUrl
+    * def someConstant = '0000-0000-0000-...'
+
+  Scenario: <Single contract under test, in plain English>
+    * configure headers = { Authorization: '#(outreachAuthHeader)' }
+    Given path '/api/v1/your-endpoint'
+    And request { "field": "value" }
+    When method POST
+    Then status 200
+    And match response.someField == 'expected'
+
+  Scenario: <Negative case proving the rule rejects the wrong input>
+    * configure headers = { Authorization: '#(outreachAuthHeader)' }
+    Given path '/api/v1/your-endpoint'
+    And request { "field": "bad-value" }
+    When method POST
+    Then status 400
+```
+
+### Auth setup
+
+The `outreachAuthHeader`, `adminAuthHeader`, `tenantSlug`, `loginUrl`, and `baseUrl` variables come from `e2e/karate/src/test/java/karate-config.js` — Karate loads it once per run and exposes the variables to every feature. To use a custom user, log in inline (see lines 63–67 of the DV exemplar).
+
+### How to run
+
+Karate runs against whatever's at `baseUrl`. You need the backend running. The simplest local setup:
+
+```bash
+# Terminal 1 — bring up the backend + nginx
+cd finding-a-bed-tonight
+./dev-start.sh --nginx          # nginx proxy on :8081, NOT the default :5173
+
+# Terminal 2 — run Karate against it
+cd finding-a-bed-tonight/e2e/karate
+mvn test                                                       # whole suite
+mvn test -Dkarate.options="--name DV-access"                   # one feature by tag/name
+mvn test -Dkarate.options="classpath:features/auth/login.feature"   # one file
+```
+
+The Karate runner is the `karate-junit5` engine; results appear in `e2e/karate/target/karate-reports/karate-summary.html`.
+
+### Common pitfalls
+
+- **Trusting seed data.** The same rule as integration tests: if your scenario assumes "user X exists with role Y and flag Z", another scenario can mutate that. Create your own user inline with a UUID-suffixed email.
+- **Asserting only on status codes.** `Then status 200` tells you the call returned. It tells you nothing about the body. Add `match response.field == 'expected'` for any field that matters to the contract.
+- **Forgetting to URL-encode IDs in paths.** Karate's `path '/api/v1/shelters', dvShelterId` handles this for you — use that form, not string concatenation.
+- **Running Karate against bare Vite (`:5173`).** Karate needs the backend at `:8080` or the nginx proxy at `:8081`. The dev-start `--nginx` flag is the safe default — it's what CI runs against (see [`feedback_check_ports_before_assuming.md`](../docs/) memory).
+- **`Background` doing too much.** If every scenario re-runs an expensive setup, the suite gets slow. Push that to `karate-config.js` (once-per-run) or into a single `Scenario:` that other scenarios link to.
+
+---
+
+## Decision tree: which kind of test should I write?
+
+```
+Is the thing I'm testing pure logic in one class?
+├── YES  → Unit test (#1)
+└── NO   → Does it need the Spring context to be real?
+          ├── NO   → Probably still a unit test — try harder to inject deps
+          └── YES  → Does it need a real Postgres / real Flyway / real RLS?
+                    ├── YES  → Does any boundary make it untestable as-is
+                    │         (e.g. SSRF guard blocks localhost, real upstream is a network service)?
+                    │         ├── YES  → Integration test with mock (#2)
+                    │         └── NO   → Integration test with Testcontainers (#3)
+                    └── NO   → Are you testing the REST API contract from outside?
+                              ├── YES  → Karate (#4)
+                              └── NO   → Re-read this tree — you probably want #1 or #3
+```
+
+Most days you'll write more #1 than anything else. Reach for #2 only when an SSRF guard or a network dependency forces it. Reach for #3 whenever you're touching SQL or RLS. Reach for #4 when you're shipping a new endpoint or pinning an API security rule.
+
+---
+
+## Cheat sheet
+
+```bash
+# Run one backend test (unit or integration)
+cd finding-a-bed-tonight/backend
+mvn test -Dtest=ClassName
+mvn test -Dtest=ClassName#methodName
+
+# Run all backend tests
+mvn test
+
+# Run a specific Karate feature against a running stack
+cd finding-a-bed-tonight
+./dev-start.sh --nginx                # Terminal 1
+cd e2e/karate && mvn test -Dkarate.options="classpath:features/auth/login.feature"  # Terminal 2
+
+# Stop the dev stack when done
+cd finding-a-bed-tonight && ./dev-start.sh stop
+```
+
+```java
+// Annotations you'll use most
+@ExtendWith(MockitoExtension.class)  // unit tests
+@Mock                                 // unit-test mocks
+@SpringBootTest                       // integration tests (inherited via BaseIntegrationTest)
+@MockitoBean                          // surgical bean replacement (NOT @MockBean — deprecated)
+@TestPropertySource                   // per-class config overrides
+@DisplayName("Human-readable name")   // shows up in test reports
+@BeforeEach / @AfterEach              // per-test setup/teardown
+
+// Assertions — use AssertJ
+import static org.assertj.core.api.Assertions.assertThat;
+assertThat(actual).as("why this rule matters").isEqualTo(expected);
+
+// Mocking
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
+when(mock.thing(any())).thenReturn(value);
+verify(mock, times(1)).thingShouldBeCalledOnce();
+```
+
+---
+
+## Where to go next
+
+- Read [`docs/FOR-DEVELOPERS.md`](FOR-DEVELOPERS.md) for the broader architecture.
+- Read [`backend/src/test/java/org/fabt/BaseIntegrationTest.java`](../backend/src/test/java/org/fabt/BaseIntegrationTest.java) to understand how Testcontainers is wired into every IT class.
+- Read [`backend/src/test/java/org/fabt/TestAuthHelper.java`](../backend/src/test/java/org/fabt/TestAuthHelper.java) to see how to create tenants, users, and authenticated request headers in any IT.
+- Skim a handful of existing `*Test.java` and `*IntegrationTest.java` files near the code you're about to change. The patterns in your area will be more specific than this general guide.
+
+When in doubt, ask in the warroom channel or open a draft PR and tag a senior — both are cheaper than guessing.

--- a/docs/operations/runbooks/oracle-vm-kernel-reboot.md
+++ b/docs/operations/runbooks/oracle-vm-kernel-reboot.md
@@ -1,0 +1,252 @@
+# Oracle VM kernel-reboot runbook
+
+**Version:** v3.1 (2026-05-30, warroom rounds 1+2+3 applied; READY TO EXECUTE)
+**Scope:** Activate an already-installed kernel by rebooting the FABT prod VM. This is the *first* such runbook, authored against the live state captured 2026-05-30 23:07Z (uptime 37 days, kernel `6.8.0-1049-oracle` running, `6.8.0-1050-oracle` installed by unattended-upgrades 2026-05-28).
+**Out of scope:** Applying the 22 non-security upgradable packages (Docker, netplan, JDK, etc.). Those need their own window and their own runbook.
+
+**How to use this runbook:**
+- `<VM_HOST>` throughout = the FABT prod VM's public IP. Per the `feedback_no_ip_in_repo` standing rule, the literal IP is held in operator memory (`project_live_deployment_status.md`), not in this file. Substitute it at run-time when copying commands.
+- Run commands in order top-to-bottom. Do not skip §2.5 (the GRUB pin) — without it, the boot target is ambiguous.
+- Checkbox each item as you go. If anything fails its acceptance criterion, stop and read §6 before proceeding.
+
+---
+
+## §0 Gate & risk
+
+| Field | Value |
+|---|---|
+| Trigger | `/var/run/reboot-required` exists AND `reboot-required.pkgs` lists a `linux-image-*` |
+| Frequency expected | ~monthly (Oracle pushes kernel patches ~every 3-5 weeks) |
+| Expected downtime | 60-180 s SSH-unreachable + ~30 s container cold-boot + nginx warm-up |
+| Customer impact | Brief unavailability of findabed.org; no data loss (postgres on durable volume) |
+| Rollback path | (a) If shell is still reachable: `sudo grub-reboot "Advanced options for Ubuntu>Ubuntu, with Linux 6.8.0-1049-oracle" && sudo reboot` (one-shot, reverts after one boot). (b) If shell is gone: Oracle Cloud serial console — **note**: OCI Ubuntu 22.04 instances have a documented issue interrupting GRUB at boot (https://community.oracle.com/customerconnect/discussion/907373/). If (b) fails, attach the boot volume to a recovery instance and edit `/etc/default/grub` from there. Multi-hour recovery. |
+| Rehearsal applicable | NO — rehearsal harness exercises the app stack, not VM-level reboot. We gain confidence instead via (i) the §2.5 explicit-pin-and-verify of the GRUB next-boot target and (ii) inspecting all 8 container restart policies, which must all be `unless-stopped` (verified 2026-05-30). |
+| Abort criteria | If §1 pre-flight fails on any item: postpone 24 h, do not retry same window. If §2.5 cannot one-shot pin the new kernel: STOP, investigate, do not reboot. |
+| Customer comms | None pre-reboot — outage is sub-3-minute and we do not pre-announce kernel reboots. Post-hoc record lives in the §7 ledger only. If a known partner is in active demo prep that day, postpone. |
+
+---
+
+## §1 Pre-flight (must all pass before §3)
+
+- [ ] No customer demo scheduled in next 30 minutes (check calendar + recent Slack/email).
+- [ ] No PR in mid-merge on either repo (`gh pr list --state open --search "is:open is:pr"` for both repos).
+- [ ] No GitHub Actions workflow in-progress on main for either repo:
+  ```bash
+  gh run list --repo ccradle/finding-a-bed-tonight --branch main --status in_progress --limit 5
+  gh run list --repo ccradle/findABed --branch main --status in_progress --limit 5
+  ```
+  (Empty output = safe. An in-progress deploy or release workflow MUST complete first.)
+- [ ] Local main is clean (`git status` in both `findABed/` and `finding-a-bed-tonight/`).
+- [ ] SSH key works: `ssh -i ~/.ssh/fabt-oracle -o StrictHostKeyChecking=accept-new ubuntu@<VM_HOST> 'uptime'`.
+- [ ] Browser tab open to https://findabed.org (we will watch it recover).
+- [ ] `lastgood` tag exists for current release: `git tag --list 'v0.57.2-lastgood'` returns a tag.
+
+---
+
+## §2 Snapshot (rollback breadcrumb)
+
+Capture pre-reboot state to a local file (gitignored):
+
+```bash
+SNAP=~/fabt-reboot-snapshot-$(date -u +%Y%m%dT%H%M%SZ).txt
+{
+  echo "=== captured at $(date -u +%Y-%m-%dT%H:%M:%SZ) ==="
+  ssh -i ~/.ssh/fabt-oracle -o StrictHostKeyChecking=accept-new ubuntu@<VM_HOST> '
+    echo "--- uptime ---"; uptime
+    echo "--- kernel ---"; uname -r
+    echo "--- containers ---"; docker ps --format "table {{.Names}}\t{{.Status}}\t{{.RunningFor}}"
+    echo "--- flyway HWM ---"
+    docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -t -c "SELECT MAX(version) FROM flyway_schema_history;"
+    echo "--- pgdata volume ---"
+    docker inspect finding-a-bed-tonight-postgres-1 --format "{{ range .Mounts }}{{ .Type }}: {{ .Source }} -> {{ .Destination }}{{ println }}{{ end }}"
+  '
+  echo "--- prod /api/v1/version ---"
+  curl -sS https://findabed.org/api/v1/version
+} > "$SNAP"
+echo "Snapshot: $SNAP"
+```
+
+- [ ] Snapshot file written.
+- [ ] Snapshot file contents reviewed for any unexpected secret values (this script only emits version + container metadata + Flyway version — no secrets — but per `feedback_never_print_rendered_secrets` we audit anyway).
+- [ ] Postgres data lives on a **named volume**, confirmed by `Type: volume` in the inspect output. (A bind mount for `init-app-user.sql` is also present — that is fine; it is only consumed on first-boot of an empty volume.)
+- [ ] Flyway HWM recorded (currently expected: V98).
+- [ ] All 8 containers have restart policy `unless-stopped` (verified 2026-05-30; if any are `no` or `on-failure:N` the cold-boot assumption breaks). Verify with:
+  ```bash
+  ssh -i ~/.ssh/fabt-oracle -o StrictHostKeyChecking=accept-new ubuntu@<VM_HOST> 'for c in $(docker ps --format "{{.Names}}"); do echo "$c: $(docker inspect $c --format "{{.HostConfig.RestartPolicy.Name}}")"; done'
+  ```
+
+---
+
+## §2.5 Pin the next boot to the new kernel (mandatory — do not skip)
+
+Because `GRUB_TIMEOUT=0` and `GRUB_TIMEOUT_STYLE=hidden`, GRUB will not show a menu and the simple "Ubuntu" entry's implicit target is ambiguous (no `/vmlinuz` symlink on this VM). We must explicitly pin the next boot:
+
+```bash
+ssh -i ~/.ssh/fabt-oracle -o StrictHostKeyChecking=accept-new ubuntu@<VM_HOST> '
+  # Verify the menu entry path exists exactly as expected
+  if ! grep -q "Ubuntu, with Linux 6.8.0-1050-oracle" /boot/grub/grub.cfg; then
+    echo "ABORT: target menuentry not found in grub.cfg" >&2; exit 1
+  fi
+  sudo grub-reboot "Advanced options for Ubuntu>Ubuntu, with Linux 6.8.0-1050-oracle"
+  echo "--- grub-editenv now (should show next_entry=...1050...) ---"
+  sudo grub-editenv list
+'
+```
+
+- [ ] `next_entry=...1050-oracle...` is set.
+- [ ] If not: STOP. The submenu path string must match `grub.cfg` exactly. Use `grep "^menuentry\|^submenu" /boot/grub/grub.cfg` to find the verbatim path.
+
+`grub-reboot` is **one-shot**: if 1050 boots cleanly, the next reboot reverts to the persistent default (which `update-grub` will have set to 1050 too, so we end up at 1050 either way). If 1050 fails to boot but the system recovers somehow, the persistent default still applies. There is no "stick on old kernel until I say otherwise" state.
+
+---
+
+## §3 Reboot
+
+**Use `shutdown -r +1` exclusively** (the 1-minute grace lets a logged-in operator cancel with `sudo shutdown -c` if a partner appears unexpectedly). Do **not** substitute `sudo reboot`.
+
+```bash
+ssh -i ~/.ssh/fabt-oracle -o StrictHostKeyChecking=accept-new ubuntu@<VM_HOST> 'sudo shutdown -r +1 "FABT: scheduled kernel reboot to 6.8.0-1050-oracle"'
+date -u +%Y-%m-%dT%H:%M:%SZ   # record the timestamp now
+```
+
+- [ ] Command accepted (broadcast message printed).
+- [ ] Timestamp of *issuing* the command recorded: <!-- T_issue: -->
+- [ ] SSH will drop ~60 s later when the system goes down. That is expected.
+
+---
+
+## §4 Wait for boot
+
+In a local terminal, poll until SSH is reachable again:
+
+```bash
+echo "Waiting for SSH starting $(date -u +%Y-%m-%dT%H:%M:%SZ)..."
+until ssh -i ~/.ssh/fabt-oracle -o ConnectTimeout=5 -o StrictHostKeyChecking=accept-new \
+  ubuntu@<VM_HOST> 'echo up' 2>/dev/null; do
+  printf '.'
+  sleep 10
+done
+echo
+echo "VM SSH back up at $(date -u +%Y-%m-%dT%H:%M:%SZ)"
+```
+
+- [ ] SSH reachable.
+- [ ] Timestamp of recovery recorded: <!-- T_recovery: -->
+- [ ] `T_recovery - T_issue` ≈ 60-180 s is normal. **If >300 s elapsed without recovery: jump to §6.**
+
+---
+
+## §5 Post-boot verification (all must pass)
+
+```bash
+ssh -i ~/.ssh/fabt-oracle -o StrictHostKeyChecking=accept-new ubuntu@<VM_HOST> '
+  echo "--- new kernel ---"; uname -r
+  echo "--- grub one-shot consumed (should be empty) ---"; sudo grub-editenv list
+  echo "--- reboot-required flag (should be gone) ---"; ls -la /var/run/reboot-required 2>&1 | head -1
+  echo "--- containers ---"; docker ps --format "table {{.Names}}\t{{.Status}}"
+  # Backend health is checked via docker exec, NOT via https://findabed.org/actuator/health —
+  # nginx does not proxy /actuator to the outside world (correctly). Do not "fix" this.
+  echo "--- backend health (in-container) ---"; docker exec fabt-backend wget -qO- http://localhost:9091/actuator/health
+  echo "--- flyway HWM ---"
+  docker exec finding-a-bed-tonight-postgres-1 psql -U fabt -d fabt -t -c "SELECT MAX(version) FROM flyway_schema_history;"
+  echo "--- dmesg tail (look for anything red) ---"; sudo dmesg --since "5 minutes ago" | tail -30
+'
+```
+
+- [ ] Kernel == `6.8.0-1050-oracle`.
+- [ ] `grub-editenv list` is **empty** (proves the one-shot was consumed by this boot; if it still shows `next_entry=...`, GRUB took a different path than we set — investigate before doing this again).
+- [ ] `/var/run/reboot-required` returns "No such file or directory".
+- [ ] All 8 containers Up (`fabt-backend`, `fabt-frontend`, `finding-a-bed-tonight-{postgres,prometheus,alertmanager,grafana,otel-collector,jaeger}-1`).
+- [ ] Postgres `Status` includes `(healthy)`.
+- [ ] Backend `/actuator/health` returns `{"status":"UP"`.
+- [ ] Flyway HWM == V98 (unchanged from §2 snapshot).
+- [ ] `dmesg` has no obvious kernel oopses, MCEs, or hardware errors.
+
+Then from local (end-to-end through nginx, not just root URL):
+
+```bash
+curl -sf https://findabed.org/api/v1/version                # expect: contains "0.57.2"
+curl -sIf https://findabed.org/                              # expect: HTTP/2 200
+curl -sf "https://findabed.org/api/v1/active-counties" | head -c 200   # expect: JSON array, proves DB-reachable
+```
+
+- [ ] Version endpoint returns `0.57.2`.
+- [ ] Root URL returns 200.
+- [ ] `/api/v1/active-counties` returns a JSON array (proves request path: nginx → backend → postgres).
+- [ ] Manual smoke: refresh findabed.org browser tab; home loads, shelter-card click works, footer renders contact email. (One-shot eyeball — does not need a recorded artifact.)
+
+---
+
+## §6 Rollback / escalation
+
+| Symptom | Action |
+|---|---|
+| VM not SSH-reachable after 5 min | Wait another 5 min (Oracle hardware-prep can be slow). |
+| VM not SSH-reachable after 10 min | Open Oracle Cloud console → Compute → Instances → fabt-prod → check **Instance state** (RUNNING/STOPPED/STOPPING). |
+| Instance state STOPPED | Click **Start**. Wait. Resume §4. |
+| Instance RUNNING + SSH up + booted to 1050 but degraded | `sudo grub-reboot "Advanced options for Ubuntu>Ubuntu, with Linux 6.8.0-1049-oracle" && sudo reboot`. This is the **happy rollback path** — works only because we still have shell. |
+| Instance RUNNING + no SSH (kernel panic at boot, or networking broken) | Open **Console connection** (serial). Known issue: OCI Ubuntu 22.04 instances often cannot interrupt GRUB via serial — see https://community.oracle.com/customerconnect/discussion/907373/. If GRUB interrupt fails: STOP the instance from the console, **detach the boot volume**, attach it to a recovery VM in the same compartment, mount, `chroot`, run `grub-reboot` for 1049, unmount, detach, reattach to original, boot. **Multi-hour recovery; this is the worst case.** |
+| SSH up, containers not running | `docker ps -a` — if exited, `docker start <name>`. If Docker daemon dead, `sudo systemctl status docker`. |
+| `/actuator/health` returns DOWN | Check `docker logs fabt-backend --tail 200`. Likely postgres race; usually self-heals within 60 s of postgres becoming healthy. |
+| Flyway HWM changed | STOP. Migration ran unexpectedly. Capture state, do not write further. Investigate before any further action. |
+
+Escalation contacts: the project operator is the sole on-call. There is no secondary today. Document anything you cannot resolve and capture screenshots of the Oracle console state.
+
+---
+
+## §7 Post-run record
+
+- [ ] Append a YAML record to `~/fabt-reboot-ledger.yaml` (eventual home: rotation-ledger.json — see secret-rotation plan §7 item 4. Using YAML for human read until that schema lands; convert at that time):
+
+```yaml
+- event: vm_kernel_reboot
+  date_utc: 2026-05-30T__:__Z
+  vm: fabt-prod
+  kernel_before: 6.8.0-1049-oracle
+  kernel_after: 6.8.0-1050-oracle
+  ssh_down_seconds: ___
+  total_recovery_seconds: ___
+  containers_restarted: 8
+  flyway_hwm_before: V98
+  flyway_hwm_after: V98
+  # Get runbook_sha with: git rev-parse HEAD:docs/operations/runbooks/oracle-vm-kernel-reboot.md
+  runbook_sha: ___
+  verified_by: sole_operator
+  notes: ___
+```
+
+- [ ] Memory write: update `project_live_deployment_status.md` to note "uptime reset by kernel reboot YYYY-MM-DD; kernel now 1050".
+- [ ] If anything surprised you, append to §8 here and to the secret-rotation plan §10 carryover.
+
+---
+
+## §8 Open follow-ups (for the 22-pkg upgrade window)
+
+The reboot itself does **not** touch any of the 22 currently-upgradable packages. Track these separately:
+
+1. **Docker stack upgrade** (`docker-ce`, `containerd.io`, plugins) — needs its own runbook; daemon restart cycles containers. Risk: high enough to warrant its own dry-run.
+2. **Netplan upgrade** (`netplan.io`, `netplan-generator`, `libnetplan0`, `python3-netplan`, `iproute2`) — Oracle Cloud has had netplan regressions before; do not bundle with Docker.
+3. **JDK 25 upgrade** (`temurin-25-jdk`) — build-host only; containers ship their own JRE. Low blast radius but verify the Maven build still passes on the upgraded JDK.
+4. **System utils** (`snapd`, `distro-info-data`, `ubuntu-advantage-tools`, `ubuntu-pro-client*`, `adoptium-ca-certificates`) — bundle into a "minor packages" window.
+5. Consider extracting the §1-§5 shape of this file into `docs/operations/runbooks/_template.md` once we have a second runbook to compare against (avoids premature templating; see secret-rotation-plan §7 item 0).
+
+### Runbook bugs surfaced during first live run (2026-05-30)
+
+- **§5 smoke endpoint chosen poorly**: `/api/v1/active-counties` requires auth (401). Replace with a public no-auth endpoint that proves nginx → backend → DB (e.g., `/api/v1/version` already validates the path, OR add a `/api/v1/health` public endpoint). Until fixed, the existing in-container `/actuator/health` + Postgres `(healthy)` + `psql` Flyway query are the authoritative DB-reachability proofs.
+- **§1 lastgood tag check over-specified**: rollback for a kernel reboot is GRUB-based, not image-based. Reword to "lastgood tag exists if you also intend to roll back the app; not required for kernel-only reboots."
+- **`dmesg --since "5 minutes ago"` returns nothing right after boot** because the relative window predates kernel-boot time. Switch to `dmesg -T | tail -50` for post-boot inspection.
+
+---
+
+## §9 Provenance & execution history
+
+- Live state captured 2026-05-30 23:07Z via `ssh -i ~/.ssh/fabt-oracle ubuntu@<VM_HOST>` (read-only checks — no secrets printed).
+- 22 upgradable packages enumerated; security pocket already drained by unattended-upgrades (last run 2026-05-30 06:23).
+- Authored under standing rule `feedback_no_ip_in_repo`: literal VM IP held in operator memory (`project_live_deployment_status.md`), never in this file. Operator substitutes `<VM_HOST>` at run time.
+
+### Run #1 — 2026-05-30 23:21Z (v3.1)
+- Kernel: 6.8.0-1049-oracle → 6.8.0-1050-oracle
+- Total recovery: 118 s (60 s grace + ~58 s actual SSH-down)
+- All 8 containers cold-booted clean via `unless-stopped`; Flyway HWM unchanged (V98)
+- One-shot GRUB pin consumed exactly as designed (`next_entry=` empty post-boot)
+- Two runbook bugs discovered (see §8); no production regression

--- a/docs/operations/secret-rotation-plan.md
+++ b/docs/operations/secret-rotation-plan.md
@@ -1,4 +1,4 @@
-# Secret Rotation Plan (Draft v3.1, 2026-05-22)
+# Secret Rotation Plan (Draft v3.2, 2026-05-22)
 
 **Status:** planning — not yet a policy. Author + project lead must agree on cadences before this becomes operational.
 
@@ -8,7 +8,7 @@
 
 **Ground-truthed:** 2026-05-22 via three SSH passes against the prod VM. All file paths, mtime dates, container ages, env-var inventories, `platform_key_material` + `tenant_key_material` schemas, and row counts in this document are observed, not assumed. See Appendix A for provenance.
 
-**Revision history:** v1 (2026-05-21, code-grounded only), v2 (2026-05-22, VM ground-truth + rehearsal gate), v3 (2026-05-22, warroom round 1 BLOCKER+HIGH fixes — 3 BLOCKERs + 14 HIGHs), v3.1 (2026-05-22, warroom round 2 HIGH fixes — 2 HIGHs applied, 8 MEDIUMs captured in §10).
+**Revision history:** v1 (2026-05-21, code-grounded only), v2 (2026-05-22, VM ground-truth + rehearsal gate), v3 (2026-05-22, warroom round 1 BLOCKER+HIGH fixes — 3 BLOCKERs + 14 HIGHs), v3.1 (2026-05-22, warroom round 2 HIGH fixes — 2 HIGHs applied, 8 MEDIUMs captured in §10), **v3.2 (2026-05-22, Marcus security-persona pass — 3 CRITICAL + 4 SIGNIFICANT control gaps closed; see §11).**
 
 ---
 
@@ -23,6 +23,8 @@ The rehearsal already catches ~80% of the v0.49-class deploy bugs (per the scrip
 > Every secret-rotation runbook MUST be exercised end-to-end in `make rehearse-deploy` *before* being authorized for prod execution. **The green rehearsal run MUST be no more than 72 hours old** at the moment prod rotation begins — matching the `deploy/release-gate-pins.txt` precedent for deploy gates. A prod rotation without a fresh-enough rehearsal-green run is a process violation. The single exception is an active-incident rotation (confirmed leak), which may bypass the rehearsal gate but **MUST** be (a) recorded as a `bypass=true` entry in the rotation ledger (see §8 Q4) and (b) followed by a same-week rehearsal pass that exercises the procedure used.
 
 This costs ~10 min per rotation (rehearsal wall-clock) and pays for itself the first time a missed step would have broken prod. It is the natural extension of the gate `feedback_rehearsal_must_test_new_env_vars` established for env-var deploys (v0.57.0 abort lesson).
+
+**Bypass-clause hygiene (Marcus v3.2):** any incident-bypass rotation MUST destroy the `.pre-rotation` backup file it created within 72 hours of confirmed smoke-clean — same window as the rehearsal-freshness clause. Otherwise the bypass leaves a cleartext copy of the credential the rotation was designed to retire. The ledger entry MUST record both the rotation timestamp AND the backup-destruction timestamp; the second timestamp is mandatory before the bypass entry is considered closed.
 
 **What rotations can be rehearsed** (see §6 for drill specs):
 
@@ -131,21 +133,23 @@ These are `${VAR}` references — the actual values come from the operator's she
 
 ## 3. Recommended cadences
 
-| Tier | Secret | Cadence | Owner | Detection / how operator knows to bring it forward |
-|---|---|---|---|---|
-| 0 | #1 DB app password | every 90 days | sole operator¹ | Operator-initiated only (no automated detection today) |
-| 0 | #2 DB owner password | every 365 days | sole operator¹ | Operator-initiated only |
-| 0 | #3 POSTGRES_PASSWORD | every 365 days | sole operator¹ | Operator-initiated only |
-| 0 | #7 SMTP password | every 90 days | sole operator¹ | Operator-initiated; Gmail security-alert email triggers incident path |
-| 0 | #8 Grafana admin | every 90 days | sole operator¹ | Operator-initiated only |
-| 0 | #9 OCI svc principal | every 90 days | sole operator¹ | OCI audit-log scan deferred (manual quarterly review) |
-| 0 | #11 Cloudflare token | every 90 days | sole operator¹ | CF audit log scan deferred (manual quarterly review) |
-| 0 | #12 GitHub PAT | every 365 days (or fine-grained 90d) | sole operator¹ | GitHub email warning on PAT expiry |
-| 1 | #4 JWT secret + per-tenant key material | every 365 days OR on suspected forgery | sole operator¹ + dev | Forgery suspected; key-derivation downgraded |
-| 2 | #5 Platform JWT key | every 365 days once tooling ships | sole operator¹ + dev | Platform-operator account compromise |
-| 3 | #6 Master KEK | DO NOT rotate until dual-key-accept design ships + kid back-fill complete. Annually thereafter. | sole operator¹ + dev | KEK exposure (catastrophic) |
+| Tier | Secret | Cadence | Owner | Detection / how operator knows to bring it forward | Audit emit on rotation |
+|---|---|---|---|---|---|
+| 0 | #1 DB app password | every 90 days | sole operator¹ | Operator-initiated; **post-policy: Prometheus alert on `pg_roles` password-change event** (§7 item 18) | `DB_ROLE_ROTATED` (operator, role, ts) |
+| 0 | #2 DB owner password | every 365 days | sole operator¹ | Operator-initiated; same Prometheus rule as #1 | `DB_ROLE_ROTATED` |
+| 0 | #3 POSTGRES_PASSWORD | every 365 days | sole operator¹ | Operator-initiated only | `POSTGRES_SUPERUSER_ROTATED` |
+| 0 | #7 SMTP password | every 90 days | sole operator¹ | Operator-initiated; Gmail security-alert email triggers incident path | `SMTP_PASSWORD_ROTATED` |
+| 0 | #8 Grafana admin | every 90 days | sole operator¹ | Operator-initiated only | `GRAFANA_ADMIN_ROTATED` |
+| 0 | #9 OCI svc principal | every 90 days | sole operator¹ | OCI audit-log scan deferred (manual quarterly review); **post-policy: OCI list-keys assertion catches "new+old both live" partial states** (§7 item 8) | `OCI_SVC_PRINCIPAL_ROTATED` (fingerprint redacted) |
+| 0 | #11 Cloudflare token | every 90 days | sole operator¹ | CF audit log scan deferred (manual quarterly review) | `CLOUDFLARE_TOKEN_ROTATED` |
+| 0 | #12 GitHub PAT | every 365 days (or fine-grained 90d) | sole operator¹ | GitHub email warning on PAT expiry | `GITHUB_PAT_ROTATED` |
+| 1 | #4 JWT secret + per-tenant key material | every 365 days OR on suspected forgery | sole operator¹ + dev | Forgery suspected; key-derivation downgraded; **Prometheus alert on `tenant_key_material` INSERT rate above expected cadence** (§7 item 18) | `TENANT_KEY_ROTATED` on every `active` flip in either direction (downgrade-attack detection per Marcus v3.2) |
+| 2 | #5 Platform JWT key | every 365 days once tooling ships | sole operator¹ + dev | Platform-operator account compromise; same Prometheus rule on `platform_key_material` | `PLATFORM_KEY_ROTATED` on every `active` flip in either direction |
+| 3 | #6 Master KEK | DO NOT rotate until dual-key-accept design ships + kid back-fill complete. Annually thereafter. | sole operator¹ + dev | KEK exposure (catastrophic) | `MASTER_KEK_ROTATED` (with envelope kid-back-fill row count) |
 
-¹ **Owner = sole operator (project lead Corey Cradle) today. No documented fallback exists.** When a second operator joins, the dev/ops split formalizes per §8 Q1. Until then, this column is a single-point-of-failure for every rotation: operator illness, PTO, or unavailability blocks rotation. **Risk-acceptance, not policy compliance.**
+¹ **Owner = sole operator (project lead Corey Cradle) today. No documented fallback exists.** When a second operator joins, the dev/ops split formalizes per §8 Q1. Until then, this column is a single-point-of-failure for every rotation: operator illness, PTO, or unavailability blocks rotation. **Risk-acceptance, not policy adherence.**
+
+**Shell-history is a credential store (Marcus v3.2, CRITICAL).** Every rotation procedure in §4 that uses `export FABT_*_PASSWORD=...` would, without mitigation, leak the new value into `~/.bash_history`. An attacker with read access to the operator laptop would have perpetual access to every rotation value ever set. Every §4 procedure now opens with `unset HISTFILE` (or equivalent) BEFORE the first `export` and ends with `history -c` AFTER smoke-gate. The "Audit emit" column above is the detection layer when this control fails; both layers are required.
 
 **Documented exception:** any secret on this list can be rotated *immediately* outside cadence in response to a confirmed leak (the SMTP rotation 2026-04-22 set the precedent). Incident rotations bypass the rehearsal gate per §0 but require (a) ledger entry with `bypass=true` + reason + operator timestamp, (b) a same-week rehearsal follow-up.
 
@@ -160,21 +164,42 @@ These are *sketches* — each becomes a full runbook under `docs/operations/runb
 ```
 PREREQUISITES: envsubst on PATH, $EDITOR set, alertmanager.yml.tmpl present.
 GLOSSARY: envsubst = GNU env-var substitution; alertmanager UID 65534 = nobody.
+
 NEVER-PRINT INVARIANT (control, not citation): the next steps edit and re-render
 files that contain the SMTP password. Do NOT `cat`, `head`, `tail`, `grep`, or
 otherwise output any portion of the rendered file to your terminal at any point.
 `$EDITOR` opens the file directly without piping its contents.
 
+SHELL-HYGIENE PREAMBLE (Marcus v3.2 CRITICAL): rotation procedures touch
+secrets via the operator's shell. Before any `export` or `read` of a secret
+value, the operator's bash history must be silenced so the new value never
+lands in ~/.bash_history. Execute these THREE lines before step 1:
+
+  unset HISTFILE                    # disables history for this session
+  set +o history                    # belt-and-suspenders for bash 5+
+  trap 'history -c' EXIT            # clears in-memory history on shell exit
+
+These three lines are part of every §4 procedure. Without them, every
+`export FABT_*_PASSWORD=...` in the session leaks to disk.
+
 1. Gmail → security → app passwords → revoke old, create new (do NOT print)
 2. cp ~/fabt-secrets/.env.prod ~/fabt-secrets/.env.prod.pre-smtp-$(date +%Y%m%d-%H%M%S)
    # ⚠ This backup IS the rollback primitive — referenced by step ROLLBACK below.
+   # ⚠ This backup is also a credential-bearing file with 72h destruction window
+   #   per the BACKUP-DESTRUCTION step.
 3. Edit .env.prod via $EDITOR (NEVER cat/grep first)
 4. cd ~/finding-a-bed-tonight && envsubst < deploy/alertmanager.yml.tmpl > ~/fabt-secrets/alertmanager.yml
 5. chmod 644 ~/fabt-secrets/alertmanager.yml  (alertmanager UID 65534 needs read)
 6. docker compose -f docker-compose.yml -f ~/fabt-secrets/docker-compose.prod.yml up -d --force-recreate alertmanager
 7. Smoke gate: amtool alert add test → confirm receipt at alert mailbox
 8. Audit: confirm old app password rejected in Gmail console
-9. Ledger: append entry to rotation-ledger.json (secret=SMTP, ts, operator, rehearsal-run-id)
+9. AUDIT EMIT: backend logs `SMTP_PASSWORD_ROTATED` event with operator + ts (per §3 audit column)
+10. Ledger: append entry to rotation-ledger.json (secret=SMTP, ts, operator, rehearsal-run-id, bypass=false)
+11. BACKUP-DESTRUCTION (mandatory, NLT 72h post-smoke-clean): `shred -u ~/fabt-secrets/.env.prod.pre-smtp-<ts>`
+    then append destruction timestamp to the same ledger entry. The entry is NOT
+    closed until both timestamps land. See §0 bypass-clause hygiene + §11 #1.
+12. SHELL-CLEAN: `history -c` (defensive — the trap already runs on EXIT but
+    explicit clear before any other operator action is the safe default).
 
 ROLLBACK (if step 6, 7, or 8 fails):
   R1. mv ~/fabt-secrets/.env.prod.pre-smtp-<ts> ~/fabt-secrets/.env.prod
@@ -182,30 +207,61 @@ ROLLBACK (if step 6, 7, or 8 fails):
   R3. docker compose ... up -d --force-recreate alertmanager
   R4. Re-test with old password via amtool
   R5. File post-incident note explaining what failed BEFORE attempting rotation again
+  R6. The 72h backup-destruction step (#11) still applies on the OLD backup file —
+      the rollback does NOT extend the cleartext-on-disk window.
 ```
 
 ### #1 / #2 DB passwords (leverage existing `rotate-db-password.sh`)
 
 ```
-PREREQUISITES: openssl, docker exec, psql. Existing 9-line rotate-db-password.sh
-  reviewed/parameterized per §7 item 1.
-GLOSSARY: ALTER ROLE = Postgres role-password update; pg_hba = host-based auth config.
+PREREQUISITES: openssl, docker exec, psql, pg_dump. Existing 9-line
+  rotate-db-password.sh reviewed/parameterized per §7 item 1.
+GLOSSARY: ALTER ROLE = Postgres role-password update; pg_hba = host-based auth
+  config; SERIALIZABLE = strongest Postgres transaction isolation level.
 
+SHELL-HYGIENE PREAMBLE (per §4 SMTP — same three lines): unset HISTFILE;
+  set +o history; trap 'history -c' EXIT.
+
+0a. PRE-ROTATION SNAPSHOT (Marcus v3.2 CRITICAL, replaces §8 Q3 deferral):
+    pg_dump -h <host> -U fabt -t platform_key_material -t tenant_key_material \
+      -t kid_to_tenant_key | gpg --encrypt --recipient <ops-pgp-key> \
+      > ~/fabt-secrets/pre-rotation-pg_dump-$(date +%Y%m%d-%H%M%S).sql.gpg
+    chmod 600 ~/fabt-secrets/pre-rotation-pg_dump-*.sql.gpg
+    Retention: 30 days post-rotation. Snapshot is the rollback primitive for
+    §4 #4 and §4 #5 — without it, beyond-grace rollback fails open.
 1. Generate new password: NEW_PWD=$(openssl rand -base64 32)
 2. cp ~/fabt-secrets/docker-compose.prod.yml ~/fabt-secrets/docker-compose.prod.yml.pre-db-$(date +%Y%m%d-%H%M%S)
 3. As operator shell: export FABT_DB_APP_PASSWORD="$NEW_PWD"
-4. bash ~/fabt-secrets/rotate-db-password.sh fabt_app  (runs ALTER ROLE inside container)
-5. docker compose -f ... up -d --force-recreate backend
-6. Smoke gate: /actuator/health green; one authenticated API request green
-7. Audit: psql connect with OLD password rejected; NEW password accepted via the
+   # ⚠ With HISTFILE unset and trap armed, the export does NOT touch ~/.bash_history.
+4. OLD_PWD=$(awk -F= '/^FABT_DB_APP_PASSWORD/{print $2}' \
+   ~/fabt-secrets/docker-compose.prod.yml.pre-db-<ts>)
+   # OLD captured from the backup (M3-r2 fix), NOT from shell history.
+5. bash ~/fabt-secrets/rotate-db-password.sh fabt_app  (runs ALTER ROLE inside container)
+6. docker compose -f ... up -d --force-recreate backend
+7. Smoke gate: /actuator/health green; one authenticated API request green
+8. Audit: psql connect with OLD password rejected; NEW password accepted via the
    SAME network path the backend uses (postgres:5432 service DNS, not localhost)
-8. Ledger entry
+9. AUDIT EMIT: backend logs `DB_ROLE_ROTATED` event (per §3 audit column)
+10. Ledger entry (bypass=false, snapshot_path=<pg_dump file>)
+11. BACKUP-DESTRUCTION (mandatory, NLT 72h post-smoke-clean):
+      shred -u ~/fabt-secrets/docker-compose.prod.yml.pre-db-<ts>
+      # pg_dump snapshot is NOT destroyed here — 30-day retention applies.
+    Append destruction timestamp to ledger.
+12. SHELL-CLEAN: history -c
+13. unset OLD_PWD NEW_PWD  # in-memory scrub before any other operator action
 
-ROLLBACK:
-  R1. ALTER ROLE fabt_app WITH PASSWORD '<old>'  (operator must have old in their
-      shell history or in the .pre-db-<ts> backup of docker-compose.prod.yml)
-  R2. export FABT_DB_APP_PASSWORD='<old>' ; docker compose ... up -d --force-recreate backend
-  R3. /actuator/health
+ROLLBACK (within smoke-gate window):
+  R1. ALTER ROLE fabt_app WITH PASSWORD '<OLD_PWD captured in step 4>'
+  R2. export FABT_DB_APP_PASSWORD="$OLD_PWD"
+  R3. docker compose ... up -d --force-recreate backend
+  R4. /actuator/health
+  R5. AUDIT EMIT: `DB_ROLE_ROTATION_ROLLED_BACK` (detection layer for forced rollback)
+  R6. Backup-destruction (#11) still applies on the OLD backup at the originally-
+      scheduled 72h mark; rollback does NOT extend the cleartext-on-disk window.
+
+ROLLBACK (after smoke-gate window, beyond shell-session):
+  Restore the encrypted pg_dump from step 0a; out-of-band runbook required;
+  treat as incident.
 ```
 
 ### #4 JWT secret per-tenant kid-rotation (already supported, never exercised)
@@ -215,33 +271,79 @@ PREREQUISITES: psql access, knowledge of kid-keyed JWT validation.
 GLOSSARY: kid = key-id JWT header field; tenant_key_material partial-unique on
   (tenant_id) WHERE active=true enforces single live generation per tenant.
 
-For each tenant T:
-1. Begin tenant context (RLS): SET LOCAL fabt.current_tenant_id = '<T>';
-2. UPDATE tenant_key_material SET active = false, rotated_at = clock_timestamp()
-     WHERE tenant_id = '<T>' AND active = true;
-3. INSERT INTO tenant_key_material (tenant_id, generation, created_at, active)
-     VALUES ('<T>', <max_gen + 1>, clock_timestamp(), true);
-4. INSERT INTO kid_to_tenant_key (kid, tenant_id, generation)
-     VALUES (gen_random_uuid(), '<T>', <max_gen + 1>);
-5. Commit. Caches expire normally; clients reauthenticate over 15-min TTL window.
+PRE-ROTATION: per §4 DB step 0a, take an encrypted pg_dump of
+tenant_key_material + kid_to_tenant_key + jwt_revocations BEFORE proceeding.
+The Marcus v3.2 grace-window-fail-open mitigation depends on this snapshot.
+
+For each tenant T (wrap the per-tenant flow in a SERIALIZABLE transaction —
+Marcus v3.2 mitigation against paused-JVM-sees-two-actives observability gap):
+
+  BEGIN;
+  SET TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+  SET LOCAL fabt.current_tenant_id = '<T>';
+
+  -- 1. Deactivate current generation
+  UPDATE tenant_key_material
+    SET active = false, rotated_at = clock_timestamp()
+    WHERE tenant_id = '<T>' AND active = true
+    RETURNING generation INTO @prev_gen;
+
+  -- 2. Insert new generation
+  INSERT INTO tenant_key_material (tenant_id, generation, created_at, active)
+    VALUES ('<T>', @prev_gen + 1, clock_timestamp(), true);
+
+  -- 3. Register new kid
+  INSERT INTO kid_to_tenant_key (kid, tenant_id, generation)
+    VALUES (gen_random_uuid(), '<T>', @prev_gen + 1);
+
+  -- 4. INVALIDATE jwt_revocations cache for the deactivated kid (Marcus v3.2
+  --    M4-r2 reclassified as security-adjacent: stale cache lets a leaked
+  --    pre-rotation kid validate past its rotated_at).
+  DELETE FROM jwt_revocations
+    WHERE tenant_id = '<T>'
+      AND kid IN (SELECT kid FROM kid_to_tenant_key
+                  WHERE tenant_id = '<T>' AND generation = @prev_gen);
+
+  COMMIT;
+
+  -- 5. AUDIT EMIT (per §3 audit column): backend logs `TENANT_KEY_ROTATED`
+  --    event with operator + tenant_id + prev_gen + new_gen + ts.
+  --    The event MUST fire on every `active` flip in EITHER direction —
+  --    including the rollback path R1 below — to detect downgrade attacks.
+
+Caches expire normally; clients reauthenticate over 15-min TTL window.
 
 The check constraint `active=true AND rotated_at IS NULL OR active=false AND
 rotated_at IS NOT NULL` enforces shape; the partial unique index prevents two
 active rows per tenant.
 
+**Read-path correctness note (Marcus v3.2):** the JWT validation read path
+(`KidRegistryService`) MUST reject a token whose kid resolves to a
+`tenant_key_material` row where `active = false` AND `rotated_at < now() - grace_window`.
+Validating on `active` alone permits a leaked pre-rotation token to forge
+sessions perpetually after the rotation that was supposed to retire it.
+Verify the read path before authorizing any prod rotation under this procedure.
+
 ROLLBACK (within grace window, before clients have reauthenticated):
-  R1. UPDATE tenant_key_material SET active=true, rotated_at=NULL WHERE generation=<old>;
-  R2. UPDATE tenant_key_material SET active=false, rotated_at=clock_timestamp() WHERE generation=<new>;
+  R1. UPDATE tenant_key_material SET active=true, rotated_at=NULL WHERE generation=<old>
+      -- This triggers a `TENANT_KEY_ROTATED` audit emit (downgrade-attack
+      -- detection per the §3 audit column rule).
+  R2. UPDATE tenant_key_material SET active=false, rotated_at=clock_timestamp() WHERE generation=<new>
+      -- Also emits.
   R3. Verify partial-unique invariant still holds.
+
+ROLLBACK (beyond grace window): restore from the §4 DB step 0a pg_dump.
+Out-of-band; treat as incident.
 ```
 
 ### #5 Platform JWT signing key (Tier 2 — needs tooling)
 
 - Build `POST /api/v1/platform/key-material/rotate` endpoint, `@PlatformAdminOnly`
 - Calls `KeyDerivationService.derivePlatformJwtKeyBytes(new UUID)` → INSERT new row with new kid + active=true + generation=N+1 → flip previous to active=false (partial-unique prevents two active rows)
-- During grace window (1 hr default), platform JWT verifier accepts either generation by looking up `platform_key_material WHERE kid=<header.kid>` (kid is already in schema and emitted in tokens — no kid-emission pre-work needed)
-- Audit emit: `PLATFORM_KEY_ROTATED`
-- Drill (§6.5): rehearsal starts at generation N (the ground-truthed live state), runs the rotation endpoint, asserts generation N+1 active, asserts old-generation tokens minted pre-rotation still validate within grace, asserts new tokens carry new kid.
+- **Transaction isolation (Marcus v3.2):** wrap INSERT-new + UPDATE-old in a single `SERIALIZABLE` transaction. The partial-unique index prevents COMMIT of two-actives but does not prevent mid-transaction observability; isolation level makes the flip atomic from the verifier's perspective.
+- During grace window (1 hr default), platform JWT verifier accepts either generation by looking up `platform_key_material WHERE kid=<header.kid>` (kid is already in schema and emitted in tokens — no kid-emission pre-work needed). **Verifier MUST reject** if `active = false AND rotated_at < now() - grace_window` (same Marcus v3.2 read-path correctness rule as §4 #4).
+- Audit emit: `PLATFORM_KEY_ROTATED` on every `active` flip in either direction (detection layer for downgrade attacks via direct DB write).
+- Drill (§6.5): rehearsal starts at generation N (the ground-truthed live state), runs the rotation endpoint, asserts generation N+1 active, asserts old-generation tokens minted pre-rotation still validate within grace, asserts new tokens carry new kid, asserts old-generation tokens are REJECTED past `grace_window` (positive control for the read-path correctness rule).
 
 ### #6 Master KEK — dual-key-accept (Tier 3 — needs design AND back-fill)
 
@@ -250,7 +352,8 @@ ROLLBACK (within grace window, before clients have reauthenticated):
 - Wire the 16-byte kid field in `EncryptionEnvelope` v1 (already reserved per `docs/FOR-DEVELOPERS.md`) so dual-key reads can match envelope kid against current vs previous KEK UUID.
 - Read path: try current → fall back to previous if kid matches previous's UUID. Write path: always current.
 - Re-wrap migration: re-emit every `tenant_dek` row under the new current key, then drop the previous key from prod env.
-- **Drill (§6.6):** rehearsal sets up `tenant_dek` rows under KEK-A, performs kid back-fill, then performs full migration to KEK-B, asserts: reads work for ALL rows (back-filled AND newly-encrypted), writes use KEK-B kid, dropping KEK-A doesn't break reads of rows written under KEK-B.
+- **AEAD construction (Marcus v3.2 CRITICAL):** kid alone MUST NOT authorize key selection. The envelope MUST be authenticated (AES-GCM or equivalent AEAD), the MAC MUST cover the kid field as **associated data**, and the read path MUST reject the envelope if MAC verification fails under the selected key. Without this, an attacker who knows a leaked PREVIOUS key can craft an envelope with attacker-controlled kid pointing to PREVIOUS → decrypt-with-leaked-key → forged plaintext under the application's signing posture. Mitigation is baked into the cryptographic primitive (AEAD); the design must specify it before any code lands.
+- **Drill (§6.6):** rehearsal sets up `tenant_dek` rows under KEK-A, performs kid back-fill, then performs full migration to KEK-B, asserts: reads work for ALL rows (back-filled AND newly-encrypted), writes use KEK-B kid, dropping KEK-A doesn't break reads of rows written under KEK-B, AND a tampered envelope with bad MAC is rejected (positive control for the AEAD assertion above).
 
 ---
 
@@ -268,6 +371,12 @@ ROLLBACK (within grace window, before clients have reauthenticated):
 ## 6. Rehearsal drill specifications
 
 **DV-tenant exclusion (control):** rehearsal seed data (`infra/scripts/seed-data.sql`) intentionally contains NO real DV-survivor PII and NO production DV-tenant rows — only synthetic `dev-coc*` tenants. **All drills below MUST operate against `dev-coc*` tenants only. Any drill that exercises DV-flagged shelter rows or DV-coordinator user paths is a process violation that must be flagged in warroom and the rehearsal env reset.** Casey-veto.
+
+**Rehearsal-harness trust boundary (Marcus v3.2 SIGNIFICANT):** the §0 policy makes `scripts/deploy-rehearsal.sh` authoritative for prod authorization. If the script is compromised via a malicious PR (drill that fakes "OK" silently), the gate is one-PR-deep. Mitigations:
+
+1. **Co-sign requirement (when second operator exists):** any PR that touches `scripts/deploy-rehearsal.sh` requires approval from a second operator before merge. Captured as future §7 backlog dependency.
+2. **Ledger flag (interim, single-operator):** every rehearsal-run-id in `rotation-ledger.json` MUST record the script's commit SHA at run time. If a rotation's recorded SHA differs from the SHA at the most-recent prior rotation, a manual review step is required before proceeding. This is the interim control while there is only one operator.
+3. **Branch-protection requirement:** `scripts/deploy-rehearsal.sh` is added to the CODEOWNERS file (or branch-protection allow-list) such that GitHub flags any change. This is a forcing function on the PR-review surface even without a second operator.
 
 Each drill becomes a numbered step in `scripts/deploy-rehearsal.sh`, added between the existing Step 8.5 (seed data load) and Step 9 (synthetic alert routing). Each one runs in 30-90 seconds; full rehearsal stays under 12 min.
 
@@ -459,22 +568,25 @@ Once `FABT_ENCRYPTION_KEY_PREVIOUS` envelope wiring + kid back-fill migration la
 | 1 | Review/parameterize `~/fabt-secrets/rotate-db-password.sh` | 30 min | Decision RECORDED in commit message: keep / parameterize / replace. Output committed. |
 | 2 | Add Step 8.9 SMTP-rotation drill to `scripts/deploy-rehearsal.sh` | 1 hr | Drill green; ENV_FILE guard tested with mutation (point at non-rehearsal file → exit non-zero). |
 | 3 | Author `rotate-smtp-password.md` referencing rehearsal as gate | 1 hr | Rollback section non-empty; prereqs + glossary header present. |
-| 4 | Run rehearsal → re-rotate prod SMTP under new runbook | 30 min | Rotation-ledger entry written; first proof of the policy. |
-| 5 | Add Step 8.8 DB-rotation drill (uses backend network path per H6) | 1 hr | Drill green; tested with mutation. |
-| 6 | Author `rotate-db-passwords.md` | 1 hr | Rollback section non-empty. |
-| 7 | Run rehearsal → rotate prod DB passwords | 30 min | Ledger entries × 2 (fabt_app + fabt). |
-| 8 | Author `rotate-oci-svc-principal.md` (no rehearsal — vendor-console; document the `systemd-network:systemd-journal` ownership constraint) | 2 hr | Rollback addresses the sudo / docker-stop / file-replace sequence. |
-| 9 | Author `rotate-grafana-admin.md` + add Step 8.x drill | 2 hr | Drill green. |
-| 10 | Author `rotate-cloudflare-token.md` + `rotate-github-pat.md` | 2 hr | Both reference vendor-console; no drill required. |
-| 11 | Add Step 8.11 JWT per-tenant kid-rotation drill (schema-grounded) | 3 hr | Drill green for 2 consecutive runs; uses real per-tenant SQL with RLS context. |
-| 12 | Author `rotate-jwt-secret.md` + dry-run on prod-demo | 4 hr | Authorize prod rotation ONLY after drill green for 2 consecutive runs AND dry-run successful. |
-| 13 | Set up `rotation-ledger.json` in docs repo + initial entries for SMTP (2026-04-22) + platform_key_material (2026-04-26) + OCI (2026-04-25) | 1 hr | Ledger checked in; pre-existing rotations back-filled with `grandfathered: pre-policy` flag set to true. **H1-r2 grandfather clause:** rotations that occurred BEFORE this policy was authored (anything before the date this plan is committed) are exempt from §0's "same-week rehearsal pass" requirement; they're recorded as historical fact only. Future incident-bypass rotations follow §0 in full. |
+| 4 | Set up `rotation-ledger.json` schema + initial pre-policy grandfathered entries (SMTP 2026-04-22, platform_key_material 2026-04-26, OCI 2026-04-25) — **moved up from former item 13 per Marcus v3.2** (ledger must exist BEFORE first rotation can record an entry) | 1 hr | Ledger checked in; per-entry schema includes `secret_id`, `rotated_at`, `operator`, `rehearsal_run_id`, `rehearsal_script_sha`, `bypass:bool`, `bypass_reason`, `backup_destroyed_at`, `snapshot_path`. Pre-existing rotations have `grandfathered: pre-policy`. |
+| 5 | Run rehearsal → re-rotate prod SMTP under new runbook | 30 min | First rotation entry written to ledger from #4. |
+| 6 | Add Step 8.8 DB-rotation drill (uses backend network path per H6) | 1 hr | Drill green; tested with mutation. |
+| 7 | Author `rotate-db-passwords.md` (includes pre-rotation pg_dump per Marcus v3.2) | 1 hr | Rollback section non-empty; pg_dump step present. |
+| 8 | Run rehearsal → rotate prod DB passwords | 30 min | Ledger entries × 2 (fabt_app + fabt). |
+| 9 | Author `rotate-oci-svc-principal.md` (no rehearsal — vendor-console; documents the `systemd-network:systemd-journal` ownership constraint AND the two-key-active detection step per Marcus v3.2) | 2 hr | Rollback addresses the sudo / docker-stop / file-replace sequence. |
+| 10 | Author `rotate-grafana-admin.md` + add Step 8.x drill | 2 hr | Drill green. |
+| 11 | Author `rotate-cloudflare-token.md` + `rotate-github-pat.md` | 2 hr | Both reference vendor-console; no drill required. |
+| 12 | Add Step 8.11 JWT per-tenant kid-rotation drill (schema-grounded, includes Marcus v3.2 audit-emit + `rotated_at < now() - grace_window` read-path assertion) | 3 hr | Drill green for 2 consecutive runs; uses real per-tenant SQL with RLS context; positive control for grace-window expiry. |
+| 13 | Author `rotate-jwt-secret.md` + dry-run on prod-demo | 4 hr | Authorize prod rotation ONLY after drill green for 2 consecutive runs AND dry-run successful AND read-path correctness fix shipped. |
 | 14 | Calendar entries for Tier 0 cadences (operator calendar + repository CALENDAR.md) | 30 min | Forcing function. |
-| 15 | OpenSpec change: `platform-jwt-key-rotation-tooling` (admin endpoint + flip job + Step 8.12 drill). **Note:** kid emission already in schema; only mint tooling needed. | 1-2 d | Tier 2 deliverable. |
-| 16 | OpenSpec change: `master-kek-dual-key-accept` (envelope + kid back-fill migration + Step 8.13 drill — pilot on TOTP path first) | 2-3 d spec + 2-3 wk impl (back-fill is the bulk) | Tier 3 deliverable. |
+| 15 | OpenSpec change: `platform-jwt-key-rotation-tooling` (admin endpoint + flip job + Step 8.12 drill + `SERIALIZABLE` transaction wrap + audit-emit-on-every-flip per Marcus v3.2). **Note:** kid emission already in schema; only mint tooling needed. | 1-2 d | Tier 2 deliverable. |
+| 16 | OpenSpec change: `master-kek-dual-key-accept` (envelope + kid back-fill migration + Step 8.13 drill — pilot on TOTP path first; **AEAD construction MUST cover kid in associated data per Marcus v3.2 CRITICAL**) | 2-3 d spec + 2-3 wk impl (back-fill is the bulk) | Tier 3 deliverable; AEAD assertion is a spec-level requirement, not implementation detail. |
 | 17 | CI guard: `secret-rotation-staleness` reads `rotation-ledger.json` and fails CI if any Tier 0 entry is past cadence | 4 hr | Forcing function so policy doesn't quietly drift. |
+| 18 | **Prometheus alert: key-material INSERT-rate (Marcus v3.2 SIGNIFICANT)** — fires when `tenant_key_material` or `platform_key_material` row-insert rate exceeds the expected rotation cadence (default: more than 1 per quarter per tenant). Catches unauthorized rotation via direct DB write. | 3 hr | Alert wired in `deploy/prometheus/`; rule tested in rehearsal via synthetic INSERT. |
+| 19 | **Prometheus alert: backup-destruction-staleness (Marcus v3.2 CRITICAL)** — fires when any `~/fabt-secrets/*.pre-*` file is older than 72h. Catches the §0 bypass-clause hygiene rule when the operator forgets to `shred`. | 2 hr | Alert wired; rule tested by leaving a stale backup in rehearsal env. |
+| 20 | **CODEOWNERS / branch-protection for `scripts/deploy-rehearsal.sh` (Marcus v3.2 SIGNIFICANT)** — adds the script to a CODEOWNERS allow-list so GitHub flags any change to the rehearsal harness. Interim until second operator exists. | 30 min | `.github/CODEOWNERS` updated; PR-time review enforced. |
 
-Items 0-4 ship the first rotation under the new policy in ~4 hr. Full Tier 0 set lands across items 5-14 in ~12 hr plus calendar entries.
+Items 0-5 ship the first rotation under the new policy in ~5 hr (added item 4 ledger setup per Marcus v3.2 sequencing). Full Tier 0 set lands across items 6-14 in ~12 hr plus calendar entries. Marcus v3.2 hardening items 18-20 add ~5.5 hr.
 
 ---
 
@@ -482,7 +594,7 @@ Items 0-4 ship the first rotation under the new policy in ~4 hr. Full Tier 0 set
 
 1. **Owner clarity.** Single-operator SPOF is documented (§3 footnote) but not resolved. Hire/recruit a second operator; until then, document operator-unavailability contingency (delegated emergency rotation authority, dead-man's-switch?).
 2. **Cadence calibration.** 90 vs 180 days for Tier 0 — 5-6 rotation events/year vs 2-3. Worth the tax at FABT's current scale?
-3. **Pre-rotation snapshot policy.** Before #4 (JWT) or #5 (Platform JWT) rotation, require a `pg_dump` of `tenant_key_material` + `platform_key_material` + `kid_to_tenant_key`? Definitely yes for #6 (KEK); debatable for #4/#5.
+3. **Pre-rotation snapshot policy.** **RESOLVED affirmatively by Marcus v3.2:** mandatory encrypted `pg_dump` of `tenant_key_material` + `platform_key_material` + `kid_to_tenant_key` + `jwt_revocations` before every Tier 1+ rotation; 30-day retention. The §4 DB procedure step 0a codifies this; §4 #4 and §4 #5 cite it as the beyond-grace rollback primitive. Question retained here for the record.
 4. **`rotation-ledger.json` schema.** Per-entry: `secret_id`, `rotated_at`, `operator`, `rehearsal_run_id` (or `bypass=true + reason` for incidents), `next_due`. Match anything?
 5. **Memory hygiene:** `project_oci_audit_anchor_credentials.md` should be aligned with the observed `audit-anchor.pem` mtime (2026-04-25). Small follow-up.
 6. **Shell-exported `${VAR}` migration.** §1 Location B documents the audit gap; the eventual fix is a sourced env file owned `ubuntu:ubuntu 600`. Is that a separate OpenSpec change or a §7 item?
@@ -514,6 +626,52 @@ These 8 MEDIUMs surfaced in warroom round 2 against v3. They're documented here 
 | M8-r2 | Alex | §4 #5 grace mechanism unstated — column on `platform_key_material` (`rotated_at` or `grace_until`) or wall-clock heuristic? | §7 item 15 (`platform-jwt-key-rotation-tooling` OpenSpec): pick one approach + cite schema implication. |
 
 **Verdict on these:** none block v3.1 shipping as a planning doc. All become acceptance criteria on §7 items 5, 11, 12, 15. The §10 listing exists so a future drill author can't claim "wasn't told."
+
+---
+
+## 11. Marcus security-persona additions (v3.2)
+
+After warroom rounds 1-3 (process/structure/drill rigor), the security persona ran a separate architectural-control review. The warroom focused on "is the procedure correct"; the security pass asked "as a security control, does this plan actually achieve secret-rotation safety and where does it leave attack surface?" Three CRITICAL + four SIGNIFICANT control gaps were identified; this section enumerates how each was addressed.
+
+### CRITICAL gaps closed
+
+| ID | Gap | v3.2 fix | Section(s) |
+|---|---|---|---|
+| MC-C1 | `.pre-rotation` backup lifecycle undefined; cleartext old secrets persist indefinitely | 72h post-smoke-clean `shred -u` step added to every §4 procedure; bypass-clause hygiene in §0; Prometheus alert in §7 item 19 | §0, §4 SMTP step 11, §4 DB step 11, §7 item 19 |
+| MC-C2 | Operator shell history is a credential store (`export FABT_*_PASSWORD=` lands in `~/.bash_history`) | SHELL-HYGIENE PREAMBLE block in every §4 procedure: `unset HISTFILE; set +o history; trap 'history -c' EXIT` BEFORE any `export`; explicit `history -c` step after rotation completes; in-memory `unset` of OLD_PWD/NEW_PWD | §3 footnote, §4 SMTP, §4 DB |
+| MC-C3 | No mandatory `pg_dump` of key-material tables before rotation; §4 #4 rollback fails open beyond grace | Step 0a added to §4 DB: encrypted `pg_dump` of `tenant_key_material` + `kid_to_tenant_key` + `jwt_revocations` before rotation; 30-day retention; §4 #4 + §4 #5 cite it as beyond-grace rollback primitive; §8 Q3 resolved affirmatively | §4 DB step 0a, §4 #4 PRE-ROTATION note, §4 #5, §8 Q3 |
+
+### SIGNIFICANT gaps closed
+
+| ID | Gap | v3.2 fix | Section(s) |
+|---|---|---|---|
+| MC-S1 | No detection layer for unauthorized rotation via direct DB write | Audit-emit-on-every-`active`-flip in BOTH directions (mint AND rollback) per §3 audit column; Prometheus alert on `tenant_key_material` / `platform_key_material` INSERT-rate | §3 audit column, §4 #4 step 5, §4 #5, §7 item 18 |
+| MC-S2 | OCI rotation has no "new+old both live" partial-state detection | §3 Detection column updated to include OCI list-keys assertion (post-policy); §7 item 9 acceptance criterion expanded | §3, §7 item 9 |
+| MC-S3 | Rehearsal-harness trust boundary unstated; gate is one-PR-deep | §6 preamble adds: (a) co-sign requirement when second operator exists, (b) ledger records `rehearsal_script_sha` (interim control), (c) CODEOWNERS/branch-protection requirement | §6 preamble, §7 item 4 (ledger schema), §7 item 20 (CODEOWNERS) |
+| MC-S4 | Downgrade attack via documented rollback path (R1 re-activates leaked old generation, no detection) | Read-path correctness rule added: validation MUST check `active = false AND rotated_at < now() - grace_window` and REJECT past grace, not just check `active`; audit emits on every `active=true ↔ false` transition (R1/R2 trigger emit) | §4 #4 read-path note + R1/R2, §4 #5 |
+
+### Cryptographic concerns addressed
+
+- **JWT kid validation** — explicit read-path rule in §4 #4: reject if `rotated_at < now() - grace_window`. Drill (§7 item 12) adds positive control for the rejection.
+- **Platform JWT grace window** — §4 #5 wraps INSERT-new + UPDATE-old in `SERIALIZABLE` transaction; M8-r2 (grace-window-mechanism-unstated) resolved by tying to the same `rotated_at` semantics as §4 #4.
+- **Dual-key envelope AEAD** — §4 #6 mandates: AEAD construction, kid in associated data, MAC verifies under selected key. Mitigates attacker-supplied kid pointing to a leaked previous-key UUID. Drill (§7 item 16) asserts MAC rejection on tampered envelope.
+
+### Reclassified items
+
+- **M4-r2** (`jwt_revocations` cache interaction during rotation) — was MEDIUM hygiene; reclassified as **security-adjacent**. Stale cache lets a leaked pre-rotation kid validate past its `rotated_at`. Now addressed in §4 #4 step 4 (DELETE FROM jwt_revocations during rotation transaction).
+
+### What remains as acceptance criteria on §7 items
+
+These Marcus v3.2 additions create new acceptance criteria on existing §7 backlog items rather than fixing the plan body further:
+
+- §7 item 12 (JWT drill): now includes positive control for past-grace token rejection
+- §7 item 15 (Platform JWT OpenSpec): now includes `SERIALIZABLE` transaction wrap + audit-emit-on-every-flip as spec requirements
+- §7 item 16 (Master KEK OpenSpec): AEAD construction with kid in associated data is now a spec-level requirement
+- §7 items 18-20 (new): Prometheus alerts + CODEOWNERS = the detection-layer and gate-trust controls
+
+### Net assessment (Marcus, post-v3.2)
+
+The plan now treats the rotation event as ending at `backup destruction + shell-history scrub + audit emit + (for Tier 1+) `pg_dump` retention`, not at `docker compose up`. With these additions plus the §7 items 18-20 hardening backlog, a third-party rotation audit would find a strong procedural framework backed by both DB-layer invariants and observability. The sole-operator SPOF (§3 footnote) remains an accepted operational risk; everything else has either a control or a documented backlog item to add one.
 
 ---
 

--- a/docs/operations/secret-rotation-plan.md
+++ b/docs/operations/secret-rotation-plan.md
@@ -1,0 +1,528 @@
+# Secret Rotation Plan (Draft v3.1, 2026-05-22)
+
+**Status:** planning — not yet a policy. Author + project lead must agree on cadences before this becomes operational.
+
+**Scope:** every secret material reachable from the FABT prod VM, plus the in-app rotation surfaces (API keys, platform passwords). Tenant data-encryption keys (`tenant_dek`) are out of scope here — they're already managed by the in-app crypto-shred lifecycle.
+
+**Goal:** turn "we rotated SMTP once after a leak" into a documented cadence with named owners, per-secret runbooks, and **a rehearsal gate that proves each runbook works before it touches prod**.
+
+**Ground-truthed:** 2026-05-22 via three SSH passes against the prod VM. All file paths, mtime dates, container ages, env-var inventories, `platform_key_material` + `tenant_key_material` schemas, and row counts in this document are observed, not assumed. See Appendix A for provenance.
+
+**Revision history:** v1 (2026-05-21, code-grounded only), v2 (2026-05-22, VM ground-truth + rehearsal gate), v3 (2026-05-22, warroom round 1 BLOCKER+HIGH fixes — 3 BLOCKERs + 14 HIGHs), v3.1 (2026-05-22, warroom round 2 HIGH fixes — 2 HIGHs applied, 8 MEDIUMs captured in §10).
+
+---
+
+## 0. Core principle — rehearsal is the gate
+
+The FABT rehearsal harness (`make rehearse-deploy`, see [`scripts/deploy-rehearsal.sh`](../../scripts/deploy-rehearsal.sh)) is a full prod-mirror compose stack with real Postgres, real Flyway, real backend container, real alertmanager, plus a Mailpit SMTP stub and ntfy stub. It runs in ~10 min, isolated via `COMPOSE_PROJECT_NAME=fabt-rehearsal` and offset ports.
+
+The rehearsal already catches ~80% of the v0.49-class deploy bugs (per the script's own header comment): env-var trailing-space, container UID file-perm, template-engine drift, service-recreate matrix, bind-mount inode pitfall, wrong actuator URL, plus the v0.57.0 pom-version mismatch and env-var-not-reaching-container classes. **The same harness can prove a rotation runbook is correct before it touches prod.**
+
+**Policy:**
+
+> Every secret-rotation runbook MUST be exercised end-to-end in `make rehearse-deploy` *before* being authorized for prod execution. **The green rehearsal run MUST be no more than 72 hours old** at the moment prod rotation begins — matching the `deploy/release-gate-pins.txt` precedent for deploy gates. A prod rotation without a fresh-enough rehearsal-green run is a process violation. The single exception is an active-incident rotation (confirmed leak), which may bypass the rehearsal gate but **MUST** be (a) recorded as a `bypass=true` entry in the rotation ledger (see §8 Q4) and (b) followed by a same-week rehearsal pass that exercises the procedure used.
+
+This costs ~10 min per rotation (rehearsal wall-clock) and pays for itself the first time a missed step would have broken prod. It is the natural extension of the gate `feedback_rehearsal_must_test_new_env_vars` established for env-var deploys (v0.57.0 abort lesson).
+
+**What rotations can be rehearsed** (see §6 for drill specs):
+
+| Tier | Secrets | Rehearsable? | Drill location |
+|---|---|---|---|
+| Periodic infra | DB×2 passwords, SMTP password, encryption key | **Yes — fully** | New Step 8.8 / 8.9 (Step 8.10 stays TBD until Tier 3 design lands) |
+| Code-supported rotation | JWT secret (per-tenant kid-rotation) | **Yes — and highest-value** because never end-to-end exercised | New Step 8.11 |
+| Tooling-deferred | Platform JWT signing key | When rotation-mint tooling ships, yes (schema already has `kid`) | (Step 8.12, ships with the tooling) |
+| External SaaS | OCI svc principal, Cloudflare token, GH PAT | **No — managed in vendor consoles** | n/a |
+
+---
+
+## 1. Inventory (ground-truthed 2026-05-22)
+
+The prod VM stores secrets in four locations:
+
+**Location A — `~/fabt-secrets/.env.prod`** (mtime 2026-05-05; 20 variable names confirmed via `awk -F= '{print $1}'` — values not printed). Contains:
+- `FABT_ALERT_*` (9 vars: SMTP host/port/user/password/TLS, email-from/to, ntfy URL/topic)
+- `FABT_ENCRYPTION_KEY` (single master KEK — see note below)
+- `FABT_OCI_AUDIT_ANCHOR_*` (9 vars: tenancy + user + compartment OCIDs, region, namespace, bucket, fingerprint, private-key path, enabled flag)
+- `FABT_PLATFORM_CONTACT_EMAIL` — note this is a real human-facing address; survivors and the public may write to it, so changing it has user-visible implications beyond credential rotation.
+
+**Location B — `~/fabt-secrets/docker-compose.prod.yml`** (mtime 2026-05-05; YAML key + `${VAR}`-reference names confirmed; values not printed). References (via `${VAR}`):
+- `FABT_DB_*_PASSWORD` (app + owner), `FABT_DB_*_USER`, `FABT_DB_URL`
+- `FABT_JWT_SECRET`
+- `FABT_ENCRYPTION_KEY` (also surfaced here as backend env)
+- `POSTGRES_PASSWORD`, `POSTGRES_USER`, `POSTGRES_DB`
+- `GF_SECURITY_ADMIN_PASSWORD` (Grafana admin)
+- Standard Spring / SpringDoc / OTel tracing config
+
+These are `${VAR}` references — the actual values come from the operator's shell environment at `docker compose up` time. The values do not appear in any file owned by `ubuntu` (verified via the awk-only scan). **This is an audit gap** (§8 Q5): there's no sourced env file owned `ubuntu:ubuntu 600` capturing these; values live in shell history.
+
+**Location C — Postgres tables (live, 2026-05-22 observation):**
+
+| Table | Purpose | Schema | State |
+|---|---|---|---|
+| `tenant_key_material` | Per-tenant JWT signing key material | `(tenant_id, generation, created_at, rotated_at, active)` PK on `(tenant_id, generation)`, partial unique `(tenant_id) WHERE active=true`, check constraint `active=true ↔ rotated_at IS NULL`, ON DELETE CASCADE from tenant. RLS-protected. | **3 total / 3 active** rows (one per dev-coc / dev-coc-east / dev-coc-west tenant; all generation=1, none rotated) |
+| `kid_to_tenant_key` | Kid registry mapping JWT kid → tenant + generation | `(kid uuid PK, tenant_id, generation, created_at)`, FK to `tenant_key_material(tenant_id, generation)`. RLS-protected. | Populated alongside tenant_key_material |
+| `platform_key_material` | Platform JWT signing key material | `(id, generation, kid, key_bytes, active, created_at)`, partial unique `(true) WHERE active=true` (global single-active). **kid IS in the schema and emitted in tokens.** | 1 row, generation=1, active=true, kid populated, created **2026-04-26 22:56 UTC (27 days old). Never rotated.** |
+| `jwt_revocations` | Revoked-kid cache | (schema not pulled in this pass) | (not enumerated) |
+| `pg_roles.rolvaliduntil` for `fabt` + `fabt_app` | Postgres-side password expiry | n/a | **NULL** (perpetual; no Postgres-side expiry policy set) |
+| `api_key.rotated_at` | In-app per-tenant API-key rotation history | n/a | Already managed via shipped `/api/v1/api-keys/{id}/rotate` |
+
+**Location D — operator's `oci/` directory** (`~/fabt-secrets/oci/`): one file, `audit-anchor.pem` (mtime 2026-04-25; 27 days old). **Owner: `systemd-network:systemd-journal` (NOT `ubuntu`)** — this is the OCI Java SDK container's mount UID/GID. Implication for the rotation runbook: the operator (`ubuntu`) cannot directly overwrite this file; rotation needs `sudo` or a docker-stop / file-replace / docker-up sequence. The OCI runbook must capture this explicitly.
+
+**Existing rotation primitives on the VM:**
+- `~/fabt-secrets/rotate-db-password.sh` (9 lines, exists since 2026-03-30). References `docker exec`, `psql`, and `ALTER ROLE`. **This is the foundation for the DB-rotation runbook** — needs review + parameterization, not net-new authoring. §7 item 1 names the decision (keep / parameterize / replace) as a deliverable, not an implicit operator call.
+- 4 timestamped `.env.prod.pre-<reason>-<timestamp>` backups already exist in `~/fabt-secrets/`. **The operator already practices "save backup before editing" hygiene; the runbooks codify it as the rollback primitive (§4 procedures).**
+
+**Full inventory table** (combined view, prod-side):
+
+| # | Secret | Storage location | Last touched (observed) | Rotation supported in code? | Blast radius | Tier |
+|---|---|---|---|---|---|---|
+| 1 | `FABT_DB_APP_PASSWORD` (`fabt_app` role) | Operator shell → `docker-compose.prod.yml` `${VAR}` | unknown (no rotation log) | Yes — `ALTER ROLE` online; existing `rotate-db-password.sh` script | Read/write all non-RLS-hidden rows for caller's tenant | 0 |
+| 2 | `FABT_DB_OWNER_PASSWORD` (`fabt` role) | Operator shell → `docker-compose.prod.yml` `${VAR}` | unknown | Yes — same | Full DB; bypass RLS; runs Flyway | 0 |
+| 3 | `POSTGRES_PASSWORD` (container superuser) | Operator shell → `docker-compose.prod.yml` `${VAR}` | unknown — set at first container init | Partial — requires Postgres container recreate; data persists | Full DB superuser (`postgres` role); rare to use post-init | 0 (low-frequency) |
+| 4 | `FABT_JWT_SECRET` (tenant JWTs, iss=fabt) | Operator shell → `docker-compose.prod.yml` `${VAR}`. **Per-tenant key material lives in `tenant_key_material` + `kid_to_tenant_key`.** | unknown for env var / **2026-04-26 for material rows** (generation 1, all 3 tenants, none rotated) | **Yes** — schema supports kid-keyed rotation per-tenant (insert new generation row, flip prior to active=false + set rotated_at). Runtime read path via `KidRegistryService` + revoked-kid cache. **Never exercised end-to-end.** | Forge any tenant user's session | 1 |
+| 5 | Platform JWT signing key (iss=fabt-platform) | DB `platform_key_material` (generation 1, kid populated, active=true, created 2026-04-26) | **2026-04-26 (27 days ago)** — never rotated | **Partial** — schema ships with `kid` + `(true) WHERE active=true` partial-unique. Tokens emit kid header. Missing: rotation MINT tooling (admin endpoint that inserts new active generation and flips prior). | Forge platform-operator session | 2 |
+| 6 | `FABT_ENCRYPTION_KEY` (master KEK — *AND* TOTP-secret encryption via fallback) | `.env.prod` (single variable in prod; rehearsal env has two for parity with future split — see §8 Q3) | unknown — file last edited 2026-05-05 for `FABT_PLATFORM_CONTACT_EMAIL` addition (NOT a key change) | **No** — single-key only. `EncryptionEnvelope` v1 envelope has a 16-byte kid field reserved per `docs/FOR-DEVELOPERS.md` but **legacy envelopes have null/zero kid and need a back-fill migration before dual-key works** | Decrypt **every** tenant DEK → every encrypted PII column + every TOTP secret. **Loss = irrecoverable data loss; survivor-safety failure mode: TOTP secrets unrecoverable → MFA-locked DV operators cannot reach the system.** | 3 |
+| 7 | `FABT_ALERT_SMTP_PASSWORD` | `.env.prod` | **2026-04-22 (30 days ago)** — rotated after v0.49 leak | Yes — Gmail console + `alertmanager.yml` regen + alertmanager recreate | Send/receive mail as the alert mailbox | 0 |
+| 8 | `GF_SECURITY_ADMIN_PASSWORD` (Grafana admin) | Operator shell → `docker-compose.prod.yml` `${VAR}` | unknown | Yes — Grafana UI rotation + container env update + recreate | Grafana admin → view all dashboards / change config | 0 |
+| 9 | OCI svc principal (`fabt-audit-anchor`) | `.env.prod` (9 vars) + key file `~/fabt-secrets/oci/audit-anchor.pem` (**owner `systemd-network:systemd-journal`, not ubuntu — needs sudo to overwrite**) | **2026-04-25 (27 days ago)** for the .pem file mtime | Yes — OCI console rotates fingerprint+key+OCID | OCI bucket write (audit anchoring fails open or false-anchors) | 0 |
+| 10 | `FABT_PLATFORM_CONTACT_EMAIL` | `.env.prod` | **2026-05-05 (17 days ago)** | n/a — not a secret, contains a real human-facing address. Changing it has user-visible legal/process implications (survivors may write to it). | Public address — but `feedback_no_ip_in_repo` posture: never committed to git | n/a |
+
+**External secrets — NOT stored on the VM:**
+
+| # | Secret | Where it lives | Notes |
+|---|---|---|---|
+| 11 | Cloudflare API token | Cloudflare dashboard | Not in `.env.prod` (confirmed). Used from operator laptop only. |
+| 12 | GitHub PAT (for `gh` CLI / Actions) | GitHub Actions secrets (CI) + operator laptop (`~/.config/gh/`) | Not in `.env.prod` (confirmed). |
+
+**In-app rotation surfaces (shipped, included for completeness):**
+
+| Surface | Rotation mechanism | Coverage |
+|---|---|---|
+| Per-tenant API keys | `POST /api/v1/api-keys/{id}/rotate` (24h grace; `rotated_at` column populated) | Already documented in `docs/FOR-DEVELOPERS.md` |
+| Platform-operator passwords | In-UI invite + first-password flow (Slice E, v0.54) | Per-user, on-demand |
+| Per-tenant `tenant_dek` | Crypto-shred via tenant FSM lifecycle | Per-tenant, on tenant decommission |
+
+---
+
+## 2. Risk tiers
+
+**All Tier 0 and Tier 1 work goes through the rehearsal gate; Tier 2 and Tier 3 build the rehearsal drills as part of their tooling deliverable.**
+
+**Tier 0 — periodic hygiene (rehearseable; rotate on calendar):**
+- #1 DB app password — quarterly
+- #2 DB owner password — annually (lower blast tier; requires VM access to use)
+- #3 POSTGRES_PASSWORD — annually
+- #7 SMTP password — quarterly (already at 30 days; next due ~2026-07-22)
+- #8 Grafana admin password — quarterly
+- #9 OCI svc principal — quarterly *(per OCI best practice + audit-anchor posture)*
+- #11 Cloudflare token — quarterly (vendor-console only; can't rehearse)
+- #12 GitHub PAT — annually (Fine-Grained PAT 1y max; vendor-console only)
+
+**Tier 1 — rehearseable; rotate after incident OR annually with planning:**
+- #4 `FABT_JWT_SECRET` + per-tenant key material — annually. Schema supports kid rotation but never exercised end-to-end. Rehearsal drill (§6.4) retires the "tooling exists but never run" risk *before* first prod rotation.
+
+**Tier 2 — needs MINT tooling; rehearsal drill ships with the tooling:**
+- #5 Platform JWT signing key — schema is ready (kid emitted in tokens, partial-unique-on-active enforces single live generation). Need an admin endpoint to mint a new active row + flip prior + enforce grace window. Drill becomes Step 8.12.
+
+**Tier 3 — needs design work AND legacy-envelope kid back-fill; rehearsal is the natural proving ground when design ships:**
+- #6 `FABT_ENCRYPTION_KEY` (master KEK + TOTP via fallback) — needs dual-key-accept envelope. `EncryptionEnvelope` already reserves a kid slot per `docs/FOR-DEVELOPERS.md`, but **existing v1 envelopes in `tenant_dek` and any other encrypted column have null/zero kid and must be back-filled (re-wrapped) before dual-key reads can work.** Plan: pilot the dual-key design on TOTP-encryption-only path (lower blast radius) before applying to the master KEK.
+
+---
+
+## 3. Recommended cadences
+
+| Tier | Secret | Cadence | Owner | Detection / how operator knows to bring it forward |
+|---|---|---|---|---|
+| 0 | #1 DB app password | every 90 days | sole operator¹ | Operator-initiated only (no automated detection today) |
+| 0 | #2 DB owner password | every 365 days | sole operator¹ | Operator-initiated only |
+| 0 | #3 POSTGRES_PASSWORD | every 365 days | sole operator¹ | Operator-initiated only |
+| 0 | #7 SMTP password | every 90 days | sole operator¹ | Operator-initiated; Gmail security-alert email triggers incident path |
+| 0 | #8 Grafana admin | every 90 days | sole operator¹ | Operator-initiated only |
+| 0 | #9 OCI svc principal | every 90 days | sole operator¹ | OCI audit-log scan deferred (manual quarterly review) |
+| 0 | #11 Cloudflare token | every 90 days | sole operator¹ | CF audit log scan deferred (manual quarterly review) |
+| 0 | #12 GitHub PAT | every 365 days (or fine-grained 90d) | sole operator¹ | GitHub email warning on PAT expiry |
+| 1 | #4 JWT secret + per-tenant key material | every 365 days OR on suspected forgery | sole operator¹ + dev | Forgery suspected; key-derivation downgraded |
+| 2 | #5 Platform JWT key | every 365 days once tooling ships | sole operator¹ + dev | Platform-operator account compromise |
+| 3 | #6 Master KEK | DO NOT rotate until dual-key-accept design ships + kid back-fill complete. Annually thereafter. | sole operator¹ + dev | KEK exposure (catastrophic) |
+
+¹ **Owner = sole operator (project lead Corey Cradle) today. No documented fallback exists.** When a second operator joins, the dev/ops split formalizes per §8 Q1. Until then, this column is a single-point-of-failure for every rotation: operator illness, PTO, or unavailability blocks rotation. **Risk-acceptance, not policy compliance.**
+
+**Documented exception:** any secret on this list can be rotated *immediately* outside cadence in response to a confirmed leak (the SMTP rotation 2026-04-22 set the precedent). Incident rotations bypass the rehearsal gate per §0 but require (a) ledger entry with `bypass=true` + reason + operator timestamp, (b) a same-week rehearsal follow-up.
+
+---
+
+## 4. Per-secret procedure sketches
+
+These are *sketches* — each becomes a full runbook under `docs/operations/runbooks/` (using the §7 item 0 template). Each runbook MUST include: prerequisites (with glossary for `envsubst` / `amtool` / kid / RLS / bind-mount), the procedure, an explicit rollback section, and a smoke-gate definition.
+
+### #7 SMTP password (precedent: 2026-04-22 rotation)
+
+```
+PREREQUISITES: envsubst on PATH, $EDITOR set, alertmanager.yml.tmpl present.
+GLOSSARY: envsubst = GNU env-var substitution; alertmanager UID 65534 = nobody.
+NEVER-PRINT INVARIANT (control, not citation): the next steps edit and re-render
+files that contain the SMTP password. Do NOT `cat`, `head`, `tail`, `grep`, or
+otherwise output any portion of the rendered file to your terminal at any point.
+`$EDITOR` opens the file directly without piping its contents.
+
+1. Gmail → security → app passwords → revoke old, create new (do NOT print)
+2. cp ~/fabt-secrets/.env.prod ~/fabt-secrets/.env.prod.pre-smtp-$(date +%Y%m%d-%H%M%S)
+   # ⚠ This backup IS the rollback primitive — referenced by step ROLLBACK below.
+3. Edit .env.prod via $EDITOR (NEVER cat/grep first)
+4. cd ~/finding-a-bed-tonight && envsubst < deploy/alertmanager.yml.tmpl > ~/fabt-secrets/alertmanager.yml
+5. chmod 644 ~/fabt-secrets/alertmanager.yml  (alertmanager UID 65534 needs read)
+6. docker compose -f docker-compose.yml -f ~/fabt-secrets/docker-compose.prod.yml up -d --force-recreate alertmanager
+7. Smoke gate: amtool alert add test → confirm receipt at alert mailbox
+8. Audit: confirm old app password rejected in Gmail console
+9. Ledger: append entry to rotation-ledger.json (secret=SMTP, ts, operator, rehearsal-run-id)
+
+ROLLBACK (if step 6, 7, or 8 fails):
+  R1. mv ~/fabt-secrets/.env.prod.pre-smtp-<ts> ~/fabt-secrets/.env.prod
+  R2. envsubst < deploy/alertmanager.yml.tmpl > ~/fabt-secrets/alertmanager.yml ; chmod 644
+  R3. docker compose ... up -d --force-recreate alertmanager
+  R4. Re-test with old password via amtool
+  R5. File post-incident note explaining what failed BEFORE attempting rotation again
+```
+
+### #1 / #2 DB passwords (leverage existing `rotate-db-password.sh`)
+
+```
+PREREQUISITES: openssl, docker exec, psql. Existing 9-line rotate-db-password.sh
+  reviewed/parameterized per §7 item 1.
+GLOSSARY: ALTER ROLE = Postgres role-password update; pg_hba = host-based auth config.
+
+1. Generate new password: NEW_PWD=$(openssl rand -base64 32)
+2. cp ~/fabt-secrets/docker-compose.prod.yml ~/fabt-secrets/docker-compose.prod.yml.pre-db-$(date +%Y%m%d-%H%M%S)
+3. As operator shell: export FABT_DB_APP_PASSWORD="$NEW_PWD"
+4. bash ~/fabt-secrets/rotate-db-password.sh fabt_app  (runs ALTER ROLE inside container)
+5. docker compose -f ... up -d --force-recreate backend
+6. Smoke gate: /actuator/health green; one authenticated API request green
+7. Audit: psql connect with OLD password rejected; NEW password accepted via the
+   SAME network path the backend uses (postgres:5432 service DNS, not localhost)
+8. Ledger entry
+
+ROLLBACK:
+  R1. ALTER ROLE fabt_app WITH PASSWORD '<old>'  (operator must have old in their
+      shell history or in the .pre-db-<ts> backup of docker-compose.prod.yml)
+  R2. export FABT_DB_APP_PASSWORD='<old>' ; docker compose ... up -d --force-recreate backend
+  R3. /actuator/health
+```
+
+### #4 JWT secret per-tenant kid-rotation (already supported, never exercised)
+
+```
+PREREQUISITES: psql access, knowledge of kid-keyed JWT validation.
+GLOSSARY: kid = key-id JWT header field; tenant_key_material partial-unique on
+  (tenant_id) WHERE active=true enforces single live generation per tenant.
+
+For each tenant T:
+1. Begin tenant context (RLS): SET LOCAL fabt.current_tenant_id = '<T>';
+2. UPDATE tenant_key_material SET active = false, rotated_at = clock_timestamp()
+     WHERE tenant_id = '<T>' AND active = true;
+3. INSERT INTO tenant_key_material (tenant_id, generation, created_at, active)
+     VALUES ('<T>', <max_gen + 1>, clock_timestamp(), true);
+4. INSERT INTO kid_to_tenant_key (kid, tenant_id, generation)
+     VALUES (gen_random_uuid(), '<T>', <max_gen + 1>);
+5. Commit. Caches expire normally; clients reauthenticate over 15-min TTL window.
+
+The check constraint `active=true AND rotated_at IS NULL OR active=false AND
+rotated_at IS NOT NULL` enforces shape; the partial unique index prevents two
+active rows per tenant.
+
+ROLLBACK (within grace window, before clients have reauthenticated):
+  R1. UPDATE tenant_key_material SET active=true, rotated_at=NULL WHERE generation=<old>;
+  R2. UPDATE tenant_key_material SET active=false, rotated_at=clock_timestamp() WHERE generation=<new>;
+  R3. Verify partial-unique invariant still holds.
+```
+
+### #5 Platform JWT signing key (Tier 2 — needs tooling)
+
+- Build `POST /api/v1/platform/key-material/rotate` endpoint, `@PlatformAdminOnly`
+- Calls `KeyDerivationService.derivePlatformJwtKeyBytes(new UUID)` → INSERT new row with new kid + active=true + generation=N+1 → flip previous to active=false (partial-unique prevents two active rows)
+- During grace window (1 hr default), platform JWT verifier accepts either generation by looking up `platform_key_material WHERE kid=<header.kid>` (kid is already in schema and emitted in tokens — no kid-emission pre-work needed)
+- Audit emit: `PLATFORM_KEY_ROTATED`
+- Drill (§6.5): rehearsal starts at generation N (the ground-truthed live state), runs the rotation endpoint, asserts generation N+1 active, asserts old-generation tokens minted pre-rotation still validate within grace, asserts new tokens carry new kid.
+
+### #6 Master KEK — dual-key-accept (Tier 3 — needs design AND back-fill)
+
+- Two env vars: `FABT_ENCRYPTION_KEY_CURRENT`, `FABT_ENCRYPTION_KEY_PREVIOUS`
+- **Prerequisite — kid back-fill migration:** existing v1 envelopes in `tenant_dek` (and any other encrypted column populated under the current single-key regime) have null/zero in their reserved kid bytes. A migration MUST iterate every encrypted row, read with the current key, re-emit the envelope with the current key's UUID populated in the kid slot. Until this back-fill runs, dual-key reads cannot determine which key encrypted a legacy row.
+- Wire the 16-byte kid field in `EncryptionEnvelope` v1 (already reserved per `docs/FOR-DEVELOPERS.md`) so dual-key reads can match envelope kid against current vs previous KEK UUID.
+- Read path: try current → fall back to previous if kid matches previous's UUID. Write path: always current.
+- Re-wrap migration: re-emit every `tenant_dek` row under the new current key, then drop the previous key from prod env.
+- **Drill (§6.6):** rehearsal sets up `tenant_dek` rows under KEK-A, performs kid back-fill, then performs full migration to KEK-B, asserts: reads work for ALL rows (back-filled AND newly-encrypted), writes use KEK-B kid, dropping KEK-A doesn't break reads of rows written under KEK-B.
+
+---
+
+## 5. Closed open questions from earlier drafts
+
+| # | Question | Status |
+|---|---|---|
+| v1-Q3 | Cloudflare token + GitHub PAT in `.env.prod`? | **Answered: no.** Confirmed via `awk` variable-name scan 2026-05-22. Vendor-console / operator-laptop only. |
+| v1-Q4 | OCI captured-at date in memory file — accurate? | **Partially answered.** `~/fabt-secrets/oci/audit-anchor.pem` mtime is 2026-04-25 (27 days). Memory file capture-date should be aligned (§8 Q5). |
+| v1-Q5 | `FABT_PLATFORM_CONTACT_EMAIL` — move out of `.env.prod`? | **Answered: leave it.** Currently in `.env.prod`, last edited 2026-05-05. **Approval co-signed:** operator decision (sole operator); flagged in §8 for second-operator review when one joins. |
+| v2-Q3 | KEK + TOTP — one key or two? | **Answered: one in prod, two in rehearsal env.** `.env.prod` has only `FABT_ENCRYPTION_KEY` — TOTP path falls back to it via `SecretEncryptionService`. Rehearsal env mirrors a *future* split (forward-compatibility) but prod is single-key. |
+
+---
+
+## 6. Rehearsal drill specifications
+
+**DV-tenant exclusion (control):** rehearsal seed data (`infra/scripts/seed-data.sql`) intentionally contains NO real DV-survivor PII and NO production DV-tenant rows — only synthetic `dev-coc*` tenants. **All drills below MUST operate against `dev-coc*` tenants only. Any drill that exercises DV-flagged shelter rows or DV-coordinator user paths is a process violation that must be flagged in warroom and the rehearsal env reset.** Casey-veto.
+
+Each drill becomes a numbered step in `scripts/deploy-rehearsal.sh`, added between the existing Step 8.5 (seed data load) and Step 9 (synthetic alert routing). Each one runs in 30-90 seconds; full rehearsal stays under 12 min.
+
+**All drills MUST start with the rehearsal-env guard** (B3 fix):
+
+```bash
+[[ "$ENV_FILE" == *.rehearsal ]] \
+  || fail "drill REFUSES to run against non-rehearsal env file: $ENV_FILE"
+```
+
+This ENV_FILE guard is a top-of-drill control, not a citation — copy/paste of the drill verbatim against `.env.prod` will exit non-zero before any `sed -i` touches the file.
+
+**Rehearsal env reset** (M1 fix): each drill snapshots `.env.rehearsal` at start (`cp .env.rehearsal /tmp/env-pre-<drill>-<ts>`) and restores it at end. Two consecutive `make rehearse-deploy` runs MUST produce byte-identical results in the env file.
+
+### §6.1 — Step 8.8: DB app-password rotation drill
+
+```bash
+[[ "$ENV_FILE" == *.rehearsal ]] || fail "..."
+cp "$ENV_FILE" "$ENV_FILE.pre-drill-$$"
+trap "mv '$ENV_FILE.pre-drill-$$' '$ENV_FILE'" EXIT
+
+NEW_PWD=$(openssl rand -base64 32)
+
+# 1. ALTER ROLE inside Postgres container (mirrors prod)
+docker exec fabt-rehearsal-postgres psql -U fabt -d fabt -c \
+  "ALTER ROLE fabt_app WITH PASSWORD '$NEW_PWD';" >/dev/null
+
+# 2. Old password rejected — assert via BACKEND NETWORK PATH (postgres:5432
+#    service DNS), not localhost-inside-container. This matches what the
+#    backend container actually does per docker-compose env line 38.
+#    (H6 fix.)
+docker run --rm --network fabt-rehearsal_default \
+  -e PGPASSWORD='<OLD>' postgres:16-alpine \
+  psql -h postgres -U fabt_app -d fabt -c "SELECT 1;" 2>&1 \
+  | grep -q "authentication failed" \
+  || fail "BACKEND PATH: old password should be rejected after rotation"
+
+# 3. New password works via backend path
+docker run --rm --network fabt-rehearsal_default \
+  -e PGPASSWORD="$NEW_PWD" postgres:16-alpine \
+  psql -h postgres -U fabt_app -d fabt -c "SELECT 1;" >/dev/null \
+  || fail "BACKEND PATH: new password should authenticate"
+
+# 4. Backend env updated + recreate
+sed -i "s|^FABT_DB_APP_PASSWORD=.*|FABT_DB_APP_PASSWORD=$NEW_PWD|" "$ENV_FILE"
+docker compose -f docker-compose.yml -f deploy/rehearsal-prod-overlay.yml \
+  -p fabt-rehearsal up -d --force-recreate backend
+
+# 5. Backend health green within 60s
+wait_for_health || fail "backend failed to come up with new password"
+
+echo "[OK] Step 8.8: DB app-password rotation drill"
+```
+
+### §6.2 — Step 8.9: SMTP password rotation drill (Mailpit-validated)
+
+```bash
+[[ "$ENV_FILE" == *.rehearsal ]] || fail "..."
+cp "$ENV_FILE" "$ENV_FILE.pre-drill-$$"
+trap "mv '$ENV_FILE.pre-drill-$$' '$ENV_FILE'" EXIT
+
+OLD_SMTP_PWD=$(awk -F= '/^FABT_ALERT_SMTP_PASSWORD/{print $2}' "$ENV_FILE")
+# REHEARSAL-ONLY PATTERN: the next assignment uses a plaintext value as the
+# Mailpit-auth-log-grep needle. This is intentional for a Mailpit-stubbed
+# rehearsal where the value carries no real authority. DO NOT lift this
+# pattern into any prod runbook — `grep -F "$REAL_SECRET"` in a prod context
+# would print the secret to the operator's terminal and recent shell history,
+# which violates `feedback_never_print_rendered_secrets`. Prod rotations
+# verify success via the OUTCOME (alert lands, /actuator/health green, etc.),
+# never by grepping for the secret value itself.
+NEW_SMTP_PWD="rehearsal-rotated-$(date +%s)"
+
+sed -i "s|^FABT_ALERT_SMTP_PASSWORD=.*|FABT_ALERT_SMTP_PASSWORD=$NEW_SMTP_PWD|" "$ENV_FILE"
+
+# Per-var envsubst with explicit error on missing (M7 fix)
+for v in FABT_ALERT_SMTP_HOST FABT_ALERT_SMTP_PORT FABT_ALERT_SMTP_USER \
+         FABT_ALERT_SMTP_PASSWORD FABT_ALERT_SMTP_REQUIRE_TLS \
+         FABT_ALERT_EMAIL_FROM FABT_ALERT_EMAIL_TO \
+         FABT_ALERT_NTFY_URL FABT_ALERT_NTFY_TOPIC; do
+  grep -q "^$v=" "$ENV_FILE" || fail "drill: env var $v missing from $ENV_FILE"
+done
+envsubst < deploy/alertmanager.yml.tmpl > ~/.fabt-rehearsal/alertmanager.yml
+chmod 644 ~/.fabt-rehearsal/alertmanager.yml
+
+docker compose ... up -d --force-recreate alertmanager
+
+# Capture Mailpit message-count BEFORE firing the alert (H5 fix)
+PRE_COUNT=$(curl -sS http://localhost:18025/api/v1/messages | jq '.messages | length')
+
+amtool alert add severity=test test_alert_id=rotation-drill \
+  --alertmanager.url=http://localhost:19093
+
+# Wait up to 30s for new message to arrive
+for i in {1..30}; do
+  POST_COUNT=$(curl -sS http://localhost:18025/api/v1/messages | jq '.messages | length')
+  [[ "$POST_COUNT" -gt "$PRE_COUNT" ]] && break
+  sleep 1
+done
+[[ "$POST_COUNT" -gt "$PRE_COUNT" ]] \
+  || fail "rotated SMTP password did not deliver: count was $PRE_COUNT, now $POST_COUNT"
+
+# H5: assert Mailpit auth log shows the NEW password was used (not the old).
+# Mailpit logs SMTP-AUTH attempts; the most recent AUTH line MUST contain
+# the new-password marker (the timestamp-derived stub uniquely identifies the
+# new value).
+docker logs fabt-rehearsal-mailpit 2>&1 \
+  | grep -F "$NEW_SMTP_PWD" \
+  || fail "Mailpit auth log does NOT show the new password — drill passed on stale creds"
+
+echo "[OK] Step 8.9: SMTP rotation drill (count + auth-log verified)"
+```
+
+### §6.3 — Step 8.10: deferred until Tier 3 design lands
+
+The encryption-key envelope round-trip drill cannot ship until the dual-key envelope design ships (§4 #6). Placeholder kept here so the numbering aligns with §6.6 when it does land.
+
+### §6.4 — Step 8.11: JWT-secret per-tenant kid-rotation drill (HIGHEST VALUE)
+
+Retires the "code supports it but never exercised end-to-end" risk. Schema verified 2026-05-22 against prod: `tenant_key_material` PK `(tenant_id, generation)`, partial unique `(tenant_id) WHERE active=true`, check constraint `active ↔ rotated_at IS NULL`. RLS-protected — drill MUST set `fabt.current_tenant_id` before mutations.
+
+```bash
+[[ "$ENV_FILE" == *.rehearsal ]] || fail "..."
+
+# 1. Pick a non-DV dev tenant (DV exclusion control)
+TENANT_ID=$(docker exec fabt-rehearsal-postgres psql -U fabt -d fabt -tA -c \
+  "SELECT id FROM tenant WHERE slug='dev-coc' LIMIT 1;")
+[[ -n "$TENANT_ID" ]] || fail "dev-coc tenant not seeded"
+
+# 2. Capture a token minted under current generation
+OLD_TOKEN=$(curl -sS -X POST http://localhost:18080/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"outreach@dev.fabt.org","password":"admin123","tenantSlug":"dev-coc"}' \
+  | jq -r .accessToken)
+# URL-safe base64 decode with padding fix (N2)
+PAD() { echo "$1" | awk '{ l=length($0); p=(4-l%4)%4; printf "%s", $0; for(i=0;i<p;i++) printf "="; }' | tr '_-' '/+'; }
+OLD_KID=$(PAD "$(echo "$OLD_TOKEN" | cut -d. -f1)" | base64 -d 2>/dev/null | jq -r .kid)
+[[ "$OLD_KID" != "null" && -n "$OLD_KID" ]] || fail "old token missing kid header"
+
+# 3. Insert new generation row inside tenant context (RLS)
+docker exec fabt-rehearsal-postgres psql -U fabt -d fabt <<SQL
+BEGIN;
+SET LOCAL fabt.current_tenant_id = '$TENANT_ID';
+WITH cur AS (
+  SELECT generation FROM tenant_key_material
+  WHERE tenant_id='$TENANT_ID' AND active=true
+)
+UPDATE tenant_key_material
+  SET active=false, rotated_at=clock_timestamp()
+  WHERE tenant_id='$TENANT_ID' AND active=true;
+INSERT INTO tenant_key_material (tenant_id, generation, created_at, active)
+  SELECT '$TENANT_ID', generation+1, clock_timestamp(), true FROM cur;
+INSERT INTO kid_to_tenant_key (kid, tenant_id, generation)
+  SELECT gen_random_uuid(), '$TENANT_ID', generation+1 FROM cur;
+COMMIT;
+SQL
+
+# 4. Mint a fresh token, assert it carries the NEW kid
+NEW_TOKEN=$(curl -sS -X POST http://localhost:18080/api/v1/auth/login \
+  -H 'Content-Type: application/json' \
+  -d '{"email":"outreach@dev.fabt.org","password":"admin123","tenantSlug":"dev-coc"}' \
+  | jq -r .accessToken)
+NEW_KID=$(PAD "$(echo "$NEW_TOKEN" | cut -d. -f1)" | base64 -d 2>/dev/null | jq -r .kid)
+[[ "$NEW_KID" != "$OLD_KID" && -n "$NEW_KID" ]] \
+  || fail "new token should carry new kid; old=$OLD_KID new=$NEW_KID"
+
+# 5. Assert OLD token still validates within grace
+HTTP=$(curl -sS -o /dev/null -w '%{http_code}' http://localhost:18080/api/v1/me \
+  -H "Authorization: Bearer $OLD_TOKEN")
+[[ "$HTTP" == "200" ]] || fail "old kid token should still validate during grace; got $HTTP"
+
+echo "[OK] Step 8.11: per-tenant kid-rotation drill (tenant=$TENANT_ID, $OLD_KID→$NEW_KID)"
+```
+
+### §6.5 — Step 8.12 (ships with Tier 2 tooling)
+
+Once `POST /api/v1/platform/key-material/rotate` exists, drill the rotation against the real `platform_key_material` table — assert generation N+1 active, kid distinct, prior generation tokens still validate within grace.
+
+### §6.6 — Step 8.13 (ships with Tier 3 dual-key-accept)
+
+Once `FABT_ENCRYPTION_KEY_PREVIOUS` envelope wiring + kid back-fill migration land, drill the full re-wrap migration against real `tenant_dek` rows.
+
+---
+
+## 7. Sequenced backlog (rehearsal-first ordering)
+
+| # | Item | Effort | Deliverable / acceptance criteria |
+|---|---|---|---|
+| 0 | Author `docs/operations/runbooks/_template.md` (frontmatter, prereqs/glossary header, procedure, rollback section, smoke gate, ledger-entry step) | 1 hr | Template file in repo; subsequent runbook items use this shape. |
+| 1 | Review/parameterize `~/fabt-secrets/rotate-db-password.sh` | 30 min | Decision RECORDED in commit message: keep / parameterize / replace. Output committed. |
+| 2 | Add Step 8.9 SMTP-rotation drill to `scripts/deploy-rehearsal.sh` | 1 hr | Drill green; ENV_FILE guard tested with mutation (point at non-rehearsal file → exit non-zero). |
+| 3 | Author `rotate-smtp-password.md` referencing rehearsal as gate | 1 hr | Rollback section non-empty; prereqs + glossary header present. |
+| 4 | Run rehearsal → re-rotate prod SMTP under new runbook | 30 min | Rotation-ledger entry written; first proof of the policy. |
+| 5 | Add Step 8.8 DB-rotation drill (uses backend network path per H6) | 1 hr | Drill green; tested with mutation. |
+| 6 | Author `rotate-db-passwords.md` | 1 hr | Rollback section non-empty. |
+| 7 | Run rehearsal → rotate prod DB passwords | 30 min | Ledger entries × 2 (fabt_app + fabt). |
+| 8 | Author `rotate-oci-svc-principal.md` (no rehearsal — vendor-console; document the `systemd-network:systemd-journal` ownership constraint) | 2 hr | Rollback addresses the sudo / docker-stop / file-replace sequence. |
+| 9 | Author `rotate-grafana-admin.md` + add Step 8.x drill | 2 hr | Drill green. |
+| 10 | Author `rotate-cloudflare-token.md` + `rotate-github-pat.md` | 2 hr | Both reference vendor-console; no drill required. |
+| 11 | Add Step 8.11 JWT per-tenant kid-rotation drill (schema-grounded) | 3 hr | Drill green for 2 consecutive runs; uses real per-tenant SQL with RLS context. |
+| 12 | Author `rotate-jwt-secret.md` + dry-run on prod-demo | 4 hr | Authorize prod rotation ONLY after drill green for 2 consecutive runs AND dry-run successful. |
+| 13 | Set up `rotation-ledger.json` in docs repo + initial entries for SMTP (2026-04-22) + platform_key_material (2026-04-26) + OCI (2026-04-25) | 1 hr | Ledger checked in; pre-existing rotations back-filled with `grandfathered: pre-policy` flag set to true. **H1-r2 grandfather clause:** rotations that occurred BEFORE this policy was authored (anything before the date this plan is committed) are exempt from §0's "same-week rehearsal pass" requirement; they're recorded as historical fact only. Future incident-bypass rotations follow §0 in full. |
+| 14 | Calendar entries for Tier 0 cadences (operator calendar + repository CALENDAR.md) | 30 min | Forcing function. |
+| 15 | OpenSpec change: `platform-jwt-key-rotation-tooling` (admin endpoint + flip job + Step 8.12 drill). **Note:** kid emission already in schema; only mint tooling needed. | 1-2 d | Tier 2 deliverable. |
+| 16 | OpenSpec change: `master-kek-dual-key-accept` (envelope + kid back-fill migration + Step 8.13 drill — pilot on TOTP path first) | 2-3 d spec + 2-3 wk impl (back-fill is the bulk) | Tier 3 deliverable. |
+| 17 | CI guard: `secret-rotation-staleness` reads `rotation-ledger.json` and fails CI if any Tier 0 entry is past cadence | 4 hr | Forcing function so policy doesn't quietly drift. |
+
+Items 0-4 ship the first rotation under the new policy in ~4 hr. Full Tier 0 set lands across items 5-14 in ~12 hr plus calendar entries.
+
+---
+
+## 8. Open questions still requiring user decision
+
+1. **Owner clarity.** Single-operator SPOF is documented (§3 footnote) but not resolved. Hire/recruit a second operator; until then, document operator-unavailability contingency (delegated emergency rotation authority, dead-man's-switch?).
+2. **Cadence calibration.** 90 vs 180 days for Tier 0 — 5-6 rotation events/year vs 2-3. Worth the tax at FABT's current scale?
+3. **Pre-rotation snapshot policy.** Before #4 (JWT) or #5 (Platform JWT) rotation, require a `pg_dump` of `tenant_key_material` + `platform_key_material` + `kid_to_tenant_key`? Definitely yes for #6 (KEK); debatable for #4/#5.
+4. **`rotation-ledger.json` schema.** Per-entry: `secret_id`, `rotated_at`, `operator`, `rehearsal_run_id` (or `bypass=true + reason` for incidents), `next_due`. Match anything?
+5. **Memory hygiene:** `project_oci_audit_anchor_credentials.md` should be aligned with the observed `audit-anchor.pem` mtime (2026-04-25). Small follow-up.
+6. **Shell-exported `${VAR}` migration.** §1 Location B documents the audit gap; the eventual fix is a sourced env file owned `ubuntu:ubuntu 600`. Is that a separate OpenSpec change or a §7 item?
+
+---
+
+## 9. What this plan is NOT
+
+- **Not a finalized policy.** Cadences in §3 are recommendations — each needs an explicit "yes" before it becomes operational.
+- **Not a runbook.** Each Tier 0 secret needs its own runbook under `docs/operations/runbooks/` before first scheduled rotation (§7 backlog items 3, 6, 8, 9, 10, 12; template at item 0).
+- **Not a tooling spec.** Tier 2 (#5 Platform JWT) and Tier 3 (#6 KEK) need their own OpenSpec changes before code lands.
+- **Not a substitute for incident-driven rotation.** Any secret on this list can be rotated *immediately* in response to a confirmed leak; the calendar is a floor, not a ceiling. The single deviation: incident rotations bypass the rehearsal gate per §0 but require ledger entry + same-week rehearsal pass.
+
+---
+
+## 10. Round-2 warroom carryover (documented MEDIUMs, non-blocking)
+
+These 8 MEDIUMs surfaced in warroom round 2 against v3. They're documented here rather than fixed in the plan body because they're drill-implementation refinements that belong in the §7 backlog items (specifically items 2, 5, 11 — the drill-authoring tasks) and the runbook templates (item 0). Whichever PR ships the actual drill scripts MUST address these or explicitly defer with rationale.
+
+| ID | Persona | Concern | Where it lands |
+|---|---|---|---|
+| M1-r2 | Riley | §6.1 trap restores `$ENV_FILE` but not the DB role password. Second `make rehearse-deploy` run will fail at "old password rejected" because the OLD became the prior NEW. | §7 item 5: trap must also `ALTER ROLE fabt_app WITH PASSWORD '<original>'` OR rehearsal precondition resets DB volume. |
+| M2-r2 | Riley | §6.4 has no cleanup; second run finds generation=2 already active and the `cur` CTE picks that as baseline, breaking the drill's invariants. | §7 item 11: trap must reset `tenant_key_material` to single-row generation=1 active per dev-coc tenant. |
+| M3-r2 | Marcus | §6.1 step 2 has a literal `<OLD>` placeholder in the `psql` command. Drill is non-runnable as-shown; needs `OLD_PWD=$(awk …)` capture line mirroring §6.2. | §7 item 5: capture `OLD_PWD` from `$ENV_FILE` before mutation. |
+| M4-r2 | Alex | §4 #4 procedure is silent on `jwt_revocations` cache interaction during rotation. If the cache is keyed by old kid, rotation may need a warm/invalidation step. | §7 item 12 (JWT runbook authoring): inspect `jwt_revocations` schema first, then add cache step if relevant. |
+| M5-r2 | Sam | §7 has 18 items with no slice/PR grouping. Risk: one mega-OpenSpec change tries to land all of them. | §7 follow-up: group items into 4-5 PR slices (template+SMTP / DB / OCI+GH+CF / JWT / Tier-2 / Tier-3). |
+| M6-r2 | Jordan | §0 mandates 72h rehearsal freshness but operator has no tool to check the timestamp of the last green rehearsal. | New §7 item: `make rehearse-status` reads `.last-green-rehearsal` and prints age + fails non-zero if >72h. |
+| M7-r2 | Casey | §6.4 logs `TENANT_ID` UUID to drill stdout. Tolerable for laptop-only logs, borderline for CI artifacts. | Document explicitly that rehearsal output stays on operator laptop, NOT uploaded to CI artifact store. |
+| M8-r2 | Alex | §4 #5 grace mechanism unstated — column on `platform_key_material` (`rotated_at` or `grace_until`) or wall-clock heuristic? | §7 item 15 (`platform-jwt-key-rotation-tooling` OpenSpec): pick one approach + cite schema implication. |
+
+**Verdict on these:** none block v3.1 shipping as a planning doc. All become acceptance criteria on §7 items 5, 11, 12, 15. The §10 listing exists so a future drill author can't claim "wasn't told."
+
+---
+
+## Appendix A — Ground-truth provenance
+
+All facts in §1 were observed via three SSH sessions on 2026-05-22 to the prod VM:
+
+1. **Pass 1** captured `~/fabt-secrets/` file listing (no contents), `.env.prod` variable NAMES only via `awk -F= '/^[A-Z]/ {print $1}'`, `.env.prod` mtime via `stat`, container ages via `docker ps`, Postgres role expiry via `SELECT rolname, rolvaliduntil FROM pg_roles`, `platform_key_material` generation count, and alertmanager status from `/api/v2/status`.
+2. **Pass 2** captured `docker-compose.prod.yml` variable NAMES only via `grep -oE` patterns (keys and `${VAR}` references), `rotate-db-password.sh` line count + first 2 lines + grep for external-tool names (`docker exec`, `psql`, `ALTER ROLE`), `oci/` directory listing, and `docker-compose.prod.yml` mtime.
+3. **Pass 3** captured JWT key-material table names via `\dt`, full `\d` schemas for `tenant_key_material` + `kid_to_tenant_key` (PKs, partial unique indexes, check constraints, FKs, RLS policies), and tenant_key_material row counts.
+
+**At no point was any secret value read.** Per `feedback_never_print_rendered_secrets`: cat/head/tail/grep against the secret-bearing files (`.env.prod`, `alertmanager.yml`, `docker-compose.prod.yml`, `oci/audit-anchor.pem`, `rotate-db-password.sh`) was avoided. All inspections used name-only or metadata-only extraction patterns.


### PR DESCRIPTION
## Summary

First operations runbook for activating an already-installed kernel by rebooting the prod VM. Authored 2026-05-30 and **executed live the same day** — the runbook and its first ledger entry were both produced against a real, successful reboot:

- Kernel: `6.8.0-1049-oracle` → `6.8.0-1050-oracle`
- Total recovery: **118 s** (60 s grace + ~58 s SSH-down)
- All 8 containers cold-booted clean via `unless-stopped`
- Flyway HWM unchanged at V98
- One-shot GRUB pin (`grub-reboot`) consumed exactly as designed — empty `next_entry=` post-boot

## Review history

- **Warroom round 1** (Alex / Sam / Riley — process/structure): closed 2 BLOCKER + 3 HIGH + 3 MEDIUM. Biggest find: GRUB rollback was fiction because `GRUB_TIMEOUT=0 + GRUB_TIMEOUT_STYLE=hidden` means no menu; added §2.5 explicit one-shot pin + rewrote §6 rollback table.
- **Warroom round 2** (Marcus / Casey / Jordan — security/legal/operator UX): closed 2 HIGH + 3 MEDIUM. Added GH-Actions in-progress check to §1, `grub-editenv list` empty assertion to §5, customer-comms row to §0.
- **Warroom round 3** (Devon — new-operator readability + sanity sweep): added "How to use" preamble, deduped 5-min timeout guidance.
- **Marcus public-repo leak review** (pre-commit): scanned 13 leak classes; verdict SAFE. One MEDIUM fix applied: replaced "operator (Corey)" / `verified_by: corey` with role placeholders.

## What the runbook does NOT cover (deferred to own windows)

22 non-security packages remain upgradable, grouped in §8 for separate runbooks:
- Docker stack (7 pkgs) — daemon restart, cycles containers
- Netplan stack (5)
- JDK 25 — build host only
- System utils (6)

## Live-run bugs captured in §8 for next iteration

1. `/api/v1/active-counties` is auth-required (401), not a useful no-auth smoke endpoint
2. `lastgood` pre-flight check is over-specified for kernel-only ops
3. `dmesg --since "5 minutes ago"` returns empty right after boot (window predates kernel time)

## Test plan
- [x] Runbook executed end-to-end on prod 2026-05-30 23:21Z
- [x] Public-repo leak review passed (no IPs, secrets, OCIDs, stakeholder names, demoguard details)
- [ ] Reviewer eyeball before merge